### PR TITLE
fix: datepicker with value and disabledDates from outside

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -3,6 +3,7 @@ import { withKnobs, boolean, array, select, text } from '@storybook/addon-knobs'
 import DatePicker from './DatePicker';
 import Stack from '../storyUtils/Stack';
 import PresentComponent from '../storyUtils/PresentComponent';
+import dayjs from 'dayjs';
 
 <Meta title="Design System|DatePicker" component={DatePicker} />
 
@@ -39,5 +40,42 @@ Implementation of the simple DayPicker
 <Preview>
   <Story name="DayPicker">
     <DatePicker />
+  </Story>
+</Preview>
+
+# DayPicker with disabled dates
+
+Some disable dates functionality
+
+<Preview>
+  <Story name="DayPicker with disabled dates">
+    <DatePicker
+      disableDates={[
+        dayjs()
+          .add(1, 'day')
+          .toDate(),
+        { daysOfWeek: [0, 6] },
+      ]}
+    />
+  </Story>
+</Preview>
+
+# DayPicker with predefined values
+
+This datepicker has a predefined initial value that can be used both for initial definition and to handle values externally
+
+<Preview>
+  <Story name="DayPicker with predefined values">
+    <DatePicker
+      value={{
+        to: dayjs()
+          .add(11, 'day')
+          .toDate(),
+        from: dayjs()
+          .add(1, 'day')
+          .toDate(),
+      }}
+      disableDates={[{ daysOfWeek: [0, 2, 3, 4, 5, 6] }]}
+    />
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -1,9 +1,14 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import { withKnobs, boolean, array, select, text } from '@storybook/addon-knobs';
+import { withKnobs, select } from '@storybook/addon-knobs';
 import DatePicker from './DatePicker';
-import Stack from '../storyUtils/Stack';
-import PresentComponent from '../storyUtils/PresentComponent';
 import dayjs from 'dayjs';
+const options = {
+  'Disable days of week (only Monday)': { daysOfWeek: [0, 2, 3, 4, 5, 6] },
+  'Disable dates after this day': { after: new Date() },
+  'Disable dates before this day': { before: new Date() },
+  'Disable dates before and after a date (-/+ 7 days)': { before: dayjs().subtract(7, 'day').toDate(), after: dayjs().add(7, 'day').toDate() },
+  'Enable dates from/to a date (7 days)': { before: dayjs().subtract(7, 'day').toDate(), after: dayjs().add(7, 'day').toDate() },
+}
 
 <Meta title="Design System|DatePicker" component={DatePicker} />
 
@@ -77,5 +82,13 @@ This datepicker has a predefined initial value that can be used both for initial
       }}
       disableDates={[{ daysOfWeek: [0, 2, 3, 4, 5, 6] }]}
     />
+  </Story>
+</Preview>
+
+
+# Dynamic disableDates with all options available - Knobs
+<Preview>
+  <Story name="Dynamic disableDates with all options available - Knobs" parameters={{ decorators: [withKnobs] }}>
+    <DatePicker disableDates={select('disableDates', options, options[0])} />
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.style.ts
+++ b/src/components/DatePicker/DatePicker.style.ts
@@ -57,15 +57,20 @@ export const datePickerStyles = ({ isRangePicker }: { isRangePicker?: boolean })
   .DayPicker-Day {
     padding: 0.7em;
     font-size: ${theme.typography[14]};
+    border-radius: 0;
   }
   .DayPicker-Day--today {
     color: initial;
   }
 
-  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside),
+  .DayPicker-Day--selected:not(.DayPicker-Day--outside),
   .DayPicker-Day--start:not(.DayPicker-Day--outside) {
     background-color: #dfdfdf;
     color: #000;
+  }
+
+  .DayPicker-Day--selected.DayPicker-Day--disabled:not(.DayPicker-Day--outside) {
+    opacity: 0.5;
   }
 
   .DayPicker-Day:hover {

--- a/src/components/DatePicker/DatePicker.style.ts
+++ b/src/components/DatePicker/DatePicker.style.ts
@@ -73,7 +73,11 @@ export const datePickerStyles = ({ isRangePicker }: { isRangePicker?: boolean })
     opacity: 0.5;
   }
 
-  .DayPicker-Day:hover {
+  .DayPicker-Day:focus {
+    outline: none;
+  }
+
+  .DayPicker-Day:not(.DayPicker-Day--disabled):hover {
     background-color: #f5f5f5 !important;
   }
   .DayPicker:not(.DayPicker--interactionDisabled)


### PR DESCRIPTION
This PR introduce to the datepicker 2 new properties
* disableDates
* value

There would be always a case that we will need to disable some dates in the calendar in order to avoid user clicking on them. This is very common and also there is a need for it in a current task in Video hunter.

Also value is also need if someone want to control the value with an external state.

You can also find two new stories that shows both cases.

## Screenshots
disabled dates
![Screenshot 2020-09-10 at 5 42 51 PM](https://user-images.githubusercontent.com/6433679/92747742-30a0bc00-f38d-11ea-84fb-3f85c34b2460.png)

value defined in the component
![Screenshot 2020-09-10 at 5 42 56 PM](https://user-images.githubusercontent.com/6433679/92747801-3b5b5100-f38d-11ea-9ba6-adc63a8ed068.png)

