### PR TITLE
new icon button implementation

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,7 @@ export type Props = {
   /** Property indicating if the component is filled with a color based on the type */
   filled?: boolean;
   /** An optional icon to turn the button to icon button with text/children */
-  icon?: string | null;
+  icon?: React.Component | JSX.Element | null;
 };
 
 export type TestProps = {
@@ -37,11 +37,25 @@ const Button: React.FC<Props & TestProps & EventProps> = ({
   return (
     <button
       data-testid={generateTestDataId('button', dataTestId)}
-      css={buttonStyle({ type, filled, size, icon })(theme)}
+      css={buttonStyle({
+        type,
+        filled,
+        size,
+        icon,
+        childrenCount: React.Children.count(children),
+      })(theme)}
       onClick={onClick}
       onBlur={onBlur}
     >
-      <span css={buttonSpanStyle({ type, filled, size, icon })(theme)}>
+      <span
+        css={buttonSpanStyle({
+          type,
+          filled,
+          size,
+          icon,
+          hasChildren: Boolean(React.Children.count(children)),
+        })(theme)}
+      >
         {icon && icon}
         {children}
       </span>

--- a/src/components/IconButton/IconButton.stories.mdx
+++ b/src/components/IconButton/IconButton.stories.mdx
@@ -1,0 +1,50 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { withKnobs, boolean, array, select, text } from '@storybook/addon-knobs';
+import IconButton from './IconButton';
+import Stack from '../storyUtils/Stack';
+
+<Meta title="Design System|IconButton" component={IconButton} />
+
+# IconButton
+
+A universal IconButton component that with the help of Button hold the icon inside it and makes it clickable and easily accessible.
+
+# Usage
+
+```js
+import { IconButton } from 'orfium-design-system';
+
+<IconButton onClick={() => {}})} name={'add'} />
+```
+
+# Props
+
+<Props of={IconButton} />
+
+# IconButton Colors
+
+IconButton with different types
+
+<Preview>
+  <Story name="IconButton Types">
+    <Stack>
+      <IconButton size={'sm'} name="add" dataTestId={'size-lg'} />
+      <IconButton size={'sm'} type="success" name="add" dataTestId={'size-lg'} />
+      <IconButton size={'sm'} type="error" name="add" dataTestId={'size-lg'} />
+    </Stack>
+  </Story>
+</Preview>
+
+# IconButton Sizes
+
+IconButton with different acceptable sizes
+
+<Preview>
+  <Story name="IconButton Sizes">
+    <Stack>
+      <IconButton size={'sm'} name="add" dataTestId={'size-lg'} />
+      <IconButton size={'md'} name="fatArrowDown" />
+      <IconButton size={'lg'} name="check" />
+    </Stack>
+  </Story>
+</Preview>

--- a/src/components/IconButton/IconButton.style.ts
+++ b/src/components/IconButton/IconButton.style.ts
@@ -18,38 +18,29 @@ const heightBasedOnSize = (size: 'lg' | 'md' | 'sm') => {
   }
 };
 
-export const buttonStyle = ({
-  type,
-  filled,
-  size,
-  icon,
-  childrenCount,
-}: RequiredProperties<Props & { childrenCount: number }>) => (theme: Theme) => {
+export const iconButtonStyle = ({ type, filled, size, icon }: RequiredProperties<Props>) => (
+  theme: Theme
+) => {
   const calculatedPaddingSpace = size === 'sm' ? theme.spacing.md : theme.spacing.lg;
-  const calculatedPaddingSpaceIfIcon = size === 'sm' ? theme.spacing.sm : theme.spacing.md;
 
   return {
     fontSize: theme.typography.fontSizes['16'],
     color: colorPickerBasedOnType(type)(theme),
     backgroundColor: filled ? backgroundPickerBasedOnType(type)(theme) : 'transparent',
-    paddingLeft: icon || childrenCount === 0 ? 0 : calculatedPaddingSpace,
-    paddingRight: icon && !childrenCount ? calculatedPaddingSpaceIfIcon : calculatedPaddingSpace,
+    paddingLeft: icon ? 0 : calculatedPaddingSpace,
+    paddingRight: calculatedPaddingSpace,
     height: heightBasedOnSize(size),
     borderRadius: theme.spacing.xsm,
     border: filled ? 'none' : `solid 1px ${theme.palette.gray100}`,
   };
 };
 
-export const buttonSpanStyle = ({
-  icon,
-  size,
-  hasChildren,
-}: RequiredProperties<Props & { hasChildren: boolean }>) => (theme: Theme) => ({
+export const buttonSpanStyle = ({ icon, size }: RequiredProperties<Props>) => (theme: Theme) => ({
   display: icon ? 'flex' : 'block',
   flexDirection: (icon ? 'row' : 'column') as FlexDirectionProperty,
   alignItems: icon ? 'center' : 'flex-start',
   '> :first-child': {
     marginLeft: icon ? (size === 'sm' ? theme.spacing.sm : theme.spacing.md) : 0,
-    marginRight: hasChildren ? theme.spacing.sm : 0,
+    marginRight: theme.spacing.sm,
   },
 });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,0 +1,48 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import * as React from 'react';
+import { AcceptedColorComponentTypes } from 'utils/themeFunctions';
+import { generateTestDataId } from 'utils/helpers';
+import { EventProps } from 'utils/common';
+import { AcceptedIconNames } from '../Icon/types';
+import Button from '../Button';
+import Icon from '../Icon';
+
+export type Props = {
+  /** Type indicating the type of the button. Defaults to 'primary' */
+  type?: AcceptedColorComponentTypes;
+  /** This property define the size of the button. Defaults to 'md' */
+  size?: 'lg' | 'md' | 'sm';
+  /** Property indicating if the component is filled with a color based on the type */
+  filled?: boolean;
+  /** This property defines witch icon to use */
+  name: AcceptedIconNames;
+};
+
+export type TestProps = {
+  dataTestId?: string;
+};
+
+const IconButton: React.FC<Props & TestProps & EventProps> = ({
+  size = 'md',
+  type = 'primary',
+  filled = true,
+  name,
+  dataTestId = '',
+  onClick,
+  onBlur,
+}) => {
+  return (
+    <Button
+      dataTestId={generateTestDataId('button', dataTestId)}
+      onClick={onClick}
+      onBlur={onBlur}
+      size={size}
+      type={type}
+      filled={filled}
+      icon={<Icon name={name} />}
+    />
+  );
+};
+
+export default IconButton;

--- a/src/components/IconButton/index.ts
+++ b/src/components/IconButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './IconButton';


### PR DESCRIPTION
This PR implements the icon button component. 

This component will just implement the icon component of the library inside the button component.
We do this to skip over-engineer stuff to implement one icon that is clickable in any project, also serves well for the upcoming pagination component.