### PR TITLE
fix(packages): after upgrade fix automatic runtime for pragma

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { last, pick } from 'lodash';

--- a/src/components/Breadcrumb/BreadcrumbCollapsed/BreadcrumbCollapsed.tsx
+++ b/src/components/Breadcrumb/BreadcrumbCollapsed/BreadcrumbCollapsed.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import uniqueId from 'lodash/uniqueId';

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbAdvancedItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbAdvancedItem.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Breadcrumb/Separator/Separator.tsx
+++ b/src/components/Breadcrumb/Separator/Separator.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { Elevation } from 'index';

--- a/src/components/Chart/BarChart/components/CustomTooltip/CustomTooltip.tsx
+++ b/src/components/Chart/BarChart/components/CustomTooltip/CustomTooltip.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Chart/DonutChart/components/CustomLabel/CustomLabel.tsx
+++ b/src/components/Chart/DonutChart/components/CustomLabel/CustomLabel.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Chart/LineChart/components/CustomTooltip/CustomTooltip.tsx
+++ b/src/components/Chart/LineChart/components/CustomTooltip/CustomTooltip.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import dayjs, { Dayjs } from 'dayjs';

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useCallback, useEffect, useState } from 'react';

--- a/src/components/DatePicker/Day/Day.tsx
+++ b/src/components/DatePicker/Day/Day.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/DatePicker/Month/Month.tsx
+++ b/src/components/DatePicker/Month/Month.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/DatePicker/OverlayComponent/OverlayComponent.tsx
+++ b/src/components/DatePicker/OverlayComponent/OverlayComponent.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/DatePicker/OverlayComponent/__snapshots__/OverlayComponent.test.tsx.snap
+++ b/src/components/DatePicker/OverlayComponent/__snapshots__/OverlayComponent.test.tsx.snap
@@ -127,10 +127,10 @@ exports[`OverlayComponent should render correctly 1`] = `
                   style="padding: 0px;"
                 >
                   <div
-                    class="css-1xl9qi0-Day"
+                    class="css-1y60bx4-Day"
                   >
                     <div
-                      class="css-14ql548-Day"
+                      class="css-1itpjzt-Day"
                     >
                       1
                     </div>
@@ -140,10 +140,10 @@ exports[`OverlayComponent should render correctly 1`] = `
                   style="padding: 0px;"
                 >
                   <div
-                    class="css-1y60bx4-Day"
+                    class="css-1xl9qi0-Day"
                   >
                     <div
-                      class="css-1itpjzt-Day"
+                      class="css-14ql548-Day"
                     >
                       2
                     </div>
@@ -682,10 +682,10 @@ exports[`OverlayComponent should render datepicker correctly 1`] = `
                   style="padding: 0px;"
                 >
                   <div
-                    class="css-1xl9qi0-Day"
+                    class="css-1y60bx4-Day"
                   >
                     <div
-                      class="css-14ql548-Day"
+                      class="css-1itpjzt-Day"
                     >
                       1
                     </div>
@@ -695,10 +695,10 @@ exports[`OverlayComponent should render datepicker correctly 1`] = `
                   style="padding: 0px;"
                 >
                   <div
-                    class="css-1y60bx4-Day"
+                    class="css-1xl9qi0-Day"
                   >
                     <div
-                      class="css-1itpjzt-Day"
+                      class="css-14ql548-Day"
                     >
                       2
                     </div>

--- a/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.tsx
+++ b/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useMemo, useState } from 'react';

--- a/src/components/DatePicker/OverlayComponent/components/MonthWrapper/__snapshots__/MonthWrapper.test.tsx.snap
+++ b/src/components/DatePicker/OverlayComponent/components/MonthWrapper/__snapshots__/MonthWrapper.test.tsx.snap
@@ -118,12 +118,25 @@ exports[`MonthWrapper should render correctly 1`] = `
             style="padding: 0px;"
           >
             <div
+              class="css-1y60bx4-Day"
+            >
+              <div
+                class="css-1itpjzt-Day"
+              >
+                1
+              </div>
+            </div>
+          </td>
+          <td
+            style="padding: 0px;"
+          >
+            <div
               class="css-1xl9qi0-Day"
             >
               <div
                 class="css-14ql548-Day"
               >
-                1
+                2
               </div>
             </div>
           </td>
@@ -135,19 +148,6 @@ exports[`MonthWrapper should render correctly 1`] = `
             >
               <div
                 class="css-qu8iha-Day"
-              >
-                2
-              </div>
-            </div>
-          </td>
-          <td
-            style="padding: 0px;"
-          >
-            <div
-              class="css-1jhrlq7-Day"
-            >
-              <div
-                class="css-1itpjzt-Day"
               >
                 3
               </div>

