### PR TITLE
refactor(checkbox): refactor according the new designs and add outlined

### DIFF
--- a/src/components/CheckBox/CheckBox.stories.mdx
+++ b/src/components/CheckBox/CheckBox.stories.mdx
@@ -53,3 +53,17 @@ Regular CheckBox with label
     </Stack>
   </Story>
 </Preview>
+
+<Preview>
+  <Story name="CheckBox with Props" parameters={{ decorators: [withKnobs] }}>
+    <Stack>
+      <CheckBox 
+        checked={boolean('checked', false)} 
+        intermediate={boolean('intermediate', false)} 
+        filled={boolean('filled', true)} 
+        label={text('custom label', '')} 
+        disabled={boolean('disabled', false)} 
+      />
+    </Stack>
+  </Story>
+</Preview>

--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -1,5 +1,5 @@
 import { css, SerializedStyles } from '@emotion/core';
-import { rem, transparentize } from 'polished';
+import { rem } from 'polished';
 import { Theme } from '../../theme';
 import { Props } from './CheckBox';
 
@@ -10,10 +10,10 @@ export const wrapperStyle = ({ disabled }: Props) => (): SerializedStyles => css
   display: flex;
 `;
 
-export const checkboxWrapperStyle = () => (theme: Theme): SerializedStyles => css`
+export const checkboxWrapperStyle = () => (): SerializedStyles => css`
   border-radius: 100%;
-  width: ${rem(50)};
-  height: ${rem(50)};
+  width: ${rem(48)};
+  height: ${rem(48)};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -22,76 +22,88 @@ export const checkboxWrapperStyle = () => (theme: Theme): SerializedStyles => cs
     border-radius: 100%;
     transition: all 0.2s;
     content: ' ';
-    width: ${rem(50)};
-    height: ${rem(50)};
+    width: ${rem(48)};
+    height: ${rem(48)};
     position: absolute;
   }
   &:hover:before {
-    background: ${transparentize(0.7, theme.utils.getColor('lightGray', 400))};
+    background: rgba(0, 0, 0, 0.05);
   }
 `;
 
-export const checkboxStyle = ({ intermediate, checked }: Props) => (
+const getBackgroundColor = ({ intermediate, checked, filled, theme }: Props & { theme: Theme }) => {
+  // if checked and no intermediate
+  if (checked && !intermediate && filled) {
+    return `background: ${theme.utils.getColor('lightGray', 700)}`;
+  }
+
+  return filled
+    ? `background: ${theme.utils.getColor('lightGray', 400)}`
+    : `background: inherit; box-shadow: inset 0px 0px 0px ${rem('2px')} ${theme.utils.getColor(
+        'darkGray',
+        700
+      )};`;
+};
+
+const getSymbolColor = ({ intermediate, filled, theme }: Props & { theme: Theme }) => {
+  if (!filled) {
+    return theme.utils.getColor('darkGray', 700);
+  } else {
+    return intermediate ? theme.utils.getColor('lightGray', 700) : 'white';
+  }
+};
+
+export const checkboxStyle = ({ intermediate, checked, filled }: Props) => (
   theme: Theme
-): SerializedStyles => css`
-  background: ${checked
-    ? intermediate
-      ? theme.utils.getColor('darkGray', 400)
-      : theme.utils.getColor('branded1', 300, 'normal')
-    : theme.utils.getColor('lightGray', 300)};
-  border: 0;
-  border-radius: ${rem(2)};
-  width: ${rem(26)};
-  height: ${rem(26)};
+): SerializedStyles => {
+  const symbolColor = getSymbolColor({ intermediate, checked, filled, theme });
 
-  position: absolute;
-  opacity: 0; // hide it
-
-  & + label {
-    position: relative;
-    cursor: pointer;
-    padding: 0;
-  }
-
-  // Box.
-  & + label:before {
-    content: '';
-    transition: all 0.2s;
-    display: inline-block;
-    vertical-align: text-top;
-    width: ${rem(26)};
-    height: ${rem(26)};
-    background: ${theme.utils.getColor('lightGray', 300)};
+  return css`
+    border: 0;
     border-radius: ${rem(2)};
-  }
+    width: ${rem(24)};
+    height: ${rem(24)};
 
-  // Box checked
-  &:checked + label:before {
-    background: ${intermediate
-      ? theme.utils.getColor('darkGray', 400)
-      : theme.utils.getColor('branded1', 400, 'normal')};
-  }
-
-  // Disabled state label.
-  &:disabled + label {
-    cursor: not-allowed;
-  }
-
-  // Checkmark.
-  &:checked + label:after {
-    content: '';
     position: absolute;
-    left: ${rem(7)};
-    top: ${rem(13)};
-    height: ${rem(2)};
-    ${intermediate
-      ? `width: ${rem(10)};`
-      : `width: ${rem(2)};
-      box-shadow: 2px 0 0 white, 4px 0 0 white, 4px -2px 0 white, 4px -4px 0 white, 4px -6px 0 white, 4px -8px 0 white;
+    opacity: 0; // hide it
+
+    & + label {
+      position: relative;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    // Box.
+    & + label:before {
+      content: '';
+      transition: all 0.2s;
+      display: inline-block;
+      vertical-align: text-top;
+      width: ${rem(24)};
+      height: ${rem(24)};
+      ${getBackgroundColor({ intermediate, checked, filled, theme })};
+      border-radius: ${rem(2)};
+    }
+
+    // Disabled state label.
+    &:disabled + label {
+      cursor: not-allowed;
+    }
+
+    // Checkmark.
+    &:checked + label:after {
+      content: '';
+      position: absolute;
+      left: ${rem(5.5)};
+      ${intermediate
+        ? `width: ${rem(13)}; top: ${rem(10.5)}; height: ${rem(3)};`
+        : `width: ${rem(2)}; top: ${rem(12)}; height: ${rem(2)};;
+      box-shadow: -2px 0 0 ${symbolColor}, 2px 0 0 ${symbolColor}, 4px 0 0 ${symbolColor}, 4px -2px 0 ${symbolColor}, 4px -4px 0 ${symbolColor}, 4px -6px 0 ${symbolColor}, 4px -8px 0 ${symbolColor}, 4px -10px 0 ${symbolColor};
       transform: rotate(45deg);`};
-    background: white;
-  }
-`;
+      background-color: ${symbolColor};
+    }
+  `;
+};
 
 export const labelStyle = () => (theme: Theme): SerializedStyles => css`
   padding-left: ${rem(4)};

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -17,6 +17,11 @@ export type Props = {
   disabled?: boolean;
   /** Boolean defining if the checkbox is in intermediate state when checked ( - instead of ✓ ). Defaults to false */
   intermediate?: boolean;
+  /** Whether the radio input is filled or outlined
+   *
+   * @default true
+   * */
+  filled?: boolean;
   /** The data test id if needed */
   dataTestId?: TestId;
 };
@@ -27,6 +32,7 @@ const CheckBox: React.FC<Props> = ({
   onClick,
   disabled = false,
   intermediate = false,
+  filled = true,
   dataTestId,
 }) => {
   const [isChecked, setIsChecked] = React.useState(checked);
@@ -49,7 +55,7 @@ const CheckBox: React.FC<Props> = ({
       <span css={checkboxWrapperStyle()}>
         <input
           data-testid={generateTestDataId('checkbox', dataTestId)}
-          css={checkboxStyle({ intermediate, checked })}
+          css={checkboxStyle({ intermediate, checked, filled })}
           id={`styled-checkbox-${id}`}
           type="checkbox"
           onChange={handleInputChange}

--- a/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
+++ b/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
@@ -46,11 +46,11 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={false}
-            className="css-tpx4o9-CheckBox"
+            className="css-114ruw8-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -79,11 +79,11 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={true}
-            className="css-1fdnkzr-CheckBox"
+            className="css-1935wu5-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -112,11 +112,11 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         className="css-2w5jy3-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={true}
-            className="css-1fdnkzr-CheckBox"
+            className="css-1935wu5-CheckBox"
             data-testid="checkbox"
             disabled={true}
             id="styled-checkbox-"
@@ -145,11 +145,11 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={true}
-            className="css-97n13b-CheckBox"
+            className="css-1pvzolo-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -178,11 +178,11 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={false}
-            className="css-z4uvgo-CheckBox"
+            className="css-1pvzolo-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -211,11 +211,11 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         className="css-2w5jy3-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={true}
-            className="css-97n13b-CheckBox"
+            className="css-1pvzolo-CheckBox"
             data-testid="checkbox"
             disabled={true}
             id="styled-checkbox-"
@@ -231,6 +231,74 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
         >
           Disabled checked intermediate
         </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Design System/CheckBox CheckBox with Props 1`] = `
+<div
+  style={
+    Object {
+      "margin": 5,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "justifyContent": "flex-end",
+      }
+    }
+  >
+    <button
+      css={
+        Object {
+          "backgroundColor": "transparent",
+          "borderRadius": 4,
+          "color": "#000",
+          "outline": "none",
+        }
+      }
+      onClick={[Function]}
+    >
+      turn 
+      dark
+       on
+    </button>
+  </div>
+  <div
+    className="css-ptimel-Stack"
+  >
+    <div
+      style={
+        Object {
+          "margin": 5,
+        }
+      }
+    >
+      <span
+        className="css-58ep04-CheckBox"
+      >
+        <span
+          className="css-16p0htb-CheckBox"
+        >
+          <input
+            checked={false}
+            className="css-114ruw8-CheckBox"
+            data-testid="checkbox"
+            disabled={false}
+            id="styled-checkbox-"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <label
+            htmlFor="styled-checkbox-"
+          />
+        </span>
+        
       </span>
     </div>
   </div>
@@ -283,11 +351,11 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={true}
-            className="css-1fdnkzr-CheckBox"
+            className="css-1935wu5-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -311,11 +379,11 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={false}
-            className="css-tpx4o9-CheckBox"
+            className="css-114ruw8-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -339,11 +407,11 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={true}
-            className="css-97n13b-CheckBox"
+            className="css-1pvzolo-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -367,11 +435,11 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
         className="css-58ep04-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={false}
-            className="css-z4uvgo-CheckBox"
+            className="css-1pvzolo-CheckBox"
             data-testid="checkbox"
             disabled={false}
             id="styled-checkbox-"
@@ -395,11 +463,11 @@ exports[`Storyshots Design System/CheckBox CheckBox without 1`] = `
         className="css-2w5jy3-CheckBox"
       >
         <span
-          className="css-1h0729d-CheckBox"
+          className="css-16p0htb-CheckBox"
         >
           <input
             checked={false}
-            className="css-z4uvgo-CheckBox"
+            className="css-1pvzolo-CheckBox"
             data-testid="checkbox"
             disabled={true}
             id="styled-checkbox-"

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -46,11 +46,11 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox"
                 disabled={false}
                 id="styled-checkbox-"
@@ -124,11 +124,11 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -188,11 +188,11 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -252,11 +252,11 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -316,11 +316,11 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -413,11 +413,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox"
                 disabled={false}
                 id="styled-checkbox-"
@@ -491,11 +491,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -555,11 +555,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -619,11 +619,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -683,11 +683,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -747,11 +747,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -811,11 +811,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -875,11 +875,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -939,11 +939,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -1003,11 +1003,11 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox-row-check"
                 disabled={false}
                 id="styled-checkbox-"
@@ -1520,11 +1520,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
             className="css-58ep04-CheckBox"
           >
             <span
-              className="css-1h0729d-CheckBox"
+              className="css-16p0htb-CheckBox"
             >
               <input
                 checked={false}
-                className="css-tpx4o9-CheckBox"
+                className="css-114ruw8-CheckBox"
                 data-testid="checkbox"
                 disabled={false}
                 id="styled-checkbox-"
@@ -1584,11 +1584,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -1710,11 +1710,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -1836,11 +1836,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -1962,11 +1962,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2088,11 +2088,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2214,11 +2214,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2340,11 +2340,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2466,11 +2466,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2592,11 +2592,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2718,11 +2718,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2844,11 +2844,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -2970,11 +2970,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3096,11 +3096,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3222,11 +3222,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3348,11 +3348,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3474,11 +3474,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3600,11 +3600,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3726,11 +3726,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3852,11 +3852,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -3978,11 +3978,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4104,11 +4104,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4230,11 +4230,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4356,11 +4356,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4482,11 +4482,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4608,11 +4608,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4734,11 +4734,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4860,11 +4860,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -4986,11 +4986,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5112,11 +5112,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5238,11 +5238,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5364,11 +5364,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5490,11 +5490,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5616,11 +5616,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5742,11 +5742,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5868,11 +5868,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -5994,11 +5994,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6120,11 +6120,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6246,11 +6246,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6372,11 +6372,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6498,11 +6498,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6624,11 +6624,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6750,11 +6750,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -6876,11 +6876,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7002,11 +7002,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7128,11 +7128,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7254,11 +7254,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7380,11 +7380,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7506,11 +7506,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7632,11 +7632,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"
@@ -7758,11 +7758,11 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                       className="css-58ep04-CheckBox"
                     >
                       <span
-                        className="css-1h0729d-CheckBox"
+                        className="css-16p0htb-CheckBox"
                       >
                         <input
                           checked={false}
-                          className="css-tpx4o9-CheckBox"
+                          className="css-114ruw8-CheckBox"
                           data-testid="checkbox-row-check"
                           disabled={false}
                           id="styled-checkbox-"


### PR DESCRIPTION
## Description

Add a new filled property for checkbox and refactor it according to the new designs in here

resolves: #119 

In more details:

* remove uneeded code 
* update hover's shadow color and width/height of checkbox and of parent element
* update shapes and theirs colors according to designs 
* add outline property
* create a new story with props

## Screenshot

Before : 
![image](https://user-images.githubusercontent.com/36039128/101024108-54366580-357c-11eb-95de-7c2e8145e9f7.png)

Now: 
![image](https://user-images.githubusercontent.com/36039128/101025160-d70bf000-357d-11eb-87b7-e21c8fdcf27c.png)
![image](https://user-images.githubusercontent.com/36039128/101025362-22be9980-357e-11eb-8a74-d39ffd5d92b2.png)
![image](https://user-images.githubusercontent.com/36039128/101025650-8c3ea800-357e-11eb-9edd-a567684d2807.png)

## Test Plan

Update the snapshots