### PR TITLE
feat(palette): Update palette color creation

### DIFF
--- a/guides/COLORS.stories.mdx
+++ b/guides/COLORS.stories.mdx
@@ -8,10 +8,10 @@ import { Meta, Preview } from '@storybook/addon-docs/blocks';
 
 All the colors in palette are created with the same principle.
 
-Each colour includes seven shades, the base colour (color400) and six shades deriving from color400,
+Each color includes seven shades, the base color (color400) and six shades deriving from color400,
 three darker and three lighter.
 
-All new shades are calculated with colour percentages (25%, 50%, 75%) on white background for the lighter shades and black background for the darker ones (75%, 50%, 25%).
+All new shades are calculated with color percentages (25%, 50%, 75%) on white background for the lighter shades and black background for the darker ones (75%, 50%, 25%).
 
 For example magenta `#d21e75`, and we take 3 darker shades and 3 lighter shades, all with a 25% step.
 
@@ -28,7 +28,3 @@ This way we get the following colors for magenta
   700: "#34071d"
 }
 ```
-
-lightGray and darkGray palettes are excluded from the above rule.
-
-The grays start from the darkest one, which is #010101 and get lighter with 8% percentage on each step, except the last one that's pure white.

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
@@ -54,7 +54,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
       >
         <li>
           <div
-            className="css-1wfnz1e-BreadcrumbItem"
+            className="css-183ezy7-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -70,7 +70,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -88,14 +88,14 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
             className="css-1w7gjlo-BreadcrumbCollapsed"
           >
             <span
-              className="css-17y3y2w-BreadcrumbCollapsed"
+              className="css-hjigrk-BreadcrumbCollapsed"
               onClick={[Function]}
             >
               <span
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-699c8a-Icon"
+                  className="css-ist487-Icon"
                 />
               </span>
             </span>
@@ -106,7 +106,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -114,7 +114,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
         </li>
         <li>
           <div
-            className="css-1wfnz1e-BreadcrumbItem"
+            className="css-183ezy7-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -130,7 +130,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -138,7 +138,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
         </li>
         <li>
           <div
-            className="css-d0vim6-BreadcrumbItem"
+            className="css-e8ptyq-BreadcrumbItem"
           >
             <div
               role="button"
@@ -147,7 +147,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
                 className="css-4yevxh-Menu"
               >
                 <button
-                  className="css-h3p2id-Button"
+                  className="css-1nqt66k-Button"
                   data-testid="button"
                   disabled={false}
                   onClick={[Function]}
@@ -167,7 +167,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
                         className="css-1gnbc76-Icon"
                       >
                         <SvgrURL
-                          className="css-1vu224h-Icon"
+                          className="css-1b2voc8-Icon"
                         />
                       </span>
                     </div>
@@ -247,7 +247,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
         >
           <li>
             <div
-              className="css-1wfnz1e-BreadcrumbItem"
+              className="css-183ezy7-BreadcrumbItem"
             >
               <a
                 className="css-kllbug"
@@ -263,7 +263,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
                   className="css-1gnbc76-Icon"
                 >
                   <SvgrURL
-                    className="css-1wizy59-Icon"
+                    className="css-hk02jy-Icon"
                   />
                 </span>
               </span>
@@ -281,14 +281,14 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
               className="css-1w7gjlo-BreadcrumbCollapsed"
             >
               <span
-                className="css-17y3y2w-BreadcrumbCollapsed"
+                className="css-hjigrk-BreadcrumbCollapsed"
                 onClick={[Function]}
               >
                 <span
                   className="css-1gnbc76-Icon"
                 >
                   <SvgrURL
-                    className="css-699c8a-Icon"
+                    className="css-ist487-Icon"
                   />
                 </span>
               </span>
@@ -299,7 +299,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
                   className="css-1gnbc76-Icon"
                 >
                   <SvgrURL
-                    className="css-1wizy59-Icon"
+                    className="css-hk02jy-Icon"
                   />
                 </span>
               </span>
@@ -307,7 +307,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
           </li>
           <li>
             <div
-              className="css-1wfnz1e-BreadcrumbItem"
+              className="css-183ezy7-BreadcrumbItem"
             >
               <a
                 className="css-kllbug"
@@ -323,7 +323,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
                   className="css-1gnbc76-Icon"
                 >
                   <SvgrURL
-                    className="css-1wizy59-Icon"
+                    className="css-hk02jy-Icon"
                   />
                 </span>
               </span>
@@ -331,7 +331,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
           </li>
           <li>
             <div
-              className="css-d0vim6-BreadcrumbItem"
+              className="css-e8ptyq-BreadcrumbItem"
             >
               <div
                 role="button"
@@ -340,7 +340,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
                   className="css-4yevxh-Menu"
                 >
                   <button
-                    className="css-h3p2id-Button"
+                    className="css-1nqt66k-Button"
                     data-testid="button"
                     disabled={false}
                     onClick={[Function]}
@@ -360,7 +360,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
                           className="css-1gnbc76-Icon"
                         >
                           <SvgrURL
-                            className="css-1vu224h-Icon"
+                            className="css-1b2voc8-Icon"
                           />
                         </span>
                       </div>
@@ -434,7 +434,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
       >
         <li>
           <div
-            className="css-1wfnz1e-BreadcrumbItem"
+            className="css-183ezy7-BreadcrumbItem"
           >
             <div>
               First Level
@@ -446,7 +446,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -454,7 +454,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
         </li>
         <li>
           <div
-            className="css-1wfnz1e-BreadcrumbItem"
+            className="css-183ezy7-BreadcrumbItem"
           >
             <div>
               Second Level
@@ -466,7 +466,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -474,7 +474,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
         </li>
         <li>
           <div
-            className="css-d0vim6-BreadcrumbItem"
+            className="css-e8ptyq-BreadcrumbItem"
           >
             <div>
               Third Level
@@ -541,7 +541,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
       >
         <li>
           <div
-            className="css-1wfnz1e-BreadcrumbItem"
+            className="css-183ezy7-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -557,7 +557,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -575,14 +575,14 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
             className="css-1w7gjlo-BreadcrumbCollapsed"
           >
             <span
-              className="css-17y3y2w-BreadcrumbCollapsed"
+              className="css-hjigrk-BreadcrumbCollapsed"
               onClick={[Function]}
             >
               <span
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-699c8a-Icon"
+                  className="css-ist487-Icon"
                 />
               </span>
             </span>
@@ -593,7 +593,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -601,7 +601,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
         </li>
         <li>
           <div
-            className="css-1wfnz1e-BreadcrumbItem"
+            className="css-183ezy7-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -617,7 +617,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-1wizy59-Icon"
+                  className="css-hk02jy-Icon"
                 />
               </span>
             </span>
@@ -625,7 +625,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
         </li>
         <li>
           <div
-            className="css-d0vim6-BreadcrumbItem"
+            className="css-e8ptyq-BreadcrumbItem"
           >
             <a
               className="css-kllbug"

--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -49,7 +49,7 @@ exports[`Storyshots Design System/Button Button Colors 1`] = `
       }
     >
       <button
