### PR TITLE
fix: adds state update on isChecked param change 

### DIFF
--- a/src/components/AssetMatching/__snapshots__/AssetMatching.stories.storyshot
+++ b/src/components/AssetMatching/__snapshots__/AssetMatching.stories.storyshot
@@ -1000,7 +1000,7 @@ exports[`Storyshots Design System/Asset Matching SectionHeader 1`] = `
       ⬇️Header section can be used separately for handling bulk actions⬇️
     </h2>
     <header
-      className="css-1kw7jcc-SectionHeader"
+      className="css-pifv7b-SectionHeader"
     >
       <div
         className="css-zj67xr-CheckBoxContainer"
@@ -1013,7 +1013,7 @@ exports[`Storyshots Design System/Asset Matching SectionHeader 1`] = `
           >
             <input
               checked={false}
-              className="css-j33lnh-CheckBox"
+              className="css-1935wu5-CheckBox"
               data-testid="checkbox"
               disabled={false}
               id="styled-checkbox-"

--- a/src/components/AssetMatching/__snapshots__/AssetMatching.stories.storyshot
+++ b/src/components/AssetMatching/__snapshots__/AssetMatching.stories.storyshot
@@ -253,6 +253,17 @@ exports[`Storyshots Design System/Asset Matching AssetMatching 1`] = `
     >
       reset actions
     </button>
+    <button
+      css={
+        Object {
+          "marginBottom": "0.625rem",
+          "marginLeft": "0.625rem",
+        }
+      }
+      onClick={[Function]}
+    >
+      check from outside
+    </button>
     <section
       css={[Function]}
     >

--- a/src/components/AssetMatching/components/CheckBoxContainer/CheckBoxContainer.tsx
+++ b/src/components/AssetMatching/components/CheckBoxContainer/CheckBoxContainer.tsx
@@ -32,7 +32,12 @@ const CheckBoxContainer: FC<Props> = ({
 
   return (
     <div css={Styles.checkBoxWrapper}>
-      <CheckBox disabled={!isEnabled} filled={isChecked} onClick={handleCheck} />
+      <CheckBox
+        disabled={!isEnabled}
+        filled={isChecked}
+        checked={isChecked}
+        onClick={handleCheck}
+      />
       <div css={Styles.scoreWrapper}>{customContent || defaultContent}</div>
     </div>
   );

--- a/src/components/storyUtils/AssetMatchingShowcase/AssetMatchingShowcase.tsx
+++ b/src/components/storyUtils/AssetMatchingShowcase/AssetMatchingShowcase.tsx
@@ -14,6 +14,7 @@ const AssetMatchingShowcase = ({
   styleType: formFieldStyles;
 }) => {
   const [matchingActions, setMatchingActions] = useState<MatchingAction[]>(Mocks.actionsMock);
+  const [checked, setChecked] = useState(false);
 
   const customShowcase = {
     ...(showCustomContent
@@ -34,6 +35,9 @@ const AssetMatchingShowcase = ({
     setMatchingActions(prevState => [...prevState, newAction]);
   };
 
+  const checkHandler = () => {
+    setChecked(!checked);
+  };
   const marginValue = rem(10);
 
   return (
@@ -48,7 +52,11 @@ const AssetMatchingShowcase = ({
       >
         reset actions
       </button>
+      <button css={{ marginBottom: marginValue, marginLeft: marginValue }} onClick={checkHandler}>
+        check from outside
+      </button>
       <AssetMatching
+        isChecked={checked}
         score={95}
         styleType={styleType}
         matchedCategoryItems={['George Michael']}

--- a/src/hooks/useCheck.ts
+++ b/src/hooks/useCheck.ts
@@ -1,9 +1,13 @@
-import { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 
 export type OnCheckHandler = (val: boolean, e: ChangeEvent) => void;
 
 export const useCheck = (isChecked = false, onCheck?: OnCheckHandler) => {
-  const [checked, setChecked] = useState(isChecked);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    setChecked(isChecked);
+  }, [isChecked]);
 
   const handleCheck = useCallback(
     (checked, e) => {

--- a/src/hooks/useCheck.ts
+++ b/src/hooks/useCheck.ts
@@ -6,7 +6,7 @@ export const useCheck = (isChecked = false, onCheck?: OnCheckHandler) => {
   const [checked, setChecked] = useState(false);
 
   useEffect(() => {
-    setChecked(isChecked);
+    setChecked(prevState => !prevState);
   }, [isChecked]);
 
   const handleCheck = useCallback(


### PR DESCRIPTION

## Description
- adds a new button in a showcase for checking the component from a parent component.
- adds useEffect and passed isChecked to Checkbox component.


## Screenshot


![asset-matching-check-from-outside](https://user-images.githubusercontent.com/50381321/113832808-a0dfb680-9791-11eb-9a48-725c8f0aa8e3.gif)

## Test Plan

updates snapshot