### PR TITLE
fix(barchart): add Billion case in tickformatter

### DIFF
--- a/src/components/Chart/BarChart/utils.ts
+++ b/src/components/Chart/BarChart/utils.ts
@@ -22,6 +22,9 @@ export const getValues = (max: number | undefined): Values => {
 export const customTickFormatter = (tickValue: number, maxDomainValue: number): string => {
   if (tickValue === 0) {
     return `${tickValue}`;
+  } else if (maxDomainValue > 1000000000 || tickValue === 1000000000) {
+    /* when tickValue === maxDomainValue === 1000000000  return 1B instead of 10000M*/
+    return `${tickValue / 1000000000}B`;
   } else if (maxDomainValue > 1000000 || tickValue === 1000000) {
     /* when tickValue === maxDomainValue === 1000000  return 1M instead of 10000K*/
     return `${tickValue / 1000000}M`;


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->
Format tick number correctly when number is greater than billion

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->
<img width="536" alt="billions" src="https://user-images.githubusercontent.com/24905735/109622882-45445c80-7b45-11eb-8a98-43d718ce5ed5.png">


## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