-        className="css-1m8krdx-Button"
+        className="css-eaj3on-Button"
         data-testid="button"
         disabled={true}
       >
@@ -68,7 +68,7 @@ exports[`Storyshots Design System/Button Button Colors 1`] = `
       }
     >
       <button
-        className="css-11opgue-Button"
+        className="css-1etjsvk-Button"
         data-testid="button"
         disabled={false}
       >
@@ -87,7 +87,7 @@ exports[`Storyshots Design System/Button Button Colors 1`] = `
       }
     >
       <button
-        className="css-1p9g1ip-Button"
+        className="css-gg6z8n-Button"
         data-testid="button"
         disabled={false}
       >
@@ -106,7 +106,7 @@ exports[`Storyshots Design System/Button Button Colors 1`] = `
       }
     >
       <button
-        className="css-1032lz1-Button"
+        className="css-ysnfml-Button"
         data-testid="button"
         disabled={false}
       >
@@ -125,7 +125,7 @@ exports[`Storyshots Design System/Button Button Colors 1`] = `
       }
     >
       <button
-        className="css-1wdj45u-Button"
+        className="css-tlqw5y-Button"
         data-testid="button"
         disabled={false}
       >
@@ -189,7 +189,7 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
       }
     >
       <button
-        className="css-1ac6mrm-Button"
+        className="css-u4rz7a-Button"
         data-testid="button"
         disabled={false}
       >
@@ -208,7 +208,7 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
       }
     >
       <button
-        className="css-9410t0-Button"
+        className="css-1p4azpg-Button"
         data-testid="button"
         disabled={false}
       >
@@ -227,7 +227,7 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
       }
     >
       <button
-        className="css-1mrt4ai-Button"
+        className="css-11g98hm-Button"
         data-testid="button"
         disabled={false}
       >
@@ -275,7 +275,7 @@ exports[`Storyshots Design System/Button Button with icon 1`] = `
     </button>
   </div>
   <button
-    className="css-r2n7ee-Button"
+    className="css-47bwvw-Button"
     data-testid="button"
     disabled={false}
   >
@@ -335,7 +335,7 @@ exports[`Storyshots Design System/Button Dynamic Button Props 1`] = `
     </button>
   </div>
   <button
-    className="css-i2xg13-Button"
+    className="css-1ig4eql-Button"
     data-testid="button"
     disabled={false}
   >
