### PR TITLE
[TextField] Fix width to fit the parent container

### DIFF
--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -15,6 +15,7 @@ export const wrapperStyle = ({ error, disabled, lean }: Props) => (
   border-radius: ${theme.spacing.xsm};
   border: ${error ? `1px solid ${theme.palette.error}` : 'none'};
   cursor: ${disabled ? 'not-allowed' : 'auto'};
+  flex: 1 1 100%;
   user-select: none;
   position: relative;
 

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -37,6 +37,7 @@ export const textFieldStyle = ({ label, leftIcon }: Props) => (
   align-items: center;
   vertical-align: top;
   margin: ${label ? rem(24) : rem(18.5)} ${rem(12)} ${label ? theme.spacing.sm : rem(18.5)};
+  width: fill-available;
 
   label {
     left: ${leftIcon ? '1.9rem' : 'inherit'};


### PR DESCRIPTION
This PR fixes the width of TextField that is now not fully expanded into its parent container.

Behaviour before fix:
<img width="351" alt="Screenshot 2020-09-16 at 2 53 47 PM" src="https://user-images.githubusercontent.com/38426486/93333832-9927e700-f82c-11ea-9076-c6a49a2be29b.png">

Behaviour after fix:
<img width="350" alt="Screenshot 2020-09-16 at 2 52 41 PM" src="https://user-images.githubusercontent.com/38426486/93333864-a6dd6c80-f82c-11ea-8976-8fa8a506dcdd.png">