### PR TITLE
wrap inline header content to span

### DIFF
--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -75,7 +75,7 @@ const RenderRowWithCells = React.memo(({ checked = false, toggleChecked = () => 
             {isComponentFunctionType(content) ? (
               content({ content, colSpan })
             ) : (
-              <span>{content}</span>
+              <span data-column={columns[cellCounter]}>{content}</span>
             )}
           </TableCell>
         );

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -72,7 +72,11 @@ const RenderRowWithCells = React.memo(({ checked = false, toggleChecked = () => 
                 {columns[cellCounter]}
               </div>
             )}
-            {isComponentFunctionType(content) ? content({ content, colSpan }) : content}
+            {isComponentFunctionType(content) ? (
+              content({ content, colSpan })
+            ) : (
+              <span>{content}</span>
+            )}
           </TableCell>
         );
       })}


### PR DESCRIPTION
This PR wraps the content of the inline header table cell to a span in order for the QA to be able to "catch" the contents with selenium and xPath