@@ -397,7 +397,7 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
       }
     >
       <button
-        className="css-r2n7ee-Button"
+        className="css-47bwvw-Button"
         data-testid="button-size-lg"
         disabled={false}
       >
@@ -430,7 +430,7 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
       }
     >
       <button
-        className="css-15rkew6-Button"
+        className="css-ymm1jn-Button"
         data-testid="button-size-md"
         disabled={false}
       >
@@ -463,7 +463,7 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
       }
     >
       <button
-        className="css-d2x47o-Button"
+        className="css-1pp7ana-Button"
         data-testid="button-size-sm"
         disabled={false}
       >
@@ -525,7 +525,7 @@ exports[`Storyshots Design System/Button Non Filled Button 1`] = `
     </button>
   </div>
   <button
-    className="css-18rg2ll-Button"
+    className="css-pd9cpq-Button"
     data-testid="button"
     disabled={false}
   >
@@ -571,7 +571,7 @@ exports[`Storyshots Design System/Button Regular Button 1`] = `
     </button>
   </div>
   <button
-    className="css-1ac6mrm-Button"
+    className="css-u4rz7a-Button"
     data-testid="button"
     disabled={false}
   >

--- a/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
+++ b/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
@@ -67,7 +67,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
           />
         </span>
         <span
-          className="css-m4bvhz-CheckBox"
+          className="css-howegt-CheckBox"
         >
           Not checked single
         </span>
@@ -99,7 +99,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
           />
         </span>
         <span
-          className="css-m4bvhz-CheckBox"
+          className="css-howegt-CheckBox"
         >
           Checked Single
         </span>
@@ -131,7 +131,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
           />
         </span>
         <span
-          className="css-m4bvhz-CheckBox"
+          className="css-howegt-CheckBox"
         >
           Disabled single
         </span>
@@ -163,7 +163,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
           />
         </span>
         <span
-          className="css-m4bvhz-CheckBox"
+          className="css-howegt-CheckBox"
         >
           Checked intermediate
         </span>
@@ -195,7 +195,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
           />
         </span>
         <span
-          className="css-m4bvhz-CheckBox"
+          className="css-howegt-CheckBox"
         >
           Not checked intermediate
         </span>
@@ -227,7 +227,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
           />
         </span>
         <span
-          className="css-m4bvhz-CheckBox"
+          className="css-howegt-CheckBox"
         >
           Disabled checked intermediate
         </span>

