### PR TITLE
Fix/ds 102 refresh options when cleared

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -100,6 +100,7 @@ const Select = React.forwardRef<HTMLInputElement, Props & InputProps>(
 
       if (isBackspaceKey) {
         setInputValue(emptyValue);
+        debouncedOnChange('');
       }
     };
 


### PR DESCRIPTION
## Description

Fixes [POR-765]

When the field is cleared, a new request should be sent to the API to refresh the options list, otherwise it can get stuck on the “No Options” state.



[POR-765]: https://orfium.atlassian.net/browse/POR-765