--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -163,10 +163,10 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
                       }
                     >
                       <div
-                        className="css-1xl9qi0-Day"
+                        className="css-1y60bx4-Day"
                       >
                         <div
-                          className="css-14ql548-Day"
+                          className="css-1itpjzt-Day"
                         >
                           1
                         </div>
@@ -181,10 +181,10 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
                       }
                     >
                       <div
-                        className="css-1y60bx4-Day"
+                        className="css-1xl9qi0-Day"
                       >
                         <div
-                          className="css-1itpjzt-Day"
+                          className="css-14ql548-Day"
                         >
                           2
                         </div>
@@ -1494,10 +1494,10 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
                       }
                     >
                       <div
-                        className="css-1xl9qi0-Day"
+                        className="css-1y60bx4-Day"
                       >
                         <div
-                          className="css-14ql548-Day"
+                          className="css-1itpjzt-Day"
                         >
                           1
                         </div>
@@ -1512,10 +1512,10 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
                       }
                     >
                       <div
-                        className="css-1y60bx4-Day"
+                        className="css-1xl9qi0-Day"
                       >
                         <div
-                          className="css-1itpjzt-Day"
+                          className="css-14ql548-Day"
                         >
                           2
                         </div>
@@ -2863,10 +2863,10 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
                       }
                     >
                       <div
-                        className="css-1xl9qi0-Day"
+                        className="css-1y60bx4-Day"
                       >
                         <div
-                          className="css-14ql548-Day"
+                          className="css-1itpjzt-Day"
                         >
                           1
                         </div>
@@ -2881,10 +2881,10 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
                       }
                     >
                       <div
-                        className="css-1y60bx4-Day"
+                        className="css-1xl9qi0-Day"
                       >
                         <div
-                          className="css-1itpjzt-Day"
+                          className="css-14ql548-Day"
                         >
                           2
                         </div>
@@ -3551,7 +3551,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
                       onKeyDown={[Function]}
                       placeholder="MM/DD/YYYY - MM/DD/YYYY "
                       required={false}
-                      value="03/01/2021 - 03/01/2021"
+                      value="03/02/2021 - 03/02/2021"
                     />
                   </div>
                   <div
@@ -3609,7 +3609,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
                       onKeyDown={[Function]}
                       placeholder="MM/DD/YYYY - MM/DD/YYYY "
                       required={false}
-                      value="03/01/2021 - 03/01/2021"
+                      value="03/02/2021 - 03/02/2021"
                     />
                   </div>
                   <div
@@ -3716,7 +3716,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                           onKeyDown={[Function]}
                           placeholder="MM/DD/YYYY "
                           required={false}
-                          value="03/01/2021"
+                          value="03/02/2021"
                         />
                       </div>
                       <div
@@ -3774,7 +3774,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                           onKeyDown={[Function]}
                           placeholder="MM/DD/YYYY "
                           required={false}
-                          value="03/01/2021"
+                          value="03/02/2021"
                         />
                       </div>
                       <div
@@ -3832,7 +3832,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                           onKeyDown={[Function]}
                           placeholder="MM/DD/YYYY "
                           required={false}
-                          value="03/01/2021"
+                          value="03/02/2021"
                         />
                       </div>
                       <div
@@ -3903,7 +3903,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                           placeholder="MM/DD/YYYY "
                           required={false}
                           status="error"
-                          value="03/01/2021"
+                          value="03/02/2021"
                         />
                       </div>
                       <div
@@ -3975,7 +3975,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                           placeholder="MM/DD/YYYY "
                           required={false}
                           status="hint"
-                          value="03/01/2021"
+                          value="03/02/2021"
                         />
                       </div>
                       <div
@@ -4087,7 +4087,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
                       onKeyDown={[Function]}
                       placeholder="MM/DD/YYYY "
                       required={false}
-                      value="03/01/2021"
+                      value="03/02/2021"
                     />
                   </div>
                   <div
@@ -4145,7 +4145,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
                       onKeyDown={[Function]}
                       placeholder="MM/DD/YYYY "
                       required={false}
-                      value="03/01/2021"
+                      value="03/02/2021"
                     />
                   </div>
                   <div
@@ -4232,7 +4232,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
                   onKeyDown={[Function]}
                   placeholder="MM/DD/YYYY "
                   required={false}
-                  value="03/01/2021"
+                  value="03/02/2021"
                 />
               </div>
               <div