--- a/src/components/DatePicker/DatePicker.style.ts
+++ b/src/components/DatePicker/DatePicker.style.ts
@@ -66,7 +66,7 @@ export const datePickerStyles = ({ isRangePicker }: { isRangePicker?: boolean })
   .DayPicker-Day--selected:not(.DayPicker-Day--outside),
   .DayPicker-Day--start:not(.DayPicker-Day--outside) {
     background-color: #dfdfdf;
-    color: #000;
+    color: ${theme.palette.black};
   }
 
   .DayPicker-Day--selected.DayPicker-Day--disabled:not(.DayPicker-Day--outside) {

--- a/src/components/Icon/__snapshots__/Icon.stories.storyshot
+++ b/src/components/Icon/__snapshots__/Icon.stories.storyshot
@@ -63,7 +63,7 @@ exports[`Storyshots Design System/Icon Icon with color 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -99,7 +99,7 @@ exports[`Storyshots Design System/Icon Icon with color 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1b6nqam-Icon"
           />
         </span>
         <p
@@ -396,7 +396,7 @@ exports[`Storyshots Design System/Icon Icon with size 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -432,7 +432,7 @@ exports[`Storyshots Design System/Icon Icon with size 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-1f91h5m-Icon"
+            className="css-1dozpx4-Icon"
           />
         </span>
         <p
@@ -468,7 +468,7 @@ exports[`Storyshots Design System/Icon Icon with size 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-wa0a95-Icon"
+            className="css-4v1yf8-Icon"
           />
         </span>
         <p
@@ -549,7 +549,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -585,7 +585,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -621,7 +621,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -657,7 +657,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -693,7 +693,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -729,7 +729,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -765,7 +765,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -801,7 +801,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -837,7 +837,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -873,7 +873,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -909,7 +909,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -945,7 +945,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -981,7 +981,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1017,7 +1017,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1053,7 +1053,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1089,7 +1089,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1125,7 +1125,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1161,7 +1161,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1197,7 +1197,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1233,7 +1233,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1269,7 +1269,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1305,7 +1305,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1341,7 +1341,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1377,7 +1377,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1413,7 +1413,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1449,7 +1449,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1485,7 +1485,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1521,7 +1521,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1557,7 +1557,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1593,7 +1593,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1629,7 +1629,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1665,7 +1665,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1701,7 +1701,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1737,7 +1737,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1773,7 +1773,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1809,7 +1809,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1845,7 +1845,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1881,7 +1881,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1917,7 +1917,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1953,7 +1953,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -1989,7 +1989,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2025,7 +2025,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2061,7 +2061,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2097,7 +2097,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2133,7 +2133,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2169,7 +2169,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2205,7 +2205,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2241,7 +2241,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2277,7 +2277,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2313,7 +2313,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2349,7 +2349,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2385,7 +2385,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2421,7 +2421,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2457,7 +2457,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2493,7 +2493,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2529,7 +2529,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2565,7 +2565,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2601,7 +2601,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2637,7 +2637,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2673,7 +2673,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2709,7 +2709,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2745,7 +2745,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2781,7 +2781,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2817,7 +2817,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2853,7 +2853,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2889,7 +2889,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2925,7 +2925,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2961,7 +2961,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -2997,7 +2997,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3033,7 +3033,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3069,7 +3069,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3105,7 +3105,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3141,7 +3141,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3177,7 +3177,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3213,7 +3213,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3249,7 +3249,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3285,7 +3285,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3321,7 +3321,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3357,7 +3357,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3393,7 +3393,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3429,7 +3429,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3465,7 +3465,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3501,7 +3501,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3537,7 +3537,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3573,7 +3573,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3609,7 +3609,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3645,7 +3645,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3681,7 +3681,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3717,7 +3717,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3753,7 +3753,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3789,7 +3789,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3825,7 +3825,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p
@@ -3861,7 +3861,7 @@ exports[`Storyshots Design System/Icon Icons Gallery 1`] = `
           className="css-1gnbc76-Icon"
         >
           <SvgrURL
-            className="css-jx17me-Icon"
+            className="css-1r0bq2o-Icon"
           />
         </span>
         <p

--- a/src/components/IconButton/__snapshots__/IconButton.stories.storyshot
+++ b/src/components/IconButton/__snapshots__/IconButton.stories.storyshot
@@ -49,7 +49,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
       }
     >
       <button
-        className="css-1bc9rfb-Button"
+        className="css-85yu03-Button"
         data-testid="button-button-size-lg"
         disabled={false}
       >
@@ -68,7 +68,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
               className="css-1gnbc76-Icon"
             >
               <SvgrURL
-                className="css-jx17me-Icon"
+                className="css-1r0bq2o-Icon"
               />
             </span>
           </div>
@@ -83,7 +83,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
       }
     >
       <button
-        className="css-1jpgrpn-Button"
+        className="css-1sztnel-Button"
         data-testid="button-button"
         disabled={false}
       >
@@ -102,7 +102,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
               className="css-1gnbc76-Icon"
             >
               <SvgrURL
-                className="css-jx17me-Icon"
+                className="css-1r0bq2o-Icon"
               />
             </span>
           </div>
@@ -117,7 +117,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
       }
     >
       <button
-        className="css-1ag7vv0-Button"
+        className="css-zaj8az-Button"
         data-testid="button-button"
         disabled={false}
       >
@@ -136,7 +136,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
               className="css-1gnbc76-Icon"
             >
               <SvgrURL
-                className="css-jx17me-Icon"
+                className="css-1r0bq2o-Icon"
               />
             </span>
           </div>
@@ -196,7 +196,7 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
       }
     >
       <button
-        className="css-1bc9rfb-Button"
+        className="css-85yu03-Button"
         data-testid="button-button-size-lg"
         disabled={false}
       >
@@ -215,7 +215,7 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
               className="css-1gnbc76-Icon"
             >
               <SvgrURL
-                className="css-jx17me-Icon"
+                className="css-1r0bq2o-Icon"
               />
             </span>
           </div>
@@ -230,7 +230,7 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
       }
     >
       <button
-        className="css-1jhd205-Button"
+        className="css-jh2kan-Button"
         data-testid="button-button-size-lg"
         disabled={false}
       >
@@ -264,7 +264,7 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
       }
     >
       <button
-        className="css-1jhd205-Button"
+        className="css-jh2kan-Button"
         data-testid="button-button-size-lg"
         disabled={false}
       >

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -86,7 +86,7 @@ export const optionsStyle = ({ menuPosition }: MenuOptions) => (theme: Theme) =>
     right 0;
     width: ${rem(148)};
     height: auto;
-    background-color: #fff;
+    background-color: ${theme.palette.white};
     box-shadow: 0px 0px ${rem(16)} grey;
     display: flex;
     flex-direction: column;
