### PR TITLE
fix build for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/react-dom": "^16.0.0"
   },
   "scripts": {
-    "install": "yarn build",
+    "postinstall": "yarn build",
     "start": "start-storybook -p 6006",
     "prebuild": "rimraf dist",
     "build": "yarn build:lib && yarn build:types",


### PR DESCRIPTION
This PR change the npm hook for install.

The issue was that when no node modules where installed the install hook failed to run build. So i changed it to run after the installation