### PR TITLE
Fix merge technique of theming

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -56,7 +56,7 @@ const ThemeSwitcher = () => {
 // wrap all components with theme provider by default
 addDecorator(storyFn => {
   return (
-    <ThemeProvider theme={{}}>
+    <ThemeProvider theme={{ palette: { branded1: '#000' } }}>
       <ThemeSwitcher />
       {storyFn()}
     </ThemeProvider>

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -29,7 +29,7 @@ export const buttonStyle = ({
   const calculatedPaddingSpace = size === 'sm' ? theme.spacing.md : theme.spacing.lg;
   const calculatedPaddingSpaceIfIcon = size === 'sm' ? theme.spacing.sm : theme.spacing.md;
 
-  const defineBackgroundColor = () => {
+  const defineBackgroundColor = (): string => {
     if (childrenCount === 0 && icon) {
       return 'transparent';
     }

--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -29,7 +29,7 @@ export const checkboxStyle = ({ intermediate, checked }: Props) => (
   background: ${checked
     ? intermediate
       ? theme.palette.gray200
-      : theme.palette.brand1
+      : theme.palette.branded1
     : theme.palette.gray50};
   border: 0;
   border-radius: ${rem(2)};
@@ -59,7 +59,7 @@ export const checkboxStyle = ({ intermediate, checked }: Props) => (
 
   // Box checked
   &:checked + label:before {
-    background: ${intermediate ? theme.palette.gray200 : theme.palette.brand1};
+    background: ${intermediate ? theme.palette.gray200 : theme.palette.branded1};
   }
 
   // Disabled state label.

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { normalize } from 'polished';
 import { ThemeProvider as EmotionThemeProvider } from 'emotion-theming';
 import { css, Global } from '@emotion/core';
-import { assign, keys, pick } from 'lodash';
+import { merge, keys, pick } from 'lodash';
 import theme, { Theme } from 'theme';
 import { useThemeSwitch } from 'hooks/useThemeSwitch';
 
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const deepMergeTheme = (newTheme: Theme, theming: 'dark' | 'light'): Theme =>
-  assign(theme(theming), pick(newTheme, keys(theme(theming))));
+  merge(theme(theming), pick(newTheme, keys(theme(theming))));
 
 const globalStyles = css`
   ${normalize()};

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -8,10 +8,10 @@ import { useThemeSwitch } from 'hooks/useThemeSwitch';
 
 type Props = {
   /** Theme properties to override or pass theming down to library */
-  theme?: any;
+  theme?: DeepPartial<Theme>;
 };
 
-const deepMergeTheme = (newTheme: Theme, theming: 'dark' | 'light'): Theme =>
+const deepMergeTheme = (newTheme: DeepPartial<Theme>, theming: 'dark' | 'light'): Theme =>
   merge(theme(theming), pick(newTheme, keys(theme(theming))));
 
 const globalStyles = css`

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -8,11 +8,11 @@ const grayPalette = {
 
 export const lightPalette: Palette = {
   // Primary Palette
-  primary: '',
+  primary: '#DFDFDF',
   secondary: '',
 
-  brand1: 'orange',
-  brand2: 'yellow',
+  branded1: 'orange',
+  branded2: 'yellow',
 
   ...grayPalette,
 
@@ -37,8 +37,8 @@ export const darkPalette: Palette = {
   primary: '',
   secondary: '',
 
-  brand1: 'orange',
-  brand2: 'yellow',
+  branded1: 'orange',
+  branded2: 'yellow',
 
   ...grayPalette,
 
@@ -63,8 +63,8 @@ export type Palette = {
   primary: string;
   secondary: string;
 
-  brand1: string;
-  brand2: string;
+  branded1: string;
+  branded2: string;
 
   gray: string;
   gray50: string;

--- a/src/utils/themeFunctions.ts
+++ b/src/utils/themeFunctions.ts
@@ -1,4 +1,5 @@
 import { Theme } from 'theme';
+import { get } from 'lodash';
 
 export type AcceptedColorComponentTypes =
   | 'primary'
@@ -21,18 +22,11 @@ export type AcceptedColorComponentTypes =
 export const backgroundPickerBasedOnType = (type: AcceptedColorComponentTypes) => (
   theme: Theme
 ) => {
-  switch (type) {
-    case 'success':
-      return theme.palette.success;
-    case 'error':
-      return theme.palette.error;
-    case 'info':
-      return theme.palette.info;
-    case 'warning':
-      return theme.palette.warning;
-    default:
-      return theme.palette.gray50;
+  if (type) {
+    return get(theme.palette, [type]);
   }
+
+  return theme.palette.gray50;
 };
 
 export const colorPickerBasedOnType = (type: AcceptedColorComponentTypes) => (theme: Theme) => {
@@ -61,9 +55,9 @@ export const fillPickerBasedOnType = (type: AcceptedColorComponentTypes) => (the
     case 'warning':
       return theme.palette.warning;
     case 'branded1':
-      return theme.palette.brand1;
+      return theme.palette.branded1;
     case 'branded2':
-      return theme.palette.brand2;
+      return theme.palette.branded2;
     case 'white':
       return theme.palette.white;
     case 'dark':


### PR DESCRIPTION
This PR fix the function that deep merge the theme with the new theme passed to the provider. This was overlapping the object assigned but now it only extends it.

I also fixed the naming of the `brand1`, `brand2` to `branded` as we used both cases.