@@ -102,6 +102,6 @@ export const optionsStyle = ({ menuPosition }: MenuOptions) => (theme: Theme) =>
     }
 
     & > button:hover {
-      background-color: ${darken(0.05, '#fff')};
+      background-color: ${darken(0.05, theme.palette.white)};
     }
   `;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -75,7 +75,7 @@ const Menu: React.FC<Props & TestProps & EventProps> = props => {
               items.map((option, index) => (
                 <button
                   css={{
-                    backgroundColor: '#fff',
+                    backgroundColor: theme.palette.white,
                     border: 0,
                   }}
                   key={`${option}-${index}`}

--- a/src/components/Menu/__snapshots__/Menu.stories.storyshot
+++ b/src/components/Menu/__snapshots__/Menu.stories.storyshot
@@ -39,7 +39,7 @@ exports[`Storyshots Design System/Menu Menu with option icon and different colou
       className="css-4yevxh-Menu"
     >
       <button
-        className="css-w373bz-Button"
+        className="css-ftvin0-Button"
         data-testid="button"
         disabled={false}
         onClick={[Function]}
@@ -59,7 +59,7 @@ exports[`Storyshots Design System/Menu Menu with option icon and different colou
               className="css-1gnbc76-Icon"
             >
               <SvgrURL
-                className="css-jx17me-Icon"
+                className="css-1r0bq2o-Icon"
               />
             </span>
           </div>
@@ -119,7 +119,7 @@ exports[`Storyshots Design System/Menu Menu with selection handler 1`] = `
         className="css-4yevxh-Menu"
       >
         <button
-          className="css-h3p2id-Button"
+          className="css-1nqt66k-Button"
           data-testid="button"
           disabled={false}
           onClick={[Function]}
@@ -139,7 +139,7 @@ exports[`Storyshots Design System/Menu Menu with selection handler 1`] = `
                 className="css-1gnbc76-Icon"
               >
                 <SvgrURL
-                  className="css-g9ijxf-Icon"
+                  className="css-1ej672q-Icon"
                 />
               </span>
             </div>

--- a/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
+++ b/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
@@ -36,7 +36,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
     className="css-x2wflh-Pagination"
   >
     <button
-      className="css-12x09g9-Button"
+      className="css-1heqbdb-Button"
       data-testid="button-button"
       disabled={true}
       onClick={[Function]}
@@ -63,7 +63,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
       </span>
     </button>
     <button
-      className="css-12x09g9-Button"
+      className="css-1heqbdb-Button"
       data-testid="button-button"
       disabled={true}
       onClick={[Function]}
@@ -96,7 +96,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
       3
     </div>
     <button
-      className="css-cq61x0-Button"
+      className="css-2jp8tq-Button"
       data-testid="button-button"
       disabled={false}
       onClick={[Function]}
@@ -116,14 +116,14 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
             className="css-1gnbc76-Icon"
           >
             <SvgrURL
-              className="css-ga6got-Icon"
+              className="css-m1uddj-Icon"
             />
           </span>
         </div>
       </span>
     </button>
     <button
-      className="css-cq61x0-Button"
+      className="css-2jp8tq-Button"
       data-testid="button-button"
       disabled={false}
       onClick={[Function]}
@@ -143,7 +143,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
             className="css-1gnbc76-Icon"
           >
             <SvgrURL
-              className="css-ga6got-Icon"
+              className="css-m1uddj-Icon"
             />
           </span>
         </div>
@@ -189,7 +189,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
     className="css-x2wflh-Pagination"
   >
     <button
-      className="css-12x09g9-Button"
+      className="css-1heqbdb-Button"
       data-testid="button-button"
       disabled={true}
       onClick={[Function]}
@@ -222,7 +222,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
       3
     </div>
     <button
-      className="css-cq61x0-Button"
+      className="css-2jp8tq-Button"
       data-testid="button-button"
       disabled={false}
       onClick={[Function]}
@@ -242,7 +242,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
             className="css-1gnbc76-Icon"
           >
             <SvgrURL
-              className="css-ga6got-Icon"
+              className="css-m1uddj-Icon"
             />
           </span>
         </div>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -71,7 +71,7 @@ const Select: React.FC<Props> = ({
   const customStyles: Styles = {
     option: (provided, state) => ({
       ...provided,
-      backgroundColor: state.isSelected ? '#ededed' : '#ffffff',
+      backgroundColor: state.isSelected ? '#ededed' : theme.palette.white,
       color: state.isDisabled ? theme.palette.flat.lightGray[700] : theme.palette.text.primary[400],
       padding: rem(16),
       '&:hover': {
@@ -142,7 +142,7 @@ const Select: React.FC<Props> = ({
           backgroundColor: '#cecece',
         },
         svg: {
-          fill: '#fff',
+          fill: theme.palette.white,
           backgroundColor: 'transparent',
         },
       },

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -60,12 +60,12 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
           onKeyDown={[Function]}
         >
           <div
-            className=" css-1r98871-Control"
+            className=" css-1l56lhw-Control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
             <label
-              className="css-mmn0ve-Label"
+              className="css-kfhhvm-Label"
               htmlFor="select-"
             >
               Flavour
@@ -75,7 +75,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
               className=" css-g1d714-ValueContainer"
             >
               <div
-                className=" css-14rf7nc-singleValue"
+                className=" css-1p4n7lv-singleValue"
               >
                 Chocolate
               </div>
@@ -100,7 +100,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
               />
               <div
                 aria-hidden="true"
-                className=" css-a6yk30-DropdownIndicator"
+                className=" css-1cumceu-DropdownIndicator"
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >
@@ -186,12 +186,12 @@ exports[`Storyshots Design System/Select Multi Tag Select 1`] = `
           onKeyDown={[Function]}
         >
           <div
-            className=" css-pzq1zi-Control"
+            className=" css-1jrkfbi-Control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
             <label
-              className="css-pjljoe-Label"
+              className="css-199on22-Label"
               htmlFor="select-"
             >
               Flavour
@@ -224,7 +224,7 @@ exports[`Storyshots Design System/Select Multi Tag Select 1`] = `
               />
               <div
                 aria-hidden="true"
-                className=" css-a6yk30-DropdownIndicator"
+                className=" css-1cumceu-DropdownIndicator"
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >
@@ -270,7 +270,7 @@ exports[`Storyshots Design System/Select Multi Tag Select 1`] = `
             onTouchEnd={[Function]}
           >
             <label
-              className="css-pjljoe-Label"
+              className="css-199on22-Label"
               htmlFor="select-"
             >
               Flavour
@@ -303,7 +303,7 @@ exports[`Storyshots Design System/Select Multi Tag Select 1`] = `
               />
               <div
                 aria-hidden="true"
-                className=" css-a6yk30-DropdownIndicator"
+                className=" css-1cumceu-DropdownIndicator"
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >
@@ -389,12 +389,12 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
           onKeyDown={[Function]}
         >
           <div
-            className=" css-huq3l-Control"
+            className=" css-d4r9dk-Control"
             onMouseDown={[Function]}
             onTouchEnd={[Function]}
           >
             <label
-              className="css-mmn0ve-Label"
+              className="css-kfhhvm-Label"
               htmlFor="select-"
             >
               Flavour
@@ -404,7 +404,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               className=" css-g1d714-ValueContainer"
             >
               <div
-                className=" css-14rf7nc-singleValue"
+                className=" css-1p4n7lv-singleValue"
               >
                 Chocolate
               </div>
@@ -493,7 +493,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               />
               <div
                 aria-hidden="true"
-                className=" css-a6yk30-DropdownIndicator"
+                className=" css-1cumceu-DropdownIndicator"
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >
@@ -539,7 +539,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
             onTouchEnd={[Function]}
           >
             <label
-              className="css-mmn0ve-Label"
+              className="css-kfhhvm-Label"
               htmlFor="select-"
             >
               Flavour
@@ -549,7 +549,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               className=" css-g1d714-ValueContainer"
             >
               <div
-                className=" css-14rf7nc-singleValue"
+                className=" css-1p4n7lv-singleValue"
               >
                 Chocolate
               </div>
@@ -638,7 +638,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               />
               <div
                 aria-hidden="true"
-                className=" css-a6yk30-DropdownIndicator"
+                className=" css-1cumceu-DropdownIndicator"
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -85,7 +85,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
   >
     <thead>
       <tr
-        className="css-1x63kg5-Table"
+        className="css-1nbzf55-Table"
       >
         <th
           className="css-1973saa-TableCell"
@@ -447,7 +447,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
   >
     <thead>
       <tr
-        className="css-1x63kg5-Table"
+        className="css-1nbzf55-Table"
       >
         <th
           className="css-a3pxss-TableCell"
@@ -1109,7 +1109,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
   >
     <thead>
       <tr
-        className="css-1x63kg5-Table"
+        className="css-1nbzf55-Table"
       >
         <th
           className="css-1qrssk1-TableCell"
@@ -1588,7 +1588,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-18ou8n5-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Title
                     </div>
@@ -1602,7 +1602,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-hgmnoe-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Name
                     </div>
@@ -1616,7 +1616,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-hgmnoe-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Surname
                     </div>
@@ -1630,7 +1630,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-l5yfaw-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Age
                     </div>
@@ -1645,7 +1645,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   >
                     <div>
                       <div
-                        className="css-1os2xg1"
+                        className="css-6l85i6"
                         onClick={[Function]}
                       >
                         <div
@@ -1655,7 +1655,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                             className="css-1gnbc76-Icon"
                           >
                             <SvgrURL
-                              className="css-1md9xlz-Icon"
+                              className="css-b61ebr-Icon"
                             />
                           </span>
                         </div>
@@ -1712,7 +1712,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-18ou8n5-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Title
                     </div>
@@ -1726,7 +1726,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-hgmnoe-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Name
                     </div>
@@ -1740,7 +1740,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-hgmnoe-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Surname
                     </div>
@@ -1754,7 +1754,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                     className="css-l5yfaw-TableCell"
                   >
                     <div
-                      className="css-1irgabx"
+                      className="css-168ctv9"
                     >
                       Age
                     </div>
@@ -1769,7 +1769,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   >
                     <div>
                       <div
-                        className="css-1os2xg1"
+                        className="css-6l85i6"
                         onClick={[Function]}
                       >
                         <div
@@ -1779,7 +1779,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                             className="css-1gnbc76-Icon"
                           >
                             <SvgrURL
-                              className="css-1md9xlz-Icon"
+                              className="css-b61ebr-Icon"
                             />
                           </span>
                         </div>

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -402,7 +402,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-1o8230t-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -450,25 +450,25 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-1nbzf55-Table"
       >
         <th
-          className="css-a3pxss-TableCell"
+          className="css-1vjr0s9-TableCell"
         />
         <th
-          className="css-1r1qkc1-TableCell"
+          className="css-1xy1ycd-TableCell"
         >
           Title
         </th>
         <th
-          className="css-1r1qkc1-TableCell"
+          className="css-1xy1ycd-TableCell"
         >
           Name
         </th>
         <th
-          className="css-1r1qkc1-TableCell"
+          className="css-1xy1ycd-TableCell"
         >
           Surname
         </th>
         <th
-          className="css-1w04xju-TableCell"
+          className="css-1keazcd-TableCell"
         >
           Age
         </th>
@@ -479,7 +479,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -542,7 +542,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -605,7 +605,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -668,7 +668,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -731,7 +731,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -794,7 +794,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -857,7 +857,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -920,7 +920,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"
@@ -983,7 +983,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-8z679-TableRow"
       >
         <th
-          className="css-sycyqs-TableCell"
+          className="css-sxuvld-TableCell"
         >
           <span
             className="css-u4dw6y-CheckBox"

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -47,7 +47,7 @@ const TableCell: React.FC<Props> = ({
           left: 0,
           zIndex: 2,
           position: 'sticky',
-          background: '#fff',
+          background: theme.palette.white,
         },
         type === 'financial' && {
           borderLeft: `1px solid ${theme.palette.flat.lightGray[400]}`,

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -55,7 +55,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
           className="css-3kv64u-TextField"
         >
           <div
-            className="css-tlzk97-TextField"
+            className="css-k9l383-TextField"
           >
             <input
               className="css-1hi3w5j-TextField"
@@ -63,7 +63,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
               required={false}
             />
             <label
-              className="css-pjljoe-Label"
+              className="css-199on22-Label"
             >
               Label
                
@@ -131,10 +131,10 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder 1`] = `
           className="css-3kv64u-TextField"
         >
           <div
-            className="css-z8chax-TextField"
+            className="css-18znayk-TextField"
           >
             <input
-              className="css-k4qzap-TextField"
+              className="css-1wgrvhw-TextField"
               placeholder="placeholder "
               required={false}
             />
@@ -201,7 +201,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder and icon
           className="css-3kv64u-TextField"
         >
           <div
-            className="css-m3wpou-TextField"
+            className="css-o738vn-TextField"
           >
             <div
               className="css-2oohh4-TextField"
@@ -213,7 +213,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder and icon
               />
             </div>
             <input
-              className="css-k4qzap-TextField"
+              className="css-1wgrvhw-TextField"
               placeholder="placeholder "
               required={false}
             />
@@ -280,7 +280,7 @@ exports[`Storyshots Design System/TextField Text Field without Label 1`] = `
           className="css-3kv64u-TextField"
         >
           <div