@@ -4402,7 +4402,7 @@ exports[`Storyshots Design System/DatePicker Dynamic disableDates with all optio
                   onKeyDown={[Function]}
                   placeholder="MM/DD/YYYY "
                   required={false}
-                  value="03/01/2021"
+                  value="03/02/2021"
                 />
               </div>
               <div

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
+++ b/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { MenuItem as MenuItemProps } from 'components/Drawer/types';

--- a/src/components/Drawer/Navigation/Navigation.tsx
+++ b/src/components/Drawer/Navigation/Navigation.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useCallback, useState } from 'react';

--- a/src/components/ExpandCollapse/ExpandCollapse.tsx
+++ b/src/components/ExpandCollapse/ExpandCollapse.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { ReactComponentLike } from 'prop-types';

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Modal/ModalContent/ModalContent.tsx
+++ b/src/components/Modal/ModalContent/ModalContent.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Notification/Banner/Banner.tsx
+++ b/src/components/Notification/Banner/Banner.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Notification/InlineNotification/InlineNotification.tsx
+++ b/src/components/Notification/InlineNotification/InlineNotification.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Notification/NotificationVisual/NotificationVisual.tsx
+++ b/src/components/Notification/NotificationVisual/NotificationVisual.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Notification/NotificationsContainer/NotificationsContainer.tsx
+++ b/src/components/Notification/NotificationsContainer/NotificationsContainer.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import Icon from 'components/Icon';

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 // @ts-nocheck
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import usePagination from '../../hooks/usePagination';

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { InputHTMLAttributes, useEffect, useMemo, KeyboardEvent } from 'react';
 import useTheme from '../../hooks/useTheme';

--- a/src/components/Select/components/SelectMenu/SelectMenu.tsx
+++ b/src/components/Select/components/SelectMenu/SelectMenu.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { menuStyle, optionStyle } from './SelectMenu.style';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import head from 'lodash/head';

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import rem from 'polished/lib/helpers/rem';

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ExpandedButtonCell/ExpandedButtonCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ExpandedButtonCell/ExpandedButtonCell.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Table/components/TableRow/TableRow.tsx
+++ b/src/components/Table/components/TableRow/TableRow.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
+++ b/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { FC, InputHTMLAttributes } from 'react';

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import * as React from 'react';

--- a/src/components/TopAppBar/TopAppBar.tsx
+++ b/src/components/TopAppBar/TopAppBar.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { FC } from 'react';

--- a/src/components/TopAppBar/components/Logo.wrapper.tsx
+++ b/src/components/TopAppBar/components/Logo.wrapper.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import Styles from './Logo.style';

--- a/src/components/TopAppBar/components/SidebarMenuIcon.tsx
+++ b/src/components/TopAppBar/components/SidebarMenuIcon.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import Icon from '../../Icon';

--- a/src/components/storyUtils/CardShowcase/CardShowcase.tsx
+++ b/src/components/storyUtils/CardShowcase/CardShowcase.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/storyUtils/ChipShowcase/ChipShowcase.tsx
+++ b/src/components/storyUtils/ChipShowcase/ChipShowcase.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/storyUtils/DrawerShowcase/DrawerShowcase.tsx
+++ b/src/components/storyUtils/DrawerShowcase/DrawerShowcase.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useState, Fragment } from 'react';

--- a/src/components/storyUtils/ModalShowcase/ModalShowcase.tsx
+++ b/src/components/storyUtils/ModalShowcase/ModalShowcase.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useState } from 'react';

--- a/src/components/storyUtils/NotificationShowcase/NotificationShowcase.tsx
+++ b/src/components/storyUtils/NotificationShowcase/NotificationShowcase.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useState } from 'react';

--- a/src/components/storyUtils/PaletteShowcase/PaletteShowcase.tsx
+++ b/src/components/storyUtils/PaletteShowcase/PaletteShowcase.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import useTheme from '../../../hooks/useTheme';

--- a/src/components/storyUtils/Stack/Stack.tsx
+++ b/src/components/storyUtils/Stack/Stack.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/utils/PositionInScreen/PositionInScreen.tsx
+++ b/src/components/utils/PositionInScreen/PositionInScreen.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useEffect, useRef, useState } from 'react';

--- a/src/components/utils/TextInputWrapper/TextInputWrapper.tsx
+++ b/src/components/utils/TextInputWrapper/TextInputWrapper.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { FC } from 'react';


### PR DESCRIPTION
## Description

This PR fix the automatic runtime error for pragma 
`Syntax error: pragma and pragmaFrag cannot be set when runtime is automatic.`

I only saw that on latest react version of 16.14.0 and 17. I am not sure why out of a sudden our project start complain about this. Nevertheless i tried removing all the jsx pragma from all the files but there is the problem with the css in the tests that are rendering just a function and not the css prop. The simplest solution is to pass to the files that had the jsx pragma the runtime pragma.

I will revisit for the fix later on an upgrade of the libs for a once and for all solution.

EDITED: i found that this is coming from the latest babel release on 7v