### PR TITLE
Fix/table and checkbox

### DIFF
--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -7,6 +7,7 @@ export const wrapperStyle = ({ disabled }: Props) => (): SerializedStyles => css
   opacity: ${disabled ? 0.3 : 1};
   justify-content: center;
   align-items: center;
+  display: flex;
 `;
 
 export const checkboxWrapperStyle = () => (theme: Theme): SerializedStyles => css`
@@ -16,9 +17,16 @@ export const checkboxWrapperStyle = () => (theme: Theme): SerializedStyles => cs
   display: flex;
   justify-content: center;
   align-items: center;
-  transition: all 0.2s;
 
-  &:hover {
+  &:before {
+    border-radius: 100%;
+    transition: all 0.2s;
+    content: ' ';
+    width: ${rem(50)};
+    height: ${rem(50)};
+    position: absolute;
+  }
+  &:hover:before {
     background: ${transparentize(0.7, theme.palette.flat.lightGray[400])};
   }
 `;

--- a/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
+++ b/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
@@ -43,10 +43,10 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={false}
@@ -75,10 +75,10 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={true}
@@ -107,10 +107,10 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
       }
     >
       <span
-        className="css-1mci7ch-CheckBox"
+        className="css-2w5jy3-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={true}
@@ -139,10 +139,10 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={true}
@@ -171,10 +171,10 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={false}
@@ -203,10 +203,10 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
       }
     >
       <span
-        className="css-1mci7ch-CheckBox"
+        className="css-2w5jy3-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={true}
@@ -274,10 +274,10 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={true}
@@ -301,10 +301,10 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={false}
@@ -328,10 +328,10 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={true}
@@ -355,10 +355,10 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
       }
     >
       <span
-        className="css-u4dw6y-CheckBox"
+        className="css-58ep04-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={false}
@@ -382,10 +382,10 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
       }
     >
       <span
-        className="css-1mci7ch-CheckBox"
+        className="css-2w5jy3-CheckBox"
       >
         <span
-          className="css-bdc5ng-CheckBox"
+          className="css-1h0729d-CheckBox"
         >
           <input
             checked={false}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -184,7 +184,7 @@ function Table<T>({
                 ]}
               >
                 {onCheck && (
-                  <TableCell component={'th'} sticky={fixedHeader} width={30} padded={padded} />
+                  <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded} />
                 )}
                 {columns.map((item, index) => (
                   <TableCell

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -43,10 +43,10 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
           className="css-1esmywb-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -88,7 +88,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         className="css-1nbzf55-Table"
       >
         <th
-          className="css-1973saa-TableCell"
+          className="css-1esmywb-TableCell"
         />
         <th
           className="css-1qrssk1-TableCell"
@@ -116,14 +116,14 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-1esmywb-TableCell"
+        <td
+          className="css-jzhxmr-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -138,7 +138,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -179,14 +179,14 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-1esmywb-TableCell"
+        <td
+          className="css-jzhxmr-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -201,7 +201,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -242,14 +242,14 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-1esmywb-TableCell"
+        <td
+          className="css-jzhxmr-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -264,7 +264,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -305,14 +305,14 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-1esmywb-TableCell"
+        <td
+          className="css-jzhxmr-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -327,7 +327,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -405,10 +405,10 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
           className="css-sxuvld-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -450,7 +450,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         className="css-1nbzf55-Table"
       >
         <th
-          className="css-1vjr0s9-TableCell"
+          className="css-sxuvld-TableCell"
         />
         <th
           className="css-1xy1ycd-TableCell"
@@ -478,14 +478,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -500,7 +500,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -541,14 +541,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -563,7 +563,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -604,14 +604,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -626,7 +626,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -667,14 +667,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -689,7 +689,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -730,14 +730,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -752,7 +752,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -793,14 +793,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -815,7 +815,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -856,14 +856,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -878,7 +878,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -919,14 +919,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -941,7 +941,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -982,14 +982,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       <tr
         className="css-8z679-TableRow"
       >
-        <th
-          className="css-sxuvld-TableCell"
+        <td
+          className="css-1q7is6o-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -1004,7 +1004,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
               />
             </span>
           </span>
-        </th>
+        </td>
         <td
           className="css-hgmnoe-TableCell"
         >
@@ -1502,10 +1502,10 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
           className="css-1esmywb-TableCell"
         >
           <span
-            className="css-u4dw6y-CheckBox"
+            className="css-58ep04-CheckBox"
           >
             <span
-              className="css-bdc5ng-CheckBox"
+              className="css-1h0729d-CheckBox"
             >
               <input
                 checked={false}
@@ -1561,14 +1561,14 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 <tr
                   className="css-1o8230t-TableRow"
                 >
-                  <th
-                    className="css-1esmywb-TableCell"
+                  <td
+                    className="css-jzhxmr-TableCell"
                   >
                     <span
-                      className="css-u4dw6y-CheckBox"
+                      className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-bdc5ng-CheckBox"
+                        className="css-1h0729d-CheckBox"
                       >
                         <input
                           checked={false}
@@ -1583,7 +1583,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                         />
                       </span>
                     </span>
-                  </th>
+                  </td>
                   <td
                     className="css-18ou8n5-TableCell"
                   >
@@ -1685,14 +1685,14 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 <tr
                   className="css-1o8230t-TableRow"
                 >
-                  <th
-                    className="css-1esmywb-TableCell"
+                  <td
+                    className="css-jzhxmr-TableCell"
                   >
                     <span
-                      className="css-u4dw6y-CheckBox"
+                      className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-bdc5ng-CheckBox"
+                        className="css-1h0729d-CheckBox"
                       >
                         <input
                           checked={false}
@@ -1707,7 +1707,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                         />
                       </span>
                     </span>
-                  </th>
+                  </td>
                   <td
                     className="css-18ou8n5-TableCell"
                   >

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -38,7 +38,7 @@ const RenderRowWithCells = React.memo(({ checked = false, toggleChecked = () => 
       css={bordered && { borderBottom: `${rem(1)} solid ${theme.palette.flat.lightGray[400]}` }}
     >
       {onSelectionChangeExist && (
-        <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded}>
+        <TableCell component={'td'} sticky={fixedHeader} width={50} padded={padded}>
           <CheckBox checked={isRowSelected} onClick={tChange} />
         </TableCell>
       )}


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->
This PR fix two bugs that i found on the table with the checkbox. 

Checkbox issue was that although we defined centering items through flex the parent was not a `flex` item so it wasn't working. This was due to the fact that when the parent was `flex` then the hover was not working correctly. Now i moved the hover to the pseudo :before.

Table issue was that when the checkbox was shown on some tables the width was smaller and because of the padding and the different width of the header cell was moving.

[designs](https://share.goabstract.com/e4bb166a-21e9-421f-b27d-c0f5215baeaf?collectionLayerId=ed92aefd-8e0d-4e49-b457-459dcb21ee65&mode=design)

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->
before
<img width="614" alt="Screenshot 2020-10-13 at 12 38 18 PM" src="https://user-images.githubusercontent.com/6433679/95844300-6e5c8000-0d51-11eb-923a-4c005bd3dd50.png">

after
<img width="615" alt="Screenshot 2020-10-13 at 12 21 40 PM" src="https://user-images.githubusercontent.com/6433679/95844335-79afab80-0d51-11eb-91d4-12f8ef1c3246.png">
<img width="817" alt="Screenshot 2020-10-13 at 12 21 27 PM" src="https://user-images.githubusercontent.com/6433679/95844339-7caa9c00-0d51-11eb-9cf6-48cf69e07589.png">

## Test Plan

<!-- Explain what you tested and why -->

Tests are only made through snapshots
<!--
  Have any questions? Check out the contributing doc for more
-->
