### PR TITLE
fix: passes setChecked state handler as an argument in onCheck callback

### DIFF
--- a/src/components/AssetMatching/Assetmatching.tsx
+++ b/src/components/AssetMatching/Assetmatching.tsx
@@ -27,6 +27,8 @@ interface Props {
   styleType?: formFieldStyles;
   /** The provided handler for the selected status of the asset matching */
   onCheck?: OnCheckHandler;
+  /** The check status of the asset matching checkbox */
+  isChecked?: boolean;
 }
 
 const AssetMatching: FC<Props> = ({
@@ -39,6 +41,7 @@ const AssetMatching: FC<Props> = ({
   matchedCategoryItems,
   styleType = 'outlined',
   onCheck,
+  isChecked = false,
 }) => {
   const defaultLeft = leftAssetProps && (
     <Asset {...leftAssetProps} matchedCategoryItems={matchedCategoryItems} />
@@ -52,6 +55,7 @@ const AssetMatching: FC<Props> = ({
       <section css={Styles.section(styleType)}>
         <div css={Styles.inner}>
           <SectionHeader
+            isChecked={isChecked}
             onCheck={onCheck}
             styleType={styleType}
             score={score}

--- a/src/components/AssetMatching/Assetmatching.tsx
+++ b/src/components/AssetMatching/Assetmatching.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
+import React, { FC } from 'react';
 import Styles from './AssetMatching.style';
 import SectionHeader from './components/SectionHeader/SectionHeader';
 import { MatchingAction } from './types';
@@ -6,6 +6,7 @@ import { Asset } from './components/Asset';
 import { AssetProps } from './components/Asset';
 import { SelectedItemProvider } from './components/SelectedItemContext';
 import { formFieldStyles } from 'theme/palette';
+import { OnCheckHandler } from '../../hooks/useCheck';
 
 interface Props {
   /** The score of the matched metadata */
@@ -25,7 +26,7 @@ interface Props {
   /** The style type of the matching section */
   styleType?: formFieldStyles;
   /** The provided handler for the selected status of the asset matching */
-  onCheck?(val: boolean, e: ChangeEvent): void;
+  onCheck?: OnCheckHandler;
 }
 
 const AssetMatching: FC<Props> = ({

--- a/src/components/AssetMatching/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/AssetMatching/components/SectionHeader/SectionHeader.tsx
@@ -16,6 +16,7 @@ interface Props {
   styleType: formFieldStyles;
   isButtonFilled?: boolean;
   customCheckboxContent?: JSX.Element;
+  isChecked?: boolean;
 }
 
 const SectionHeader: FC<Props> = ({
@@ -25,8 +26,9 @@ const SectionHeader: FC<Props> = ({
   score,
   isButtonFilled = false,
   customCheckboxContent,
+  isChecked = false,
 }) => {
-  const { checked, handleCheck } = useCheck(onCheck);
+  const { checked, handleCheck } = useCheck(isChecked, onCheck);
   const hasActions = matchingActions.length > 0;
 
   return (

--- a/src/components/AssetMatching/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/AssetMatching/components/SectionHeader/SectionHeader.tsx
@@ -1,16 +1,16 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { ChangeEvent, FC } from 'react';
+import { FC } from 'react';
 import Styles from './SectionHeader.style';
 import { ActionsToolbox } from '../ActionsToolbox';
-import { useCheck } from 'hooks/useCheck';
+import { OnCheckHandler, useCheck } from 'hooks/useCheck';
 import { CheckBoxContainer } from '../CheckBoxContainer';
 import { MatchingAction } from '../../types';
 import { formFieldStyles } from 'theme/palette';
 
 interface Props {
-  onCheck?(val: boolean, e: ChangeEvent): void;
+  onCheck?: OnCheckHandler;
   score?: string | number;
   matchingActions?: MatchingAction[];
   styleType: formFieldStyles;

--- a/src/hooks/useCheck.ts
+++ b/src/hooks/useCheck.ts
@@ -1,18 +1,14 @@
-import { ChangeEvent, Dispatch, SetStateAction, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 
-export type OnCheckHandler = (
-  val: boolean,
-  setChecked: Dispatch<SetStateAction<boolean>>,
-  e: ChangeEvent
-) => void;
+export type OnCheckHandler = (val: boolean, e: ChangeEvent) => void;
 
-export const useCheck = (onCheck?: OnCheckHandler) => {
-  const [checked, setChecked] = useState(false);
+export const useCheck = (isChecked = false, onCheck?: OnCheckHandler) => {
+  const [checked, setChecked] = useState(isChecked);
 
   const handleCheck = useCallback(
     (checked, e) => {
       if (onCheck) {
-        onCheck(checked, setChecked, e);
+        onCheck(checked, e);
       }
 
       setChecked(checked);

--- a/src/hooks/useCheck.ts
+++ b/src/hooks/useCheck.ts
@@ -1,12 +1,18 @@
-import { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent, Dispatch, SetStateAction, useCallback, useState } from 'react';
 
-export const useCheck = (onCheck?: (val: boolean, e: ChangeEvent) => void) => {
+export type OnCheckHandler = (
+  val: boolean,
+  setChecked: Dispatch<SetStateAction<boolean>>,
+  e: ChangeEvent
+) => void;
+
+export const useCheck = (onCheck?: OnCheckHandler) => {
   const [checked, setChecked] = useState(false);
 
   const handleCheck = useCallback(
     (checked, e) => {
       if (onCheck) {
-        onCheck(checked, e);
+        onCheck(checked, setChecked, e);
       }
 
       setChecked(checked);


### PR DESCRIPTION
## Description

I forgot to expose the setChecked state handler of the checkbox.  🤭

This is a minor fix that passes the state handler to the onCheck callback.