### PR TITLE
Extend Select TS support

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -5,7 +5,7 @@ import { rem, transparentize } from 'polished';
 import Label from 'components/Label';
 import { generateUniqueID } from 'utils/helpers';
 
-export type SelectOption = { value: string; label: string; isDisabled?: boolean };
+export type SelectOption = { value: string | number; label: string; isDisabled?: boolean };
 
 export type Props = {
   /** The label that is going to be displayed */


### PR DESCRIPTION
This PR extends the support of select option value for both string and number as there is no point to limit it to just `string`, values can be anything 