### PR TITLE
add percentage width option

### DIFF
--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -135,7 +135,7 @@ Table with expandable rows and nested header
         {
           id: 1,
           cells: [
-            { content: 'title' },
+            { content: 'title', widthPercentage: 40 },
             { content: 'firstname' },
             { content: 'lastname' },
             { content: 4.221 },
@@ -145,7 +145,7 @@ Table with expandable rows and nested header
         {
           id: 2,
           cells: [
-            { content: 'title' },
+            { content: 'title', widthPercentage: 40 },
             { content: 'firstname' },
             { content: 'lastname' },
             { content: 4.221 },

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -18,6 +19,7 @@ export type Cell<T> = {
   colSpan?: number;
   type?: 'financial' | 'normal';
   align?: 'left' | 'right';
+  widthPercentage?: number;
 };
 
 export type Row<T> = {
@@ -109,96 +111,118 @@ function Table<T>({
     []
   );
 
+  const columnsWithWidth = React.useMemo(
+    () =>
+      head(
+        data.map(({ cells }) =>
+          cells.map(({ widthPercentage }) => {
+            return widthPercentage;
+          })
+        )
+      ) || [],
+    []
+  );
+
   return (
-    <table css={tableStyle()(theme)}>
-      {(onCheck || topRightArea || type === 'normal') && (
-        <thead>
-          <TableRow>
-            {onCheck && (
-              <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded}>
-                <CheckBox
-                  checked={Boolean(selectedIds.length > 0)}
-                  intermediate={selectedIds.length > 0 && selectedIds.length !== data.length}
-                  onClick={() => {
-                    if (selectedIds.length === data.length) {
-                      onSelectionChange([]);
-                    } else {
-                      onSelectionChange(data.map(({ id }) => id));
-                    }
-                  }}
-                />
-              </TableCell>
-            )}
-            <TableCell padded={padded}>
-              {selectedIds.length > 0 ? (
-                <span>
-                  <b>{selectedIds.length}</b> {pluralize('item', selectedIds.length)} selected
-                </span>
-              ) : (
-                topLeftText
-              )}
-            </TableCell>
-            {topRightArea && (
-              <TableCell
-                textAlign={'right'}
-                padded={padded}
-                colSpan={columnCount - (onCheck ? 2 : 1)}
-              >
-                {topRightArea(data, selectedIds)}
-              </TableCell>
-            )}
-          </TableRow>
-          {type === 'normal' && (
-            <TableRow
-              css={[
-                {
-                  paddingTop: theme.spacing.md,
-                  paddingBottom: theme.spacing.md,
-                  borderBottomWidth: rem(1),
-                  borderBottomStyle: 'solid',
-                  borderBottomColor: theme.palette.gray100,
-                },
-              ]}
-            >
+    <>
+      <table css={tableStyle()(theme)}>
+        {(onCheck || topRightArea || type === 'normal') && (
+          <thead>
+            <TableRow>
               {onCheck && (
-                <TableCell component={'th'} sticky={fixedHeader} width={30} padded={padded} />
-              )}
-              {columns.map((item, index) => (
-                <TableCell
-                  textAlign={columnsHasNumberArr && columnsHasNumberArr[index] ? 'right' : 'left'}
-                  component={'th'}
-                  key={`${item}`}
-                  sticky={fixedHeader}
-                  padded={padded}
-                >
-                  {item}
+                <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded}>
+                  <CheckBox
+                    checked={Boolean(selectedIds.length > 0)}
+                    intermediate={selectedIds.length > 0 && selectedIds.length !== data.length}
+                    onClick={() => {
+                      if (selectedIds.length === data.length) {
+                        onSelectionChange([]);
+                      } else {
+                        onSelectionChange(data.map(({ id }) => id));
+                      }
+                    }}
+                  />
                 </TableCell>
-              ))}
+              )}
+              <TableCell padded={padded}>
+                {selectedIds.length > 0 ? (
+                  <span>
+                    <b>{selectedIds.length}</b> {pluralize('item', selectedIds.length)} selected
+                  </span>
+                ) : (
+                  topLeftText
+                )}
+              </TableCell>
+              {topRightArea && (
+                <TableCell
+                  textAlign={'right'}
+                  padded={padded}
+                  colSpan={columnCount - (onCheck ? 2 : 1)}
+                >
+                  {topRightArea(data, selectedIds)}
+                </TableCell>
+              )}
             </TableRow>
-          )}
-        </thead>
-      )}
-      <tbody>
-        {data.map(row => (
-          <TableRowWrapper<T>
-            key={row.id}
-            {...{
-              row,
-              selectedIds,
-              onSelectionAdd,
-              padded,
-              columns,
-              fixedHeader,
-              type,
-              columnCount,
-              columnsHasNumberArr,
-              onSelectionChangeExist: Boolean(onCheck),
-              expanded: !!row.expanded,
-            }}
-          />
-        ))}
-      </tbody>
-    </table>
+          </thead>
+        )}
+      </table>
+      <table css={tableStyle()(theme)}>
+        {(onCheck || topRightArea || type === 'normal') && (
+          <thead>
+            {type === 'normal' && (
+              <TableRow
+                css={[
+                  {
+                    paddingTop: theme.spacing.md,
+                    paddingBottom: theme.spacing.md,
+                    borderBottomWidth: rem(1),
+                    borderBottomStyle: 'solid',
+                    borderBottomColor: theme.palette.gray100,
+                  },
+                ]}
+              >
+                {onCheck && (
+                  <TableCell component={'th'} sticky={fixedHeader} width={30} padded={padded} />
+                )}
+                {columns.map((item, index) => (
+                  <TableCell
+                    textAlign={columnsHasNumberArr && columnsHasNumberArr[index] ? 'right' : 'left'}
+                    component={'th'}
+                    key={`${item}`}
+                    sticky={fixedHeader}
+                    padded={padded}
+                    width={columnsWithWidth[index] ? `${columnsWithWidth[index]}%` : 'initial'}
+                  >
+                    {item}
+                  </TableCell>
+                ))}
+              </TableRow>
+            )}
+          </thead>
+        )}
+        <tbody>
+          {data.map(row => (
+            <TableRowWrapper<T>
+              key={row.id}
+              {...{
+                row,
+                selectedIds,
+                onSelectionAdd,
+                padded,
+                columns,
+                fixedHeader,
+                type,
+                columnCount,
+                columnsHasNumberArr,
+                columnsWithWidth,
+                onSelectionChangeExist: Boolean(onCheck),
+                expanded: !!row.expanded,
+              }}
+            />
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 }
 
@@ -207,6 +231,7 @@ type TableRowWrapperProps<T> = {
   selectedIds: Selection[];
   onSelectionAdd: (selection: Selection) => void;
   columnsHasNumberArr: boolean[];
+  columnsWithWidth: number[];
   padded: boolean;
   onSelectionChangeExist: boolean;
   columnCount: number;
@@ -225,6 +250,7 @@ const TableRowWrapper = <T extends {}>({
   fixedHeader,
   type,
   columnsHasNumberArr,
+  columnsWithWidth,
   columnCount,
   onSelectionChangeExist,
   expanded,
@@ -239,6 +265,7 @@ const TableRowWrapper = <T extends {}>({
       value={{
         row,
         columnsHasNumberArr,
+        columnsWithWidth,
         onSelectionChangeExist,
         padded,
         columns,

--- a/src/components/Table/TableRowContext.ts
+++ b/src/components/Table/TableRowContext.ts
@@ -4,6 +4,7 @@ import { Row, TableType } from './Table';
 export type TableRowContextProps<T extends {}> = {
   row: Row<T>;
   columnsHasNumberArr: boolean[];
+  columnsWithWidth: number[];
   padded: boolean;
   onSelectionChangeExist: boolean;
   isRowSelected: boolean;
@@ -21,6 +22,7 @@ export const TableRowContext = createContext<TableRowContextProps<{}>>({
     cells: [],
   },
   columnsHasNumberArr: [],
+  columnsWithWidth: [],
   padded: false,
   onSelectionChangeExist: false,
   isRowSelected: false,

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -16,6 +16,7 @@ import CheckBox from '../../../CheckBox';
 const RenderRowWithCells = React.memo(({ checked = false, toggleChecked = () => {} }: any) => {
   const {
     columnsHasNumberArr,
+    columnsWithWidth,
     onSelectionChangeExist,
     padded,
     columns,
@@ -59,6 +60,7 @@ const RenderRowWithCells = React.memo(({ checked = false, toggleChecked = () => 
             colSpan={colSpan}
             type={cellType}
             padded={padded}
+            width={columnsWithWidth[index] ? `${columnsWithWidth[index]}%` : 'initial'}
           >
             {type === 'nested-header' && (
               <div


### PR DESCRIPTION
In this PR we introduce a new option on the table data to define the width percentage of the cell. This is applied to all the columns and leave the columns with no width defined to the window to calculate their size. 

_Only downfall to this solution is if you define more than 100% width to your columns._ 