### PR TITLE
Feature/swatches utils

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -55,6 +55,7 @@ const ThemeSwitcher = () => {
 
 export const decorators = [
   Story => {
+    console.log('j');
     return (
       <ThemeProvider theme={{ palette: { branded1: '#000' } }}>
         <ThemeSwitcher />

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -55,7 +55,6 @@ const ThemeSwitcher = () => {
 
 export const decorators = [
   Story => {
-    console.log('j');
     return (
       <ThemeProvider theme={{ palette: { branded1: '#000' } }}>
         <ThemeSwitcher />

--- a/guides/COLORS.stories.mdx
+++ b/guides/COLORS.stories.mdx
@@ -1,14 +1,20 @@
 import { Meta, Preview } from '@storybook/addon-docs/blocks';
+import PaletteShowcase from '../src/components/storyUtils/PaletteShowcase';
+import ThemeWrapper from '../src/components/storyUtils/ThemeWrapper';
 
 <Meta title="Guide/Colors" />
 
-# COLORS
+# COLORS<br/><br/>
 
 ### PALETTE
 
+The palette is a collection of colors that has being designed with colors that work harmoniously with each other
+
+### SHADES
+
 All the colors in palette are created with the same principle.
 
-Each color includes seven shades, the base color (color400) and six shades deriving from color400,
+Each color includes seven shades, the base color (shade: 400) and six shades deriving from color 400,
 three darker and three lighter.
 
 All new shades are calculated with color percentages (25%, 50%, 75%) on white background for the lighter shades and black background for the darker ones (75%, 50%, 25%).
@@ -28,3 +34,11 @@ This way we get the following colors for magenta
   700: "#34071d"
 }
 ```
+
+### COLOR PALETTE
+
+The color palette have some text color for each shade either black or white. This text color was picked based on the best accessibility for the end user.
+
+<ThemeWrapper>
+  <PaletteShowcase />
+</ThemeWrapper>

--- a/src/components/storyUtils/PaletteShowcase/PaletteShowcase.style.tsx
+++ b/src/components/storyUtils/PaletteShowcase/PaletteShowcase.style.tsx
@@ -1,0 +1,50 @@
+import { css } from '@emotion/core';
+import { colorShades, flatColors, pickTextColorFromSwatches } from '../../../theme/palette';
+
+export const paletteWrapper = css`
+  display: grid;
+  grid-template-columns: 25% 25% 25% 25%;
+`;
+
+export const paletteColorWrapper = css`
+  width: calc(100% - 20px);
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin: 10px;
+`;
+
+export const colorNameBox = (color: string, colorName: typeof flatColors[number]) => css`
+  height: 100px;
+  background: ${color};
+  width: calc(100% - 20px);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  color: ${pickTextColorFromSwatches(colorName, 400)}; // base shade
+`;
+
+export const colorBoxWrapper = css`
+  flex-direction: column;
+  align-items: center;
+  display: flex;
+  width: 100%;
+`;
+
+export const colorBox = (
+  color: string,
+  colorName: typeof flatColors[number],
+  shade: typeof colorShades[number]
+) => css`
+  height: 50px;
+  width: calc(100% - 20px);
+  background: ${color};
+  color: ${pickTextColorFromSwatches(colorName, shade)};
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+  padding: 0 10px;
+  div:last-child {
+    font-size: 14px;
+  }
+`;

--- a/src/components/storyUtils/PaletteShowcase/PaletteShowcase.tsx
+++ b/src/components/storyUtils/PaletteShowcase/PaletteShowcase.tsx
@@ -1,0 +1,59 @@
+/** @jsx jsx */
+import { jsx, css } from '@emotion/core';
+import useTheme from '../../../hooks/useTheme';
+import { colorShades, flatColors } from '../../../theme/palette';
+import mapValues from 'lodash/mapValues';
+import values from 'lodash/values';
+import toPairs from 'lodash/toPairs';
+import {
+  paletteColorWrapper,
+  paletteWrapper,
+  colorBox,
+  colorBoxWrapper,
+  colorNameBox,
+} from './PaletteShowcase.style';
+
+const PaletteShowcase = () => {
+  const theme = useTheme();
+
+  type Palette = [typeof flatColors[number], string[]];
+  const palette = toPairs(mapValues(theme.palette.flat, values)) as Palette[];
+
+  return (
+    <div css={paletteWrapper}>
+      {palette.map(([colorName, colors]) => (
+        <div key={colorName} css={paletteColorWrapper}>
+          <div css={colorNameBox(colors[3], colorName)}>
+            <div
+              css={css`
+                flex: 1;
+              `}
+            >
+              {colorName}
+            </div>
+            <div
+              css={css`
+                font-size: 14px;
+              `}
+            >
+              Base (400)
+            </div>
+          </div>
+          <div css={colorBoxWrapper}>
+            {colors.map((color, index) => (
+              <div
+                key={color}
+                css={colorBox(color, colorName, ((index + 1) * 100) as typeof colorShades[number])}
+              >
+                <div>{(index + 1) * 100}</div>
+                <div>{color}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PaletteShowcase;

--- a/src/components/storyUtils/PaletteShowcase/index.tsx
+++ b/src/components/storyUtils/PaletteShowcase/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './PaletteShowcase';

--- a/src/components/storyUtils/ThemeWrapper/ThemeWrapper.tsx
+++ b/src/components/storyUtils/ThemeWrapper/ThemeWrapper.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ThemeProvider from '../../ThemeProvider';
+
+const ThemeWrapper: React.FC = ({ children }) => {
+  return <ThemeProvider>{children}</ThemeProvider>;
+};
+
+export default ThemeWrapper;

--- a/src/components/storyUtils/ThemeWrapper/index.tsx
+++ b/src/components/storyUtils/ThemeWrapper/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ThemeWrapper';

--- a/src/theme/palette.config.ts
+++ b/src/theme/palette.config.ts
@@ -1,4 +1,6 @@
-export const flatPaletteConfig: flatPaletteConfigType = {
+import { flatColors } from './palette';
+
+export const flatPaletteConfig: Record<typeof flatColors[number], string> = {
   lightGray: '#cfcfcf',
   darkGray: '#494949',
   coolGray: '#a3a9ac',
@@ -14,6 +16,7 @@ export const flatPaletteConfig: flatPaletteConfigType = {
   blue: '#1283d3',
   darkBlue: '#232d7d',
   purple: '#71458f',
+  mint: '#2AFFC3',
 };
 
 export const lightPaletteConfig: PaletteConfig = {
@@ -74,23 +77,7 @@ export const darkPaletteConfig: PaletteConfig = {
   black: 'black',
 };
 
-export type flatPaletteConfigType = {
-  lightGray?: string;
-  darkGray?: string;
-  coolGray?: string;
-  warmGray?: string;
-  magenta?: string;
-  red?: string;
-  orange?: string;
-  yellow?: string;
-  olive?: string;
-  green?: string;
-  teal?: string;
-  lightBlue?: string;
-  blue?: string;
-  darkBlue?: string;
-  purple?: string;
-};
+export type flatPaletteConfigType = Partial<Record<typeof flatColors[number], string>>;
 
 export type TextPaletteConfigType = {
   primary?: string;

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -18,6 +18,7 @@ export const flatColors = [
   'blue',
   'darkBlue',
   'purple',
+  'mint',
 ] as const;
 /**
  * Here are listed all the color shades
@@ -64,3 +65,76 @@ export type Palette = {
 } & Record<typeof mainTypes[number], generatedColorShades>;
 
 export type formFieldStyles = 'filled' | 'outlined' | 'elevated';
+
+/**
+ * this function picks either white or black color based on the background that is passed
+ * swatches are calculated based on accessibility by the design team and splited to those two colors
+ **/
+export const pickTextColorFromSwatches = (
+  color: typeof flatColors[number],
+  shade: typeof colorShades[number]
+) => {
+  const colorsForWhiteText: Partial<Record<
+    typeof colorShades[number],
+    typeof flatColors[number][]
+  >> = {
+    700: [
+      'lightGray',
+      'darkGray',
+      'coolGray',
+      'warmGray',
+      'magenta',
+      'red',
+      'orange',
+      'yellow',
+      'olive',
+      'green',
+      'teal',
+      'lightBlue',
+      'blue',
+      'darkBlue',
+      'purple',
+      'mint',
+    ],
+    600: [
+      'lightGray',
+      'darkGray',
+      'coolGray',
+      'warmGray',
+      'magenta',
+      'red',
+      'orange',
+      'yellow',
+      'olive',
+      'green',
+      'teal',
+      'lightBlue',
+      'blue',
+      'darkBlue',
+      'purple',
+      'mint',
+    ],
+    500: [
+      'lightGray',
+      'darkGray',
+      'coolGray',
+      'warmGray',
+      'magenta',
+      'red',
+      'orange',
+      'yellow',
+      'olive',
+      'green',
+      'lightBlue',
+      'blue',
+      'darkBlue',
+      'purple',
+    ],
+    400: ['darkGray', 'magenta', 'red', 'olive', 'darkBlue', 'purple'],
+    300: ['darkGray', 'red', 'olive', 'magenta', 'purple', 'darkBlue'],
+  };
+  const pickedShade = colorsForWhiteText[shade];
+  const pickedColor = pickedShade && pickedShade?.find(item => item === color);
+
+  return pickedColor ? '#fff' : '#000';
+};

--- a/src/theme/tests/utils.test.ts
+++ b/src/theme/tests/utils.test.ts
@@ -4,7 +4,7 @@ import { getColor } from '../index';
 import { flatPaletteConfig, lightPaletteConfig } from '../palette.config';
 import { pickTextColorFromSwatches } from '../palette';
 
-describe('GetColor', () => {
+describe('GetColor functionalities', () => {
   test('magenta base color to be shaded correctly', () => {
     expect(colorShadesCreator(flatPaletteConfig.magenta as string, 0.25)).toStrictEqual(
       magentaShades
@@ -20,8 +20,8 @@ describe('GetColor', () => {
   });
 });
 
-describe('pickTextColorFromSwatches', () => {
-  test('pickTextColorFromSwatches works', () => {
+describe('pickTextColorFromSwatches functionalities', () => {
+  test('pickTextColorFromSwatches works with the given colors and to return the correct color', () => {
     const black = '#000';
     const white = '#fff';
 

--- a/src/theme/tests/utils.test.ts
+++ b/src/theme/tests/utils.test.ts
@@ -2,17 +2,33 @@ import { colorShadesCreator, enhancePaletteWithShades } from '../utils';
 import { magentaShades } from './const';
 import { getColor } from '../index';
 import { flatPaletteConfig, lightPaletteConfig } from '../palette.config';
+import { pickTextColorFromSwatches } from '../palette';
 
-test('magenta base color to be shaded correctly', () => {
-  expect(colorShadesCreator(flatPaletteConfig.magenta as string, 0.25)).toStrictEqual(
-    magentaShades
-  );
+describe('GetColor', () => {
+  test('magenta base color to be shaded correctly', () => {
+    expect(colorShadesCreator(flatPaletteConfig.magenta as string, 0.25)).toStrictEqual(
+      magentaShades
+    );
+  });
+
+  test('that the getColor fetch the correct colors from what has being requested', () => {
+    const palette = enhancePaletteWithShades(lightPaletteConfig);
+    const getColorFun = getColor(palette);
+    expect(getColorFun('lightBlue', 400)).toStrictEqual('#18aed2');
+    expect(getColorFun('magenta', 200)).toStrictEqual(magentaShades['200']);
+    expect(getColorFun('primary', 400, 'text')).toStrictEqual('#494949');
+  });
 });
 
-test('that the getColor fetch the correct colors from what has being requested', () => {
-  const palette = enhancePaletteWithShades(lightPaletteConfig);
-  const getColorFun = getColor(palette);
-  expect(getColorFun('lightBlue', 400)).toStrictEqual('#18aed2');
-  expect(getColorFun('magenta', 200)).toStrictEqual(magentaShades['200']);
-  expect(getColorFun('primary', 400, 'text')).toStrictEqual('#494949');
+describe('pickTextColorFromSwatches', () => {
+  test('pickTextColorFromSwatches works', () => {
+    const black = '#000';
+    const white = '#fff';
+
+    expect(pickTextColorFromSwatches('lightBlue', 400)).toBe(black);
+    expect(pickTextColorFromSwatches('darkBlue', 400)).toBe(white);
+    expect(pickTextColorFromSwatches('magenta', 400)).toBe(white);
+    expect(pickTextColorFromSwatches('green', 400)).toBe(black);
+    expect(pickTextColorFromSwatches('green', 700)).toBe(white);
+  });
 });


### PR DESCRIPTION
## Description
This PR introduce a new mechanism to calculate the text color based on the background. This will help us color the text for components based on the passed color from props and  to make sure the accessibility (reading) is always there.

I also update all the palette docs with the shade, color and the new "swatches" mechanism

Also more info can be found to the ticket
closes #129 

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->

Part of the documentation
![image](https://user-images.githubusercontent.com/6433679/101139783-b2198a80-361a-11eb-9901-15cd2158784e.png)


## Test Plan
Test provided for the new util that handles some of the colors to check if it returns the correct font color

<!--
  Have any questions? Check out the contributing doc for more
-->
