### PR TITLE
fix: removes proposed solution after last PR 

### DIFF
--- a/src/components/AssetMatching/Assetmatching.tsx
+++ b/src/components/AssetMatching/Assetmatching.tsx
@@ -7,6 +7,7 @@ import { AssetProps } from './components/Asset';
 import { SelectedItemProvider } from './components/SelectedItemContext';
 import { formFieldStyles } from 'theme/palette';
 import { OnCheckHandler } from '../../hooks/useCheck';
+import { generateUniqueID } from '../../utils/helpers';
 
 interface Props {
   /** The score of the matched metadata */
@@ -55,6 +56,7 @@ const AssetMatching: FC<Props> = ({
       <section css={Styles.section(styleType)}>
         <div css={Styles.inner}>
           <SectionHeader
+            key={generateUniqueID(`checkbox_${isChecked}`)}
             isChecked={isChecked}
             onCheck={onCheck}
             styleType={styleType}

--- a/src/components/AssetMatching/__snapshots__/AssetMatching.stories.storyshot
+++ b/src/components/AssetMatching/__snapshots__/AssetMatching.stories.storyshot
@@ -1000,7 +1000,7 @@ exports[`Storyshots Design System/Asset Matching SectionHeader 1`] = `
       ⬇️Header section can be used separately for handling bulk actions⬇️
     </h2>
     <header
-      className="css-pifv7b-SectionHeader"
+      className="css-1kw7jcc-SectionHeader"
     >
       <div
         className="css-zj67xr-CheckBoxContainer"
@@ -1013,7 +1013,7 @@ exports[`Storyshots Design System/Asset Matching SectionHeader 1`] = `
           >
             <input
               checked={false}
-              className="css-1935wu5-CheckBox"
+              className="css-j33lnh-CheckBox"
               data-testid="checkbox"
               disabled={false}
               id="styled-checkbox-"

--- a/src/hooks/useCheck.ts
+++ b/src/hooks/useCheck.ts
@@ -1,13 +1,9 @@
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 
-export type OnCheckHandler = (val: boolean, e: ChangeEvent) => void;
+export type OnCheckHandler = (val: boolean, e?: ChangeEvent) => void;
 
-export const useCheck = (isChecked = false, onCheck?: OnCheckHandler) => {
-  const [checked, setChecked] = useState(false);
-
-  useEffect(() => {
-    setChecked(prevState => !prevState);
-  }, [isChecked]);
+export const useCheck = (isChecked: boolean, onCheck?: OnCheckHandler) => {
+  const [checked, setChecked] = useState(() => isChecked);
 
   const handleCheck = useCallback(
     (checked, e) => {


### PR DESCRIPTION
## Description

Removes proposed solution after the last PR and adds a key that changes dynamically to force rerender the component.

We can use a key that changes dynamically every time the parent components change the boolean prop `isChecked`. This way, we force the section component that contains the checkbox to rerender and pass down the updated value of `isChecked` prop without using the useEffect hook.

## Screenshot

![ezgif com-gif-maker](https://user-images.githubusercontent.com/50381321/113888223-d228a880-97ca-11eb-8796-11c9bdd1720b.gif)
