### PR TITLE
feat: adding style type selections to datepicker

### DIFF
--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -9,14 +9,23 @@ import Icon from '../../Icon';
 import TextField from '../../TextField';
 import { wrapperStyle } from '../../TextField/TextField.style';
 import { DateRange } from '../DatePicker';
+import { formFieldStyles } from '../../../theme/palette';
 
 type Props = {
   isRangePicker: boolean;
   selectedDay: DateRange;
   inputLabel: string;
+  /** Style of input field */
+  styleType: formFieldStyles;
 } & DayPickerInputProps;
 
-const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, inputLabel, ...props }) => {
+const DatePickInput: React.FC<Props> = ({
+  isRangePicker,
+  styleType,
+  selectedDay,
+  inputLabel,
+  ...props
+}) => {
   const theme = useTheme();
   const getDateFormatted = React.useCallback(
     (date: Date | undefined) => (date ? dayjs(date).format('MM/DD/YYYY') : ''),
@@ -26,7 +35,7 @@ const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, inputLabel
   return isRangePicker ? (
     <div
       css={[
-        wrapperStyle({})(theme),
+        wrapperStyle({ styleType })(theme),
         flex,
         {
           width: 275,
@@ -51,6 +60,7 @@ const DatePickInput: React.FC<Props> = ({ isRangePicker, selectedDay, inputLabel
     <TextField
       label={inputLabel}
       {...props}
+      styleType={styleType}
       value={getDateFormatted(selectedDay.from)}
       rightIcon={<Icon name={'calendarEmpty'} color={'secondary'} />}
     />

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -48,8 +48,11 @@ Implementation of the regular DatePicker
 Implementation of the simple DayPicker
 
 <Preview>
-  <Story name="DayPicker">
-    <DatePicker />
+  <Story name="DayPicker" parameters={{ decorators: [withKnobs] }}>
+    <DatePicker
+      styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])}
+      disableDates={select('disableDates', options, options[0])}
+    />
   </Story>
 </Preview>
 

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -9,6 +9,7 @@ const options = {
   'Disable dates before and after a date (-/+ 7 days)': { before: dayjs().subtract(7, 'day').toDate(), after: dayjs().add(7, 'day').toDate() },
   'Enable dates from/to a date (7 days)': { before: dayjs().subtract(7, 'day').toDate(), after: dayjs().add(7, 'day').toDate() },
 }
+const styleTypeOptions = ['filled', 'outlined', 'elevated']
 
 <Meta title="Design System/DatePicker" component={DatePicker} />
 
@@ -33,8 +34,12 @@ import { DatePicker } from '@orfium/ictinus';
 Implementation of the regular DatePicker
 
 <Preview>
-  <Story name="DatePicker">
-    <DatePicker isRangePicker />
+  <Story name="DatePicker" parameters={{ decorators: [withKnobs] }}>
+    <DatePicker
+      isRangePicker
+      styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])}
+      disableDates={select('disableDates', options, options[0])}
+    />
   </Story>
 </Preview>
 
@@ -88,6 +93,6 @@ This datepicker has a predefined initial value that can be used both for initial
 # Dynamic disableDates with all options available and custom label - Knobs
 <Preview>
   <Story name="Dynamic disableDates with all options available - Knobs" parameters={{ decorators: [withKnobs] }}>
-    <DatePicker disableDates={select('disableDates', options, options[0])} inputLabel={text('inputLabel', 'Custom Date')} isRangePicker={boolean('isRangePicker', false)} />
+    <DatePicker styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])} disableDates={select('disableDates', options, options[0])} inputLabel={text('inputLabel', 'Custom Date')} isRangePicker={boolean('isRangePicker', false)} />
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -10,6 +10,7 @@ import DayPicker, { DateUtils, RangeModifier, DayPickerInputProps } from 'react-
 import DatePickInput from './DatePickInput/DatePickInput';
 import OverlayComponent from './OverlayComponent/OverlayComponent';
 import { Modifier } from 'react-day-picker/types/Modifiers';
+import { formFieldStyles } from '../../theme/palette';
 
 export type Props = {
   /** This boolean shows if the date picker will have the future dates available to select. Default: false */
@@ -24,6 +25,8 @@ export type Props = {
   value?: RangeModifier;
   /** The label that the input will use to show it. Default: Date */
   inputLabel?: string;
+  /** Style of input field */
+  styleType?: formFieldStyles;
 };
 
 export type DateRange =
@@ -74,6 +77,7 @@ const DatePicker: React.FC<Props> = ({
     to: undefined,
   },
   inputLabel = 'Date',
+  styleType = 'filled',
 }) => {
   const theme = useTheme();
   const dayPickerInputRef = useRef<DayPickerInput>(null);
@@ -185,6 +189,7 @@ const DatePicker: React.FC<Props> = ({
         component={(props: DayPickerInputProps) => (
           <DatePickInput
             {...props}
+            styleType={styleType}
             inputLabel={inputLabel}
             selectedDay={selectedDay}
             isRangePicker={isRangePicker}


### PR DESCRIPTION
##  Description

This PR introduce the new style types (elevated, filled, outlined) to the datepicker component. I also included some knobs functionality on the stories of the day and datepicker for the viewer to handle it and demonstrate it

closes #87 

## Screenshot

### datepicker
<img width="307" alt="Screenshot 2020-09-22 at 11 21 25 PM" src="https://user-images.githubusercontent.com/6433679/93933551-82046000-fd2a-11ea-8568-52863207de69.png">
<img width="316" alt="Screenshot 2020-09-22 at 11 21 15 PM" src="https://user-images.githubusercontent.com/6433679/93933554-829cf680-fd2a-11ea-8064-171a0c774429.png">
<img width="338" alt="Screenshot 2020-09-22 at 11 21 20 PM" src="https://user-images.githubusercontent.com/6433679/93933558-83358d00-fd2a-11ea-9db2-e8f6f06e0211.png">

### daypicker
<img width="254" alt="Screenshot 2020-09-22 at 11 24 48 PM" src="https://user-images.githubusercontent.com/6433679/93933817-e45d6080-fd2a-11ea-8b03-73c5ad9a8bf9.png">
<img width="249" alt="Screenshot 2020-09-22 at 11 24 53 PM" src="https://user-images.githubusercontent.com/6433679/93933821-e58e8d80-fd2a-11ea-9e56-32dd0cd800c4.png">
<img width="251" alt="Screenshot 2020-09-22 at 11 24 58 PM" src="https://user-images.githubusercontent.com/6433679/93933823-e58e8d80-fd2a-11ea-88e9-8cd8cf2e5d9b.png">



## Test Plan

Storyshots are the same

