### PR TITLE
Feat/Optional isActive

### DIFF
--- a/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
+++ b/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
@@ -81,6 +81,7 @@ const MenuItem: React.FC<Props> = memo(
                           }}
                           data-testid={subMenuItem.url}
                           activeClassName="active"
+                          isActive={subMenuItem?.isActive}
                           key={subMenuItem.url}
                           css={subMenuLinkStyle()}
                           id={'submenu-item-link'}

--- a/src/components/Drawer/types.ts
+++ b/src/components/Drawer/types.ts
@@ -1,4 +1,6 @@
 import { AcceptedIconNames } from 'components/Icon/types';
+import * as H from 'history';
+import { match } from 'react-router';
 
 export type MenuItem = {
   name: string;
@@ -6,5 +8,9 @@ export type MenuItem = {
   state?: Record<string, any> | null;
   visible: boolean;
   iconName: AcceptedIconNames;
+  isActive?<Params extends { [K in keyof Params]?: string }>(
+    match: match<Params> | null,
+    location: H.Location
+  ): boolean;
   options: MenuItem[];
 };

--- a/src/components/Drawer/types.ts
+++ b/src/components/Drawer/types.ts
@@ -1,5 +1,5 @@
 import { AcceptedIconNames } from 'components/Icon/types';
-import * as H from 'history';
+import { Location, LocationState } from 'history';
 import { match } from 'react-router';
 
 export type MenuItem = {
@@ -8,9 +8,9 @@ export type MenuItem = {
   state?: Record<string, any> | null;
   visible: boolean;
   iconName: AcceptedIconNames;
-  isActive?<Params extends { [K in keyof Params]?: string }>(
+  isActive?<Params extends { [K in keyof Params]?: string }, S = LocationState>(
     match: match<Params> | null,
-    location: H.Location
+    location: Location<S>
   ): boolean;
   options: MenuItem[];
 };


### PR DESCRIPTION
## Description

On initial render , the active classname is not appended.  This PR introduces the [isActive](https://reactrouter.com/web/api/NavLink/isactive-func) function as an optional param to help solve this issue. 

[Ticket](https://orfium.atlassian.net/browse/DS-125)
