### PR TITLE
fix(checkbox): adds a prop to disable autogenerated id for snapshots

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -24,6 +24,8 @@ export type Props = {
   filled?: boolean;
   /** The data test id if needed */
   dataTestIdSuffix?: TestId;
+  /** Disables auto generated id for snapshots*/
+  mockId?: string;
 };
 
 const CheckBox: React.FC<Props> = ({
@@ -34,6 +36,7 @@ const CheckBox: React.FC<Props> = ({
   intermediate = false,
   dataTestIdSuffix,
   filled = true,
+  mockId,
 }) => {
   const [isChecked, setIsChecked] = React.useState(checked);
 
@@ -41,7 +44,7 @@ const CheckBox: React.FC<Props> = ({
     setIsChecked(checked);
   }, [checked]);
 
-  const id = generateUniqueID();
+  const id = mockId || generateUniqueID();
 
   const handleInputChange = (event: ChangeEvent) => {
     const newChecked = !isChecked;

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -25,7 +25,7 @@ export type Props = {
   /** The data test id if needed */
   dataTestIdSuffix?: TestId;
   /** Disables auto generated id for snapshots*/
-  mockId?: string;
+  id?: string;
 };
 
 const CheckBox: React.FC<Props> = ({
@@ -36,15 +36,13 @@ const CheckBox: React.FC<Props> = ({
   intermediate = false,
   dataTestIdSuffix,
   filled = true,
-  mockId,
+  id = generateUniqueID(),
 }) => {
   const [isChecked, setIsChecked] = React.useState(checked);
 
   useEffect(() => {
     setIsChecked(checked);
   }, [checked]);
-
-  const id = mockId || generateUniqueID();
 
   const handleInputChange = (event: ChangeEvent) => {
     const newChecked = !isChecked;

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
+<div
+  style={
+    Object {
+      "margin": 5,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "justifyContent": "flex-end",
+      }
+    }
+  >
+    <button
+      css={
+        Object {
+          "backgroundColor": "transparent",
+          "borderRadius": 4,
+          "color": "#000",
+          "outline": "none",
+        }
+      }
+      onClick={[Function]}
+    >
+      turn 
+      dark
+       on
+    </button>
+  </div>
+  <div
+    className="css-ptimel-Stack"
+  >
+    <div
+      style={
+        Object {
+          "margin": 5,
+        }
+      }
+    >
+      <div>
+        <div
+          className="css-12qr1pz-TextField"
+        >
+          <div
+            className="css-yzthsf-TextField"
+          >
+            <div
+              className="css-11hzh72-TextField"
+            >
+              <div
+                className="css-8lp52w-IconWrapper"
+              >
+                <span
+                  className="css-1gnbc76-Icon"
+                >
+                  <span
+                    className="css-1k5aruc-Icon"
+                  />
+                </span>
+              </div>
+              <input
+                className="css-jo6z7m-TextField"
+                placeholder="label"
+                required={false}
+              />
+              <label
+                className="css-1qcp0f-Label"
+              >
+                label
+                 
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
 <div
   style={


### PR DESCRIPTION
## Description

When the checkbox component is imported in another project the snapshots of the component that uses the checkbox will fail due to autogenerated id. 

I passed a new prop to give us the ability to pass a static id in our snapshot tests to avoid this issue in future usages.


## Screenshot

![Screenshot 2020-12-17 at 9 33 32 PM](https://user-images.githubusercontent.com/50381321/102534510-87661200-40af-11eb-89ea-5c337a71d784.png)

