### PR TITLE
feat(pagination): adds two new props for disabling prev and next buttons

### DIFF
--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -25,8 +25,8 @@ import { Pagination } from '@orfium/ictinus';
 Simple pagination with all buttons
 
 <Preview>
-  <Story name="Pagination">
-    <Pagination count={3} page={1} />
+  <Story name="Pagination" parameters={{ decorators: [withKnobs] }}>
+    <Pagination count={3} page={1} nextPageDisabled={boolean('nextPageDisabled', false)} prevPageDisabled={boolean('prevPageDisabled', false)}/>
   </Story>
 </Preview>
 
@@ -35,7 +35,7 @@ Simple pagination with all buttons
 Simple pagination without jumping on first or last page
 
 <Preview>
-  <Story name="Pagination without all buttons">
-    <Pagination count={3} page={1} hideEnhancedPaginationButtons />
+  <Story name="Pagination without all buttons" parameters={{ decorators: [withKnobs] }}>
+    <Pagination count={3} page={1} hideEnhancedPaginationButtons nextPageDisabled={boolean('nextPageDisabled', false)} prevPageDisabled={boolean('prevPageDisabled', false)}/>
   </Story>
 </Preview>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -14,6 +14,10 @@ type Props = {
   onChange?: (page: number) => void;
   /** Hide the enhanced button functionality, this way the jump to first and last page will be hidden **/
   hideEnhancedPaginationButtons?: boolean;
+  /** Manually disable next page buttons **/
+  nextPageDisabled?: boolean;
+  /** Manually disable previous page buttons **/
+  prevPageDisabled?: boolean;
 };
 
 const Pagination = ({
@@ -21,6 +25,8 @@ const Pagination = ({
   count,
   onChange = () => {},
   hideEnhancedPaginationButtons = false,
+  nextPageDisabled,
+  prevPageDisabled,
 }: Props) => {
   const theme = useTheme();
   const {
@@ -47,7 +53,7 @@ const Pagination = ({
           name={'arrowToLeft'}
           onClick={navigateToFirstPage}
           iconSize={24}
-          disabled={!hasPrevPage}
+          disabled={prevPageDisabled || !hasPrevPage}
           type={'dark'}
         />
       )}
@@ -55,7 +61,7 @@ const Pagination = ({
         name={'arrowLeft'}
         iconSize={24}
         onClick={navigateToPrevPage}
-        disabled={!hasPrevPage}
+        disabled={prevPageDisabled || !hasPrevPage}
         type={'dark'}
       />
 
@@ -67,7 +73,7 @@ const Pagination = ({
         name={'arrowRight'}
         iconSize={24}
         onClick={navigateToNextPage}
-        disabled={!hasNextPage}
+        disabled={nextPageDisabled || !hasNextPage}
         type={'dark'}
       />
       {!hideEnhancedPaginationButtons && (
@@ -75,7 +81,7 @@ const Pagination = ({
           name={'arrowToRight'}
           iconSize={24}
           onClick={navigateToLastPage}
-          disabled={!hasNextPage}
+          disabled={nextPageDisabled || !hasNextPage}
           type={'dark'}
         />
       )}


### PR DESCRIPTION
## Description

Using pagination with react query requires handling the next/prev buttons.
We should be able to navigate to the next page only when the fetched data are ready. 
That said, we need 2 additional properties to be able to disable the pagination buttons manually.

**Note:**  _this is for v1 as it does not affect the current functionality of the component_.

## Screenshot

<img width="406" alt="Screenshot 2021-01-13 at 1 22 47 PM" src="https://user-images.githubusercontent.com/50381321/104445975-77ecc280-55a2-11eb-9f38-a78425f2d9b6.png">
