### PR TITLE
[DS-93][DS-95][DS-97] Feat/button transparent

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -61,6 +61,7 @@ Button types based on the system approved literals for `success, error, info, wa
         <Button size={'sm'} type='error'>Hello world</Button>
         <Button size={'sm'} type='info'>Hello world</Button>
         <Button size={'sm'} type='warning'>Hello world</Button>
+        <Button size={'sm'} transparent>Hello world</Button>
     </Stack>
   </Story>
 </Preview>
@@ -99,7 +100,14 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 # Non Filled Button
 <Preview>
   <Story name="Non Filled Button">
-    <Button filled={false} size={'lg'}>Hello world</Button>;
+    <Button filled={false} size={'lg'}>Hello world</Button>
+  </Story>
+</Preview>
+
+# Transparent Button
+<Preview>
+  <Story name="Transparent Button">
+    <Button type='success' size={'lg'} transparent>Hello world</Button>
   </Story>
 </Preview>
 

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -37,6 +37,7 @@ export const buttonStyle = ({
   size,
   iconExists,
   disabled,
+  transparent,
   childrenCount,
 }: RequiredProperties<
   Props & {
@@ -47,12 +48,14 @@ export const buttonStyle = ({
 >) => (theme: Theme) => {
   return {
     fontSize: fontSizeBasedOnSize(theme, size),
-    color: filled
-      ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
-      : defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0),
-    backgroundColor: filled
-      ? defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0)
-      : 'transparent',
+    color:
+      filled && !transparent
+        ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
+        : defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0),
+    backgroundColor:
+      filled && !transparent
+        ? defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0)
+        : 'transparent',
     padding:
       size === 'sm' || size === 'md'
         ? `${theme.spacing.sm} ${theme.spacing.md}`
@@ -60,25 +63,26 @@ export const buttonStyle = ({
     height: heightBasedOnSize(size),
     opacity: disabled ? 0.5 : 1,
     borderRadius: theme.spacing.xsm,
-    border: filled
-      ? 'none'
-      : `solid 1px ${defineBackgroundColor(
-          theme,
-          calculatedColor,
-          type,
-          iconExists,
-          childrenCount > 0
-        )}`,
+    border:
+      filled || transparent
+        ? 'none'
+        : `solid 1px ${defineBackgroundColor(
+            theme,
+            calculatedColor,
+            type,
+            iconExists,
+            childrenCount > 0
+          )}`,
     cursor: 'pointer',
     transition: 'background-color 150ms linear',
     ':hover': {
       backgroundColor: !disabled
-        ? stateBackgroundColor(theme, 'hover', calculatedColor, filled)
+        ? stateBackgroundColor(theme, 'hover', calculatedColor, filled && !transparent)
         : undefined,
     },
     ':active': {
       backgroundColor: !disabled
-        ? stateBackgroundColor(theme, 'active', calculatedColor, filled)
+        ? stateBackgroundColor(theme, 'active', calculatedColor, filled && !transparent)
         : undefined,
     },
   };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,6 +18,8 @@ export type Props = {
   size?: 'lg' | 'md' | 'sm';
   /** Property indicating if the component is filled with a color based on the type */
   filled?: boolean;
+  /** Property indicating if the component is transparent with a color based on the type */
+  transparent?: boolean;
   /** An optional icon to put on the right of the button */
   iconRight?: React.Component | JSX.Element | null;
   /** An optional icon to put on the left of the button */
@@ -36,6 +38,7 @@ const Button: React.FC<Props & TestProps & EventProps> = props => {
     type = 'primary',
     color = '',
     filled = true,
+    transparent = false,
     iconLeft = null,
     iconRight = null,
     disabled = false,
@@ -56,6 +59,7 @@ const Button: React.FC<Props & TestProps & EventProps> = props => {
         filled,
         size,
         color,
+        transparent,
         calculatedColor,
         iconExists: Boolean(iconLeft || iconRight),
         disabled,
@@ -75,6 +79,7 @@ const Button: React.FC<Props & TestProps & EventProps> = props => {
             filled,
             size,
             color,
+            transparent,
             iconLeft,
             iconRight,
             disabled,

--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -366,6 +366,29 @@ exports[`Storyshots Design System/Button Button Types 1`] = `
         </span>
       </button>
     </div>
+    <div
+      style={
+        Object {
+          "margin": 5,
+        }
+      }
+    >
+      <button
+        className="css-fqcnmv-Button"
+        data-testid="button"
+        disabled={false}
+      >
+        <span
+          className="css-1xr6sam-Button"
+        >
+          <span
+            className="css-l730ys-Button"
+          >
+            Hello world
+          </span>
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 `;
@@ -783,6 +806,56 @@ exports[`Storyshots Design System/Button Regular Button 1`] = `
   </div>
   <button
     className="css-gajiax-Button"
