### PR TITLE
introduce custom label to datepicker

### DIFF
--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -13,9 +13,10 @@ import { DateRange } from '../DatePicker';
 type Props = {
   isRangePicker: boolean;
   selectedDay: DateRange;
+  inputLabel: string;
 } & DayPickerInputProps;
 
-const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, ...props }) => {
+const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, inputLabel, ...props }) => {
   const theme = useTheme();
   const getDateFormatted = React.useCallback(
     (date: Date | undefined) => (date ? dayjs(date).format('MM/DD/YYYY') : ''),
@@ -33,14 +34,14 @@ const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, ...props }
       ]}
     >
       <TextField
-        label="Date (Start)"
+        label={`${inputLabel} (Start)`}
         lean={true}
         {...props}
         value={getDateFormatted(selectedDay.from)}
       />
       <TextField
         rightIcon={<Icon name={'calendarEmpty'} color={'secondary'} />}
-        label={`Date (End)`}
+        label={`${inputLabel} (End)`}
         {...props}
         lean={true}
         value={getDateFormatted(selectedDay.to)}
@@ -48,7 +49,7 @@ const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, ...props }
     </div>
   ) : (
     <TextField
-      label="Date"
+      label={inputLabel}
       {...props}
       value={getDateFormatted(selectedDay.from)}
       rightIcon={<Icon name={'calendarEmpty'} color={'secondary'} />}

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import { withKnobs, select } from '@storybook/addon-knobs';
+import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
 import DatePicker from './DatePicker';
 import dayjs from 'dayjs';
 const options = {
@@ -85,10 +85,9 @@ This datepicker has a predefined initial value that can be used both for initial
   </Story>
 </Preview>
 
-
-# Dynamic disableDates with all options available - Knobs
+# Dynamic disableDates with all options available and custom label - Knobs
 <Preview>
   <Story name="Dynamic disableDates with all options available - Knobs" parameters={{ decorators: [withKnobs] }}>
-    <DatePicker disableDates={select('disableDates', options, options[0])} />
+    <DatePicker disableDates={select('disableDates', options, options[0])} inputLabel={text('inputLabel', 'Custom Date')} isRangePicker={boolean('isRangePicker', false)} />
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -22,6 +22,8 @@ export type Props = {
   disableDates?: Modifier[];
   /** Value to define if needed an initial state or to handle it externally */
   value?: RangeModifier;
+  /** The label that the input will use to show it. Default: Date */
+  inputLabel?: string;
 };
 
 export type DateRange =
@@ -71,6 +73,7 @@ const DatePicker: React.FC<Props> = ({
     from: undefined,
     to: undefined,
   },
+  inputLabel = 'Date',
 }) => {
   const theme = useTheme();
   const dayPickerInputRef = useRef<DayPickerInput>(null);
@@ -180,7 +183,12 @@ const DatePicker: React.FC<Props> = ({
         )}
         dayPickerProps={dayPickerProps}
         component={(props: DayPickerInputProps) => (
-          <DatePickInput {...props} selectedDay={selectedDay} isRangePicker={isRangePicker} />
+          <DatePickInput
+            {...props}
+            inputLabel={inputLabel}
+            selectedDay={selectedDay}
+            isRangePicker={isRangePicker}
+          />
         )}
         hideOnDayClick={false}
         keepFocus={false}


### PR DESCRIPTION
This PR extends the functionality of the Datepicker and adds a new prop to handle a custom label for the input/inputs.

This way we can add anything we want as we do on the `TextField` component. The prop is optional and defaults to the label of the design `Date`

### Screenshot
![image](https://user-images.githubusercontent.com/6433679/93450885-2a579600-f8df-11ea-8b7c-280735fd5204.png)

### More
I also extended the knobs functionality so we can play with these values