### PR TITLE
feat: add new blue color and info is set to darkBlue

### DIFF
--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -100,7 +100,7 @@ exports[`Storyshots Design System/Button Button Colors 1`] = `
       }
     >
       <button
-        className="css-ysnfml-Button"
+        className="css-1josrgf-Button"
         data-testid="button"
         disabled={false}
       >

--- a/src/components/Icon/__snapshots__/Icon.stories.storyshot
+++ b/src/components/Icon/__snapshots__/Icon.stories.storyshot
@@ -206,7 +206,7 @@ exports[`Storyshots Design System/Icon Icon with color 1`] = `
           className="css-1gnbc76-Icon"
         >
           <span
-            className="css-qdgub4-Icon"
+            className="css-8vh3ja-Icon"
           />
         </span>
         <p

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -21,7 +21,9 @@ export const flatPaletteConfig: flatPaletteConfigType = {
 
   teal: '#27dcbd',
 
-  blue: '#18aed2',
+  lightBlue: '#18aed2',
+
+  blue: '#1283d3',
 
   darkBlue: '#232d7d',
 
@@ -49,7 +51,7 @@ export const lightPalette: PaletteConfig = {
   success: flatPaletteConfig.green,
   error: flatPaletteConfig.red,
   warning: flatPaletteConfig.orange,
-  info: flatPaletteConfig.blue,
+  info: flatPaletteConfig.darkBlue,
   light: flatPaletteConfig.lightGray,
 
   flat: {
@@ -78,7 +80,7 @@ export const darkPalette: PaletteConfig = {
   success: flatPaletteConfig.green,
   error: flatPaletteConfig.red,
   warning: flatPaletteConfig.orange,
-  info: flatPaletteConfig.blue,
+  info: flatPaletteConfig.darkBlue,
   light: flatPaletteConfig.lightGray,
 
   flat: {
@@ -118,6 +120,8 @@ export type flatPaletteConfigType = {
 
   teal?: string;
 
+  lightBlue?: string;
+
   blue?: string;
 
   darkBlue?: string;
@@ -147,6 +151,8 @@ export type flatPalette = {
   green: generatedColorShades;
 
   teal: generatedColorShades;
+
+  lightBlue: generatedColorShades;
 
   blue: generatedColorShades;
 


### PR DESCRIPTION
BREAKING CHANGE: A new blue was added. Default info color changed to darkBlue

## Description

In this PR:

- A new color was added. There was the need for a new blue color that is in between the existing darkBlue and blue. So now we have darkBlue , blue and lightBlue.
- The default info color was changed from blue to darkBlue. 

The changes will break the UI colors. In order to keep everything the same, wherever blue is used it must be changed to lightBlue and the info color must be set through the ThemeProvider to lightBlue.  

## Screenshot

new palette blues:
![blues](https://user-images.githubusercontent.com/28539607/99260998-cc82f400-2824-11eb-8c0a-1f79fa6867e9.png)


new info color:
![newInfoColor](https://user-images.githubusercontent.com/28539607/99248783-af90f580-2811-11eb-8d08-4dfd43da04d7.png)


## Test Plan

Snapshots updated.
