### PR TITLE
fix(textfield): fixes size prop causing a typescript error

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -58,7 +58,9 @@ export type Props = {
   onInput?: React.EventHandler<any>;
 };
 
-const TextField = React.forwardRef<HTMLInputElement, Props & InputHTMLAttributes<HTMLInputElement>>(
+type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
+
+const TextField = React.forwardRef<HTMLInputElement, Props & InputProps>(
   (
     {
       id = undefined,


### PR DESCRIPTION
Conflicting 'size' props from TextField and HTMLInputProps caused a type error to be thrown when the prop was used. This fixes that.