+    data-testid="button"
+    disabled={false}
+  >
+    <span
+      className="css-1xr6sam-Button"
+    >
+      <span
+        className="css-l730ys-Button"
+      >
+        Hello world
+      </span>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Storyshots Design System/Button Transparent Button 1`] = `
+<div
+  style={
+    Object {
+      "margin": 5,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "justifyContent": "flex-end",
+      }
+    }
+  >
+    <button
+      css={
+        Object {
+          "backgroundColor": "transparent",
+          "borderRadius": 4,
+          "color": "#000",
+          "outline": "none",
+        }
+      }
+      onClick={[Function]}
+    >
+      turn 
+      dark
+       on
+    </button>
+  </div>
+  <button
+    className="css-12d5shl-Button"
     data-testid="button"
     disabled={false}
   >

--- a/src/components/Chart/BarChart/components/CustomTooltipContent/CustomTooltipContent.tsx
+++ b/src/components/Chart/BarChart/components/CustomTooltipContent/CustomTooltipContent.tsx
@@ -1,3 +1,4 @@
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';

--- a/src/components/IconButton/IconButton.stories.mdx
+++ b/src/components/IconButton/IconButton.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
-import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs/blocks';
+import { boolean, select } from '@storybook/addon-knobs';
 import IconButton from './IconButton';
 import Stack from '../storyUtils/Stack';
 import iconSelector from '../Icon/assets/iconSelector';
-import { mainTypes, flatColors, colorShades } from "../../theme/palette";
+import { colorShades, flatColors, mainTypes } from '../../theme/palette';
 
 <Meta title="Design System/IconButton" component={IconButton} />
 
@@ -53,16 +53,26 @@ IconButton with different acceptable sizes
 
 # IconButton Playground
 
-
 <Preview>
   <Story name="IconButton Playground">
     <Stack>
       <IconButton
-        type={select("type", mainTypes, "primary")}
-        size={select("size", ['sm', 'md','lg'], 'md')}
-        filled={boolean("filled", false)}
-        name={select("name", Object.keys(iconSelector).sort((a, b) => a.localeCompare(b)).map((iconName) => iconName), "check")}
-        color={select("color", flatColors.map((color) => colorShades.map((shade) => `${color}-${shade}`)).flat(), "")}
+        type={select('type', mainTypes, 'primary')}
+        size={select('size', ['sm', 'md', 'lg'], 'md')}
+        filled={boolean('filled', false)}
+        transparent={boolean('transparent', false)}
+        name={select(
+          'name',
+          Object.keys(iconSelector)
+            .sort((a, b) => a.localeCompare(b))
+            .map(iconName => iconName),
+          'check'
+        )}
+        color={select(
+          'color',
+          flatColors.map(color => colorShades.map(shade => `${color}-${shade}`)).flat(),
+          ''
+        )}
       />
     </Stack>
   </Story>

