### PR TITLE
feat(datepicker): adds date format option for date pick input

### DIFF
--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -11,6 +11,8 @@ import { formFieldStyles } from '../../../theme/palette';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import localeData from 'dayjs/plugin/localeData';
 import { getLocaleFormat } from '../../../utils/helpers';
+import 'dayjs/locale/en-gb';
+import 'dayjs/locale/en';
 
 type Props = {
   isRangePicker: boolean;
@@ -18,27 +20,34 @@ type Props = {
   inputLabel: string;
   /** Style of input field */
   styleType: formFieldStyles;
-  dateFormat: DateFormatType;
-  hasLocalizedFormat: boolean;
+  dateFormat?: DateFormatType;
 } & DayPickerInputProps;
 
 [localizedFormat, localeData].forEach(dayjs.extend);
+
+(function InitDatePickerLocaleFormat(usLocale: string, euLocale: string) {
+  const browserLanguage = navigator?.language === 'en-GB' ? euLocale : usLocale;
+  dayjs.locale(browserLanguage);
+})('en', 'en-gb');
 
 const DatePickInput: React.FC<Props> = ({
   isRangePicker,
   styleType,
   selectedDay,
   inputLabel,
-  dateFormat,
-  hasLocalizedFormat,
+  dateFormatOverride = undefined,
   ...props
 }) => {
   const theme = useTheme();
   const formatDate = (date: Date | undefined) => {
-    return date ? dayjs(date).format(getLocaleFormat(hasLocalizedFormat, dateFormat)) : '';
+    return date ? dayjs(date).format(getLocaleFormat(dateFormatOverride)) : '';
   };
 
   const getDateFormatted = React.useCallback(formatDate, []);
+
+  console.log(
+    selectedDay.from && dayjs(selectedDay.from).format(getLocaleFormat(dateFormatOverride))
+  );
 
   return isRangePicker ? (
     <div

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -20,7 +20,7 @@ type Props = {
   inputLabel: string;
   /** Style of input field */
   styleType: formFieldStyles;
-  dateFormat?: DateFormatType;
+  dateFormatOverride?: DateFormatType;
 } & DayPickerInputProps;
 
 [localizedFormat, localeData].forEach(dayjs.extend);

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -8,6 +8,9 @@ import TextField from '../../TextField';
 import { wrapperStyle } from '../../TextField/TextField.style';
 import { DateFormatType, DateRange } from '../DatePicker';
 import { formFieldStyles } from '../../../theme/palette';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import localeData from 'dayjs/plugin/localeData';
+import { getLocaleFormat } from '../../../utils/helpers';
 
 type Props = {
   isRangePicker: boolean;
@@ -15,22 +18,27 @@ type Props = {
   inputLabel: string;
   /** Style of input field */
   styleType: formFieldStyles;
-  dateFormat: DateFormatType
+  dateFormat: DateFormatType;
+  hasLocalizedFormat: boolean;
 } & DayPickerInputProps;
+
+[localizedFormat, localeData].forEach(dayjs.extend);
 
 const DatePickInput: React.FC<Props> = ({
   isRangePicker,
   styleType,
   selectedDay,
   inputLabel,
-  dateFormat ,
+  dateFormat,
+  hasLocalizedFormat,
   ...props
 }) => {
   const theme = useTheme();
-  const getDateFormatted = React.useCallback(
-    (date: Date | undefined) => (date ? dayjs(date).format(dateFormat) : ''),
-    []
-  );
+  const formatDate = (date: Date | undefined) => {
+    return date ? dayjs(date).format(getLocaleFormat(hasLocalizedFormat, dateFormat)) : '';
+  };
+
+  const getDateFormatted = React.useCallback(formatDate, []);
 
   return isRangePicker ? (
     <div

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -44,10 +44,6 @@ const DatePickInput: React.FC<Props> = ({
 
   const getDateFormatted = React.useCallback(formatDate, []);
 
-  console.log(
-    selectedDay.from && dayjs(selectedDay.from).format(getLocaleFormat(dateFormatOverride))
-  );
-
   return isRangePicker ? (
     <div
       css={[

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -23,9 +23,8 @@ type Props = {
   dateFormatOverride?: DateFormatType;
 } & DayPickerInputProps;
 
-[localizedFormat, localeData].forEach(dayjs.extend);
-
 (function InitDatePickerLocaleFormat(usLocale: string, euLocale: string) {
+  [localizedFormat, localeData].forEach(dayjs.extend);
   const browserLanguage = navigator?.language === 'en-GB' ? euLocale : usLocale;
   dayjs.locale(browserLanguage);
 })('en', 'en-gb');

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -32,8 +32,6 @@ const DatePickInput: React.FC<Props> = ({
     []
   );
 
-  console.log(getDateFormatted(selectedDay.from), dateFormat);
-
   return isRangePicker ? (
     <div
       css={[

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -8,11 +8,7 @@ import TextField from '../../TextField';
 import { wrapperStyle } from '../../TextField/TextField.style';
 import { DateFormatType, DateRange } from '../DatePicker';
 import { formFieldStyles } from '../../../theme/palette';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
-import localeData from 'dayjs/plugin/localeData';
 import { getLocaleFormat } from '../../../utils/helpers';
-import 'dayjs/locale/en-gb';
-import 'dayjs/locale/en';
 
 type Props = {
   isRangePicker: boolean;
@@ -22,12 +18,6 @@ type Props = {
   styleType: formFieldStyles;
   dateFormatOverride?: DateFormatType;
 } & DayPickerInputProps;
-
-(function InitDatePickerLocaleFormat(usLocale: string, euLocale: string) {
-  [localizedFormat, localeData].forEach(dayjs.extend);
-  const browserLanguage = navigator?.language === 'en-GB' ? euLocale : usLocale;
-  dayjs.locale(browserLanguage);
-})('en', 'en-gb');
 
 const DatePickInput: React.FC<Props> = ({
   isRangePicker,

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -6,7 +6,7 @@ import { flex } from '../../../theme/functions';
 import Icon from '../../Icon';
 import TextField from '../../TextField';
 import { wrapperStyle } from '../../TextField/TextField.style';
-import { DateRange } from '../DatePicker';
+import { DateFormatType, DateRange } from '../DatePicker';
 import { formFieldStyles } from '../../../theme/palette';
 
 type Props = {
@@ -15,6 +15,7 @@ type Props = {
   inputLabel: string;
   /** Style of input field */
   styleType: formFieldStyles;
+  dateFormat: DateFormatType
 } & DayPickerInputProps;
 
 const DatePickInput: React.FC<Props> = ({
@@ -22,13 +23,16 @@ const DatePickInput: React.FC<Props> = ({
   styleType,
   selectedDay,
   inputLabel,
+  dateFormat ,
   ...props
 }) => {
   const theme = useTheme();
   const getDateFormatted = React.useCallback(
-    (date: Date | undefined) => (date ? dayjs(date).format('MM/DD/YYYY') : ''),
+    (date: Date | undefined) => (date ? dayjs(date).format(dateFormat) : ''),
     []
   );
+
+  console.log(getDateFormatted(selectedDay.from), dateFormat);
 
   return isRangePicker ? (
     <div

--- a/src/components/DatePicker/DatePickInput/__tests__/DatePickInput.js
+++ b/src/components/DatePicker/DatePickInput/__tests__/DatePickInput.js
@@ -1,0 +1,9 @@
+describe('Change Locale Test Suite', () => {
+  let navigator;
+  beforeEach(() => {
+    navigator = {
+      languages: ['el', 'en'],
+    };
+  });
+  it('should display the correct locale', () => {});
+});

--- a/src/components/DatePicker/DatePickInput/__tests__/DatePickInput.js
+++ b/src/components/DatePicker/DatePickInput/__tests__/DatePickInput.js
@@ -1,9 +1,0 @@
-describe('Change Locale Test Suite', () => {
-  let navigator;
-  beforeEach(() => {
-    navigator = {
-      languages: ['el', 'en'],
-    };
-  });
-  it('should display the correct locale', () => {});
-});

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -10,6 +10,7 @@ const options = {
   'Enable dates from/to a date (7 days)': { before: dayjs().subtract(7, 'day').toDate(), after: dayjs().add(7, 'day').toDate() },
 }
 const styleTypeOptions = ['filled', 'outlined', 'elevated']
+const dateFormatOptions = ['MM/DD/YYYY', 'MMMM D, YYYY', 'dddd, MMMM D, YYYY', 'M/D/YYYY', 'MMM D, YYYY', 'ddd, MMM D, YYYY']
 
 <Meta title="Design System/DatePicker" component={DatePicker} />
 
@@ -39,6 +40,7 @@ Implementation of the regular DatePicker
       isRangePicker
       styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])}
       disableDates={select('disableDates', options, options[0])}
+      dateFormat={select('dateFormat', dateFormatOptions, dateFormatOptions[0])}
     />
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -10,7 +10,15 @@ const options = {
   'Enable dates from/to a date (7 days)': { before: dayjs().subtract(7, 'day').toDate(), after: dayjs().add(7, 'day').toDate() },
 }
 const styleTypeOptions = ['filled', 'outlined', 'elevated']
-const dateFormatOptions = ['MM/DD/YYYY', 'MMMM D, YYYY', 'dddd, MMMM D, YYYY', 'M/D/YYYY', 'MMM D, YYYY', 'ddd, MMM D, YYYY']
+const dateFormatOptions = {
+  'Enables system\'s locale format' : undefined,
+  'MM/DD/YYYY':'MM/DD/YYYY',
+  'MMMM D, YYYY': 'MMMM D, YYYY',
+  'dddd, MMMM D, YYYY':'dddd, MMMM D, YYYY',
+  'M/D/YYYY':  'M/D/YYYY',
+  'MMM D, YYYY': 'MMM D, YYYY',
+  'ddd, MMM D, YYYY': 'ddd, MMM D, YYYY'
+}
 
 <Meta title="Design System/DatePicker" component={DatePicker} />
 
@@ -32,7 +40,8 @@ import { DatePicker } from '@orfium/ictinus';
 
 # DatePicker
 
-Implementation of the regular DatePicker
+Implementation of the regular DatePicker.
+
 
 <Preview>
   <Story name="DatePicker" parameters={{ decorators: [withKnobs] }}>
@@ -44,22 +53,6 @@ Implementation of the regular DatePicker
     />
   </Story>
 </Preview>
-
-
-# DatePicker - locale date format
-
-Implementation of the regular DatePicker with locale date format
-
-<Preview>
-  <Story name="DatePicker with locale date format" parameters={{ decorators: [withKnobs] }}>
-    <DatePicker
-      isRangePicker
-      styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])}
-      disableDates={select('disableDates', options, options[0])}
-    />
-  </Story>
-</Preview>
-
 
 # DayPicker
 

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -40,10 +40,26 @@ Implementation of the regular DatePicker
       isRangePicker
       styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])}
       disableDates={select('disableDates', options, options[0])}
-      dateFormat={select('dateFormat', dateFormatOptions, dateFormatOptions[0])}
+      dateFormatOverride={select('dateFormat', dateFormatOptions, dateFormatOptions[0])}
     />
   </Story>
 </Preview>
+
+
+# DatePicker - locale date format
+
+Implementation of the regular DatePicker with locale date format
+
+<Preview>
+  <Story name="DatePicker with locale date format" parameters={{ decorators: [withKnobs] }}>
+    <DatePicker
+      isRangePicker
+      styleType={select('styleType', styleTypeOptions, styleTypeOptions[0])}
+      disableDates={select('disableDates', options, options[0])}
+    />
+  </Story>
+</Preview>
+
 
 # DayPicker
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -27,7 +27,9 @@ export type Props = {
   /** Style of input field */
   styleType?: formFieldStyles;
   /** The format of the date displayed in the input field */
-  dateFormat?: DateFormatType
+  dateFormat?: DateFormatType;
+  /** Indicates if we should use locale system's date for the date picker*/
+  hasLocalizedFormat: boolean;
 };
 
 export type DateRange =
@@ -87,7 +89,8 @@ const DatePicker: React.FC<Props> = ({
   },
   inputLabel = 'Date',
   styleType = 'filled',
-  dateFormat = 'MM/DD/YYYY'
+  dateFormat = 'MM/DD/YYYY',
+  hasLocalizedFormat= true
 }) => {
   const dayPickerInputRef = useRef<DayPickerInput>(null);
   const dayPickerRef = useRef<DayPicker>(null);
@@ -198,6 +201,7 @@ const DatePicker: React.FC<Props> = ({
         component={(props: DayPickerInputProps) => (
           <DatePickInput
             {...props}
+            hasLocalizedFormat={hasLocalizedFormat}
             styleType={styleType}
             inputLabel={inputLabel}
             selectedDay={selectedDay}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -26,6 +26,8 @@ export type Props = {
   inputLabel?: string;
   /** Style of input field */
   styleType?: formFieldStyles;
+  /** The format of the date displayed in the input field */
+  dateFormat?: DateFormatType
 };
 
 export type DateRange =
@@ -36,6 +38,14 @@ export type DateRange =
     };
 
 export type ExtraOption = { value: string; label: string; dates: Date | Date[] };
+
+export type DateFormatType =
+'MM/DD/YYYY' |
+'MMMM D, YYYY' |
+'dddd, MMMM D, YYYY' |
+'M/D/YYYY' |
+'MMM D, YYYY' |
+'ddd, MMM D, YYYY';
 
 const extraOptions: ExtraOption[] = [
   {
@@ -77,6 +87,7 @@ const DatePicker: React.FC<Props> = ({
   },
   inputLabel = 'Date',
   styleType = 'filled',
+  dateFormat = 'MM/DD/YYYY'
 }) => {
   const dayPickerInputRef = useRef<DayPickerInput>(null);
   const dayPickerRef = useRef<DayPicker>(null);
@@ -191,6 +202,7 @@ const DatePicker: React.FC<Props> = ({
             inputLabel={inputLabel}
             selectedDay={selectedDay}
             isRangePicker={isRangePicker}
+            dateFormat={dateFormat}
           />
         )}
         hideOnDayClick={false}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -27,9 +27,7 @@ export type Props = {
   /** Style of input field */
   styleType?: formFieldStyles;
   /** The format of the date displayed in the input field */
-  dateFormat?: DateFormatType;
-  /** Indicates if we should use locale system's date for the date picker*/
-  hasLocalizedFormat: boolean;
+  dateFormatOverride?: DateFormatType;
 };
 
 export type DateRange =
@@ -42,12 +40,12 @@ export type DateRange =
 export type ExtraOption = { value: string; label: string; dates: Date | Date[] };
 
 export type DateFormatType =
-'MM/DD/YYYY' |
-'MMMM D, YYYY' |
-'dddd, MMMM D, YYYY' |
-'M/D/YYYY' |
-'MMM D, YYYY' |
-'ddd, MMM D, YYYY';
+  | 'MM/DD/YYYY'
+  | 'MMMM D, YYYY'
+  | 'dddd, MMMM D, YYYY'
+  | 'M/D/YYYY'
+  | 'MMM D, YYYY'
+  | 'ddd, MMM D, YYYY';
 
 const extraOptions: ExtraOption[] = [
   {
@@ -89,8 +87,7 @@ const DatePicker: React.FC<Props> = ({
   },
   inputLabel = 'Date',
   styleType = 'filled',
-  dateFormat = 'MM/DD/YYYY',
-  hasLocalizedFormat= true
+  dateFormatOverride = undefined,
 }) => {
   const dayPickerInputRef = useRef<DayPickerInput>(null);
   const dayPickerRef = useRef<DayPicker>(null);
@@ -201,12 +198,11 @@ const DatePicker: React.FC<Props> = ({
         component={(props: DayPickerInputProps) => (
           <DatePickInput
             {...props}
-            hasLocalizedFormat={hasLocalizedFormat}
             styleType={styleType}
             inputLabel={inputLabel}
             selectedDay={selectedDay}
             isRangePicker={isRangePicker}
-            dateFormat={dateFormat}
+            dateFormatOverride={dateFormatOverride}
           />
         )}
         hideOnDayClick={false}

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -7,6 +7,7 @@ import { enhancePaletteWithShades } from '../../theme/utils';
 import { DeepPartial } from '../../utils/types';
 import { css, Global } from '@emotion/core';
 import { normalize } from 'polished';
+import 'utils/initLocaleFormat';
 
 type Props = {
   /** Theme properties to override or pass theming down to library */

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { TestId } from 'utils/types';
+import dayjs from 'dayjs';
 
 /** A function that generates a unique id by making a value randomly based on time also */
 export const generateUniqueID = () => '_' + (Date.now() + Math.random()).toString(36).substr(2, 9);
@@ -17,3 +18,12 @@ export function isComponentFunctionType(
 ): element is Function {
   return typeof element === 'function' && React.isValidElement(element());
 }
+
+/**  A function that retrieves the correct date format based on system's locale */
+export const getLocaleFormat = (hasLocalizedFormat: boolean, fallbackDateFormat: string) => {
+  const localeFormat = dayjs()
+    ?.localeData()
+    ?.longDateFormat('L');
+
+  return hasLocalizedFormat && localeFormat ? localeFormat : fallbackDateFormat;
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -20,10 +20,10 @@ export function isComponentFunctionType(
 }
 
 /**  A function that retrieves the correct date format based on system's locale */
-export const getLocaleFormat = (hasLocalizedFormat: boolean, fallbackDateFormat: string) => {
+export const getLocaleFormat = (dateFormat: string | undefined) => {
   const localeFormat = dayjs()
     ?.localeData()
     ?.longDateFormat('L');
 
-  return hasLocalizedFormat && localeFormat ? localeFormat : fallbackDateFormat;
+  return dateFormat ? dateFormat : localeFormat;
 };

--- a/src/utils/initLocaleFormat.ts
+++ b/src/utils/initLocaleFormat.ts
@@ -1,0 +1,11 @@
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import localeData from 'dayjs/plugin/localeData';
+import dayjs from 'dayjs';
+import 'dayjs/locale/en-gb';
+import 'dayjs/locale/en';
+
+(function InitLocaleFormat(usLocale: string, euLocale: string) {
+  [localizedFormat, localeData].forEach(dayjs.extend);
+  const browserLanguage = navigator?.language === 'en-GB' ? euLocale : usLocale;
+  dayjs.locale(browserLanguage);
+})('en', 'en-gb');


### PR DESCRIPTION
## Description

This PR adds the ability to the user to change the date format of the date picker based on the list of localized formats in [dayjs](https://day.js.org/docs/en/display/format).
## Screenshot
**Example of a new date format:**
![Screenshot 2020-10-21 at 1 45 40 PM](https://user-images.githubusercontent.com/50381321/96709776-d5a6af80-13a3-11eb-9102-212637df9a9d.png)

**List of localized formats:**
![Screenshot 2020-10-21 at 1 46 04 PM](https://user-images.githubusercontent.com/50381321/96709780-d63f4600-13a3-11eb-9db3-1d8ea2750a0e.png)

resolves #100 