-            className="css-z8chax-TextField"
+            className="css-18znayk-TextField"
           >
             <input
               className="css-9qa453-TextField"
@@ -349,7 +349,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
           className="css-17t39sg-TextField"
         >
           <div
-            className="css-tlzk97-TextField"
+            className="css-k9l383-TextField"
           >
             <input
               className="css-1hi3w5j-TextField"
@@ -358,7 +358,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
               required={false}
             />
             <label
-              className="css-pjljoe-Label"
+              className="css-199on22-Label"
             >
               Label
                
@@ -427,7 +427,7 @@ exports[`Storyshots Design System/TextField TextField with label and error handl
             className="css-kba2bb-TextField"
           >
             <div
-              className="css-tlzk97-TextField"
+              className="css-k9l383-TextField"
             >
               <input
                 className="css-1hi3w5j-TextField"

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -62,8 +62,8 @@ export const lightPalette: PaletteConfig = {
     light: flatPaletteConfig.lightGray,
   },
 
-  white: '#fff',
-  black: '#000',
+  white: 'white',
+  black: 'black',
 };
 
 export const darkPalette: PaletteConfig = {
@@ -91,8 +91,8 @@ export const darkPalette: PaletteConfig = {
     light: flatPaletteConfig.lightGray,
   },
 
-  white: '#fff',
-  black: '#000',
+  white: 'white',
+  black: 'black',
 };
 
 export type flatPaletteConfigType = {

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,7 +1,7 @@
 export const flatPaletteConfig: flatPaletteConfigType = {
-  lightGray: '#101010',
+  lightGray: '#cfcfcf',
 
-  darkGray: '#101010',
+  darkGray: '#494949',
 
   coolGray: '#a3a9ac',
 
@@ -61,6 +61,9 @@ export const lightPalette: PaletteConfig = {
     secondary: flatPaletteConfig.coolGray,
     light: flatPaletteConfig.lightGray,
   },
+
+  white: '#fff',
+  black: '#101010',
 };
 
 export const darkPalette: PaletteConfig = {
@@ -87,6 +90,9 @@ export const darkPalette: PaletteConfig = {
     secondary: flatPaletteConfig.coolGray,
     light: flatPaletteConfig.lightGray,
   },
+
+  white: '#fff',
+  black: '#101010',
 };
 
 export type flatPaletteConfigType = {
@@ -172,6 +178,9 @@ export type PaletteConfig = {
   text?: TextPaletteConfigType;
 
   flat?: flatPaletteConfigType;
+
+  white?: string;
+  black?: string;
 };
 
 export type generatedColorShades = {
@@ -204,6 +213,9 @@ export type Palette = {
   };
 
   flat: flatPalette;
+
+  white: string;
+  black: string;
 };
 
 export type formFieldStyles = 'filled' | 'outlined' | 'elevated';

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -63,7 +63,7 @@ export const lightPalette: PaletteConfig = {
   },
 
   white: '#fff',
-  black: '#101010',
+  black: '#000',
 };
 
 export const darkPalette: PaletteConfig = {
@@ -92,7 +92,7 @@ export const darkPalette: PaletteConfig = {
   },
 
   white: '#fff',
-  black: '#101010',
+  black: '#000',
 };
 
 export type flatPaletteConfigType = {

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -9,9 +9,7 @@ import {
 
 const BASE_PERCENTAGE = 0.25;
 
-const SPECIAL_GRAY_PERCENTAGE = 0.08;
-
-const SPECIAL_GRAY = ['lightGray', 'darkGray'];
+const EXCLUDED = ['white', 'black'];
 
 export const convertPointsToPixels = (pt: number) => (96 / 72) * pt;
 
@@ -38,17 +36,9 @@ export const colorShadesCreator = (base: string, per: number) =>
     ...createShades((index: number) => tint(per * index, base)),
   ]);
 
-export const grayShadesCreator = (base: string, name: string, per: number) => {
-  return reduceColorShades(
-    name === SPECIAL_GRAY[0]
-      ? [...createShades((index: number) => tint(per * index, base), 14).slice(7, 13), '#fff']
-      : [...createShades((index: number) => tint(per * index, base), 14).slice(0, 7)]
-  );
-};
-
 export const iterateObject = <T>(
   obj: T,
-  func: (value: string, name: string) => generatedColorShades
+  func: (value: string, name: string) => generatedColorShades | string
 ) =>
   Object.keys(obj).reduce((acc, value) => {
     acc[value] =
@@ -61,7 +51,5 @@ export const iterateObject = <T>(
 
 export const enhancePaletteWithShades = (obj: PaletteConfig): Palette =>
   iterateObject<PaletteConfig>(obj, (value: string, name: string) =>
-    SPECIAL_GRAY.includes(name)
-      ? grayShadesCreator(value, name, SPECIAL_GRAY_PERCENTAGE)
-      : colorShadesCreator(value, BASE_PERCENTAGE)
+    EXCLUDED.includes(name) ? value : colorShadesCreator(value, BASE_PERCENTAGE)
   ) as Palette;


### PR DESCRIPTION

## Description

In previous version we had complicated and contradicting way of creating the colors. 

In this PR there is only one rule for creating all the colors.

Each color includes seven shades, the base color (color400) and six shades deriving from color400,
three darker and three lighter.

All new shades are calculated with color percentages (25%, 50%, 75%) on white background for the lighter shades and black background for the darker ones (75%, 50%, 25%).


## Screenshot
 
No screenshot on this.

## Test Plan

Storyshots tests are updated based on the css objects returned.