--- a/src/components/IconButton/IconButton.style.ts
+++ b/src/components/IconButton/IconButton.style.ts
@@ -7,6 +7,7 @@ import { Theme } from '../../theme';
 export const iconButtonStyle = ({
   type,
   filled,
+  transparent,
   calculatedColor,
   size,
   iconExists,
@@ -28,6 +29,7 @@ export const iconButtonStyle = ({
     color,
     calculatedColor,
     iconExists,
+    transparent,
     disabled,
     iconLeft,
     iconRight,

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -25,6 +25,8 @@ export type Props = {
   size?: 'lg' | 'md' | 'sm';
   /** Property indicating if the component is filled with a color based on the type */
   filled?: boolean;
+  /** Property indicating if the component is transparent with a color based on the type */
+  transparent?: boolean;
   /** This property defines witch icon to use */
   name: AcceptedIconNames;
   /** Define if the button is in disabled state */
@@ -46,6 +48,7 @@ const IconButton: React.FC<Props & TestProps & EventProps> = ({
   onClick,
   onBlur,
   disabled = false,
+  transparent = false,
 }) => {
   const theme = useTheme();
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
@@ -62,6 +65,7 @@ const IconButton: React.FC<Props & TestProps & EventProps> = ({
         filled,
         size,
         color,
+        transparent,
         calculatedColor,
         iconExists: true,
         disabled,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -34,6 +34,7 @@ const Modal: React.FC<Props> = ({ open = false, onClose, dataTestId, children, c
                 <IconButton
                   name={'close'}
                   filled={false}
+                  transparent
                   size={'sm'}
                   onClick={onClose}
                   dataTestId={'modal-close'}

--- a/src/components/Modal/ModalContent/ModalContent.style.ts
+++ b/src/components/Modal/ModalContent/ModalContent.style.ts
@@ -21,7 +21,7 @@ export const labelContainer = (theme: Theme): SerializedStyles => css`
 
 export const headingContainer = (theme: Theme): SerializedStyles => css`
   font-size: ${theme.typography.fontSizes['28']};
-  color: ${theme.utils.getColor('lightGray', 500, 'flat')};
+  color: ${theme.utils.getColor('lightGray', 600, 'flat')};
   font-weight: ${theme.typography.weights.light};
   margin: 0 0 ${theme.spacing.md} 0;
 `;

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -56,6 +56,8 @@ const Pagination = ({
           name={'arrowToLeft'}
           onClick={navigateToFirstPage}
           iconSize={24}
+          transparent
+          filled={false}
           disabled={prevPageDisabled || !hasPrevPage}
         />
       )}
@@ -63,6 +65,8 @@ const Pagination = ({
         iconColor={'darkGray'}
         name={'arrowLeft'}
         iconSize={24}
+        transparent
+        filled={false}
         onClick={navigateToPrevPage}
         disabled={prevPageDisabled || !hasPrevPage}
       />
@@ -75,6 +79,8 @@ const Pagination = ({
         iconColor={'darkGray'}
         name={'arrowRight'}
         iconSize={24}
+        transparent
+        filled={false}
         onClick={navigateToNextPage}
         disabled={nextPageDisabled || !hasNextPage}
       />
@@ -83,6 +89,8 @@ const Pagination = ({
           iconColor={'darkGray'}
           name={'arrowToRight'}
           iconSize={24}
+          transparent
+          filled={false}
           onClick={navigateToLastPage}
           disabled={nextPageDisabled || !hasNextPage}
         />

--- a/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
+++ b/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
@@ -36,7 +36,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
     className="css-jdkik2-Pagination"
   >
     <button
-      className="css-1ce3lpe-IconButton"
+      className="css-1cbac61-IconButton"
       color=""
       data-testid="icon-button"
       disabled={true}
@@ -47,12 +47,12 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
         onClick={[Function]}
       >
         <span
-          className="css-tz7hxk-Icon"
+          className="css-4szf62-Icon"
         />
       </span>
     </button>
     <button
-      className="css-1ce3lpe-IconButton"
+      className="css-1cbac61-IconButton"
       color=""
       data-testid="icon-button"
       disabled={true}
@@ -63,7 +63,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
         onClick={[Function]}
       >
         <span
-          className="css-tz7hxk-Icon"
+          className="css-4szf62-Icon"
         />
       </span>
     </button>
@@ -74,7 +74,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
       3
     </div>
     <button
-      className="css-1e2pjpj-IconButton"
+      className="css-1ek82po-IconButton"
       color=""
       data-testid="icon-button"
       disabled={false}
@@ -85,12 +85,12 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
         onClick={[Function]}
       >
         <span
-          className="css-tz7hxk-Icon"
+          className="css-4szf62-Icon"
         />
       </span>
     </button>
     <button
-      className="css-1e2pjpj-IconButton"
+      className="css-1ek82po-IconButton"
       color=""
       data-testid="icon-button"
       disabled={false}
@@ -101,7 +101,7 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
         onClick={[Function]}
       >
         <span
-          className="css-tz7hxk-Icon"
+          className="css-4szf62-Icon"
         />
       </span>
     </button>
@@ -145,7 +145,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
     className="css-jdkik2-Pagination"
   >
     <button
-      className="css-1ce3lpe-IconButton"
+      className="css-1cbac61-IconButton"
       color=""
       data-testid="icon-button"
       disabled={true}
@@ -156,7 +156,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
         onClick={[Function]}
       >
         <span
-          className="css-tz7hxk-Icon"
+          className="css-4szf62-Icon"
         />
       </span>
     </button>
@@ -167,7 +167,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
       3
     </div>
     <button
-      className="css-1e2pjpj-IconButton"
+      className="css-1ek82po-IconButton"
       color=""
       data-testid="icon-button"
       disabled={false}
@@ -178,7 +178,7 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
         onClick={[Function]}
       >
         <span
-          className="css-tz7hxk-Icon"
+          className="css-4szf62-Icon"
         />
       </span>
     </button>


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

This PR introduce a new design addon for buttons which is the transparent state. This state actually is like the non-filled without the border.

Introduce feature is also applied to icon buttons.

This feature applied already to modal close button and pagination buttons which previously was using the filled version of it.

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->
<img width="359" alt="Screenshot 2021-03-16 at 2 09 43 PM" src="https://user-images.githubusercontent.com/6433679/111433819-70af7580-8707-11eb-8efc-fe9360f3b4a2.png">
<img width="497" alt="Screenshot 2021-03-16 at 2 07 08 PM" src="https://user-images.githubusercontent.com/6433679/111433823-71e0a280-8707-11eb-8d53-e34a344043fb.png">
<img width="474" alt="Screenshot 2021-03-16 at 2 06 59 PM" src="https://user-images.githubusercontent.com/6433679/111433827-72793900-8707-11eb-8d40-477a62c5c6e2.png">




## Test Plan
Updated snapshots
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
