### PR TITLE
fix(asset-matching): adds prop for explicitly handling checkbox

### DIFF
--- a/src/components/AssetMatching/AssetMatching.stories.mdx
+++ b/src/components/AssetMatching/AssetMatching.stories.mdx
@@ -248,7 +248,7 @@ import { SectionHeader as SectionBulkActions } from '@orfium/ictinus/dist/AssetM
 
 <Preview>
   <Story name="SectionHeader" parameters={{ decorators: [withKnobs] }}>
-    <SectionHeaderShowcase isButtonFilled={boolean('isButtonFilled',true)} />
+    <SectionHeaderShowcase isCheckboxEnabled={boolean('isCheckboxEnabled', true)} isButtonFilled={boolean('isButtonFilled',true)} />
   </Story>
 </Preview>
 

--- a/src/components/AssetMatching/Assetmatching.tsx
+++ b/src/components/AssetMatching/Assetmatching.tsx
@@ -31,6 +31,8 @@ interface Props {
   isChecked?: boolean;
   /** The custom element to pass custom elements to actions toolbox */
   customActionsContent?: JSX.Element | null;
+  /** The prop needed for explicitly enabling or disabling checkbox */
+  isCheckboxEnabled?: boolean;
 }
 
 const AssetMatching: FC<Props> = ({
@@ -45,6 +47,7 @@ const AssetMatching: FC<Props> = ({
   onCheck,
   isChecked = false,
   customActionsContent,
+  isCheckboxEnabled = true,
 }) => {
   const defaultLeft = leftAssetProps && (
     <Asset {...leftAssetProps} matchedCategoryItems={matchedCategoryItems} />
@@ -58,6 +61,7 @@ const AssetMatching: FC<Props> = ({
       <section css={Styles.section(styleType)}>
         <div css={Styles.inner}>
           <SectionHeader
+            isCheckboxEnabled={isCheckboxEnabled}
             customActionsContent={customActionsContent}
             isChecked={isChecked}
             onCheck={onCheck}

--- a/src/components/AssetMatching/components/CheckBoxContainer/CheckBoxContainer.tsx
+++ b/src/components/AssetMatching/components/CheckBoxContainer/CheckBoxContainer.tsx
@@ -22,7 +22,7 @@ const CheckBoxContainer: FC<Props> = ({
   isIntermediateStatus = false,
 }) => {
   const scoreText = `${score}%`;
-  const defaultContent = isEnabled && (
+  const defaultContent = !customCheckboxContent && (
     <Fragment>
       <span css={Styles.score(isEnabled)}>{score ? scoreText : 'N/A'}</span>
       <span css={Styles.text(isEnabled)}>

--- a/src/components/AssetMatching/components/SectionHeader/SectionHeader.tsx
+++ b/src/components/AssetMatching/components/SectionHeader/SectionHeader.tsx
@@ -24,6 +24,7 @@ interface Props {
   isIntermediateStatus?: boolean;
   isBulkSection?: boolean;
   customActionsContent?: JSX.Element | null;
+  isCheckboxEnabled?: boolean;
 }
 
 const SectionHeader: FC<Props> = ({
@@ -37,6 +38,7 @@ const SectionHeader: FC<Props> = ({
   isBulkSection = false,
   isIntermediateStatus = false,
   customActionsContent,
+  isCheckboxEnabled = true,
 }) => {
   const { checked, handleCheck } = useCheck(isChecked, onCheck);
 
@@ -46,7 +48,7 @@ const SectionHeader: FC<Props> = ({
         isIntermediateStatus={isIntermediateStatus}
         customCheckboxContent={customCheckboxContent}
         isChecked={checked}
-        isEnabled={Boolean(score || customCheckboxContent)}
+        isEnabled={isCheckboxEnabled}
         handleCheck={handleCheck}
         score={score}
       />

--- a/src/components/storyUtils/AssetMatchingShowcase/BulkActionsShowcase.tsx
+++ b/src/components/storyUtils/AssetMatchingShowcase/BulkActionsShowcase.tsx
@@ -3,7 +3,6 @@ import AssetMatching from '../../AssetMatching/Assetmatching';
 import Mocks from './mocks';
 import { rem } from 'polished';
 import BulkActionsSection from '../../AssetMatching/components/SectionHeader/SectionHeader';
-import Select from '../../Select';
 
 const BulkActionsShowcase = () => {
   const [checked, setChecked] = useState(false);

--- a/src/components/storyUtils/AssetMatchingShowcase/SectionHeaderShowcase.tsx
+++ b/src/components/storyUtils/AssetMatchingShowcase/SectionHeaderShowcase.tsx
@@ -3,7 +3,13 @@ import { rem } from 'polished';
 import SectionHeader from '../../AssetMatching/components/SectionHeader/SectionHeader';
 import mocks from './mocks';
 
-const SectionHeaderShowcase = ({ isButtonFilled }: { isButtonFilled: boolean }) => {
+const SectionHeaderShowcase = ({
+  isCheckboxEnabled,
+  isButtonFilled,
+}: {
+  isButtonFilled: boolean;
+  isCheckboxEnabled: boolean;
+}) => {
   const marginValue = rem(10);
 
   return (
@@ -19,6 +25,7 @@ const SectionHeaderShowcase = ({ isButtonFilled }: { isButtonFilled: boolean }) 
     >
       <h2>⬇️Header section can be used separately for handling bulk actions⬇️</h2>
       <SectionHeader
+        isCheckboxEnabled={isCheckboxEnabled}
         isBulkSection
         styleType={'outlined'}
         customCheckboxContent={<span css={{ color: 'black' }}>2 items selected</span>}


### PR DESCRIPTION
## Description

- adds `isCheckboxEnabled` prop for explicitly handling checkbox `disabled` prop
- changes the behavior of default probability score element
- updates `SectionHeader` showcase.

