### PR TITLE
Fix/textfield wrapper

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -3478,7 +3478,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
                 className="css-71prqf-TextInputWrapper"
               >
                 <div
-                  className="css-ziw0v5-TextInputWrapper"
+                  className="css-19bjb4x-TextInputWrapper"
                 >
                   <div
                     className="css-1u4znjd"
@@ -3536,7 +3536,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
                 className="css-71prqf-TextInputWrapper"
               >
                 <div
-                  className="css-1kf684z-TextInputWrapper"
+                  className="css-1il6azq-TextInputWrapper"
                 >
                   <div
                     className="css-1u4znjd"
@@ -3643,7 +3643,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                     className="css-hpo279-TextInputWrapper"
                   >
                     <div
-                      className="css-1kf684z-TextInputWrapper"
+                      className="css-1il6azq-TextInputWrapper"
                     >
                       <div
                         className="css-1u4znjd"
@@ -3701,7 +3701,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                     className="css-71prqf-TextInputWrapper"
                   >
                     <div
-                      className="css-1kf684z-TextInputWrapper"
+                      className="css-1il6azq-TextInputWrapper"
                     >
                       <div
                         className="css-1u4znjd"
@@ -3759,7 +3759,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                     className="css-fpor5m-TextInputWrapper"
                   >
                     <div
-                      className="css-1kf684z-TextInputWrapper"
+                      className="css-1il6azq-TextInputWrapper"
                     >
                       <div
                         className="css-1u4znjd"
@@ -3829,7 +3829,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                     className="css-8zmr6c-TextInputWrapper"
                   >
                     <div
-                      className="css-1kf684z-TextInputWrapper"
+                      className="css-1il6azq-TextInputWrapper"
                     >
                       <div
                         className="css-1u4znjd"
@@ -3900,7 +3900,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                     className="css-hpo279-TextInputWrapper"
                   >
                     <div
-                      className="css-1kf684z-TextInputWrapper"
+                      className="css-1il6azq-TextInputWrapper"
                     >
                       <div
                         className="css-1u4znjd"
@@ -4012,7 +4012,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
                 className="css-71prqf-TextInputWrapper"
               >
                 <div
-                  className="css-ziw0v5-TextInputWrapper"
+                  className="css-19bjb4x-TextInputWrapper"
                 >
                   <div
                     className="css-1u4znjd"
@@ -4070,7 +4070,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
                 className="css-71prqf-TextInputWrapper"
               >
                 <div
-                  className="css-1kf684z-TextInputWrapper"
+                  className="css-1il6azq-TextInputWrapper"
                 >
                   <div
                     className="css-1u4znjd"
@@ -4157,7 +4157,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -4242,7 +4242,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with predefined values 1`
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -4327,7 +4327,7 @@ exports[`Storyshots Design System/DatePicker Dynamic disableDates with all optio
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -48,7 +48,7 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -147,7 +147,7 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -253,7 +253,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
               className="css-1p4z2la-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -320,7 +320,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
               className="css-1e1zkk7-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -387,7 +387,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
               className="css-yklu5p-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -493,7 +493,7 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
               className="css-hpo279-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -599,7 +599,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-ziw0v5-TextInputWrapper"
+                className="css-19bjb4x-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -666,7 +666,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -772,7 +772,7 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
               className="css-hpo279-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -875,7 +875,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -935,7 +935,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
           className="css-hpo279-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -1001,7 +1001,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -1106,7 +1106,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-ziw0v5-TextInputWrapper"
+                className="css-19bjb4x-TextInputWrapper"
               >
                 <div
                   className="css-1i3wexl-IconWrapper"
@@ -1187,7 +1187,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1252,7 +1252,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1i3wexl-IconWrapper"
@@ -1380,7 +1380,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                   className="css-8zmr6c-TextInputWrapper"
                 >
                   <div
-                    className="css-1kf684z-TextInputWrapper"
+                    className="css-1il6azq-TextInputWrapper"
                   >
                     <div
                       className="css-1u4znjd"
@@ -1460,7 +1460,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                   className="css-alwr26-TextInputWrapper"
                 >
                   <div
-                    className="css-1kf684z-TextInputWrapper"
+                    className="css-1il6azq-TextInputWrapper"
                   >
                     <div
                       className="css-1u4znjd"
@@ -1540,7 +1540,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                   className="css-1r0s33d-TextInputWrapper"
                 >
                   <div
-                    className="css-1kf684z-TextInputWrapper"
+                    className="css-1il6azq-TextInputWrapper"
                   >
                     <div
                       className="css-1u4znjd"
@@ -1632,7 +1632,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                   className="css-hpo279-TextInputWrapper"
                 >
                   <div
-                    className="css-1kf684z-TextInputWrapper"
+                    className="css-1il6azq-TextInputWrapper"
                   >
                     <div
                       className="css-1u4znjd"
@@ -1712,7 +1712,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                   className="css-71prqf-TextInputWrapper"
                 >
                   <div
-                    className="css-1kf684z-TextInputWrapper"
+                    className="css-1il6azq-TextInputWrapper"
                   >
                     <div
                       className="css-1u4znjd"
@@ -1792,7 +1792,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                   className="css-fpor5m-TextInputWrapper"
                 >
                   <div
-                    className="css-1kf684z-TextInputWrapper"
+                    className="css-1il6azq-TextInputWrapper"
                   >
                     <div
                       className="css-1u4znjd"
@@ -1913,7 +1913,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               className="css-hpo279-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1980,7 +1980,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -2047,7 +2047,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
               className="css-fpor5m-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"

--- a/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
+++ b/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
@@ -49,7 +49,7 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -81,7 +81,7 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -152,7 +152,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
           className="css-hpo279-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -182,7 +182,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -212,7 +212,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
           className="css-fpor5m-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -281,7 +281,7 @@ exports[`Storyshots Design System/TextArea Text Area with KNOBS 1`] = `
           className="css-hpo279-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -353,7 +353,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
           className="css-1p4z2la-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -384,7 +384,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
           className="css-1e1zkk7-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -415,7 +415,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
           className="css-yklu5p-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -495,7 +495,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
               className="css-8zmr6c-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -540,7 +540,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
               className="css-alwr26-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -585,7 +585,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
               className="css-1r0s33d-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -642,7 +642,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
               className="css-hpo279-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -687,7 +687,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -732,7 +732,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
               className="css-fpor5m-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -49,7 +49,7 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -85,7 +85,7 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-1kf684z-TextInputWrapper"
+            className="css-1il6azq-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -160,7 +160,7 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
           className="css-hpo279-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -196,7 +196,7 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -232,7 +232,7 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
           className="css-fpor5m-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -307,7 +307,7 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1i3wexl-IconWrapper"
@@ -367,7 +367,7 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1i3wexl-IconWrapper"
@@ -466,7 +466,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -502,7 +502,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -532,7 +532,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -600,7 +600,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1i3wexl-IconWrapper"
@@ -650,7 +650,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -700,7 +700,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
           className="css-71prqf-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1i3wexl-IconWrapper"
@@ -803,7 +803,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
           className="css-1p4z2la-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -839,7 +839,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
           className="css-1e1zkk7-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -875,7 +875,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
           className="css-yklu5p-TextInputWrapper"
         >
           <div
-            className="css-ziw0v5-TextInputWrapper"
+            className="css-19bjb4x-TextInputWrapper"
           >
             <div
               className="css-1u4znjd"
@@ -960,7 +960,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
               className="css-1hsfcrv-TextInputWrapper"
             >
               <div
-                className="css-ziw0v5-TextInputWrapper"
+                className="css-19bjb4x-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1008,7 +1008,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
               className="css-1sl0795-TextInputWrapper"
             >
               <div
-                className="css-ziw0v5-TextInputWrapper"
+                className="css-19bjb4x-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1056,7 +1056,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
               className="css-1v3snu0-TextInputWrapper"
             >
               <div
-                className="css-ziw0v5-TextInputWrapper"
+                className="css-19bjb4x-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1116,7 +1116,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
               className="css-1hsfcrv-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1164,7 +1164,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
               className="css-1sl0795-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1212,7 +1212,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
               className="css-1v3snu0-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1311,7 +1311,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-8zmr6c-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1360,7 +1360,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-alwr26-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1409,7 +1409,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-1r0s33d-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1465,7 +1465,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                 className="css-8zmr6c-TextInputWrapper"
               >
                 <div
-                  className="css-1kf684z-TextInputWrapper"
+                  className="css-1il6azq-TextInputWrapper"
                 >
                   <div
                     className="css-1u4znjd"
@@ -1527,7 +1527,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-hpo279-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1576,7 +1576,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-71prqf-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1625,7 +1625,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-fpor5m-TextInputWrapper"
             >
               <div
-                className="css-1kf684z-TextInputWrapper"
+                className="css-1il6azq-TextInputWrapper"
               >
                 <div
                   className="css-1u4znjd"
@@ -1681,7 +1681,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                 className="css-hpo279-TextInputWrapper"
               >
                 <div
-                  className="css-1kf684z-TextInputWrapper"
+                  className="css-1il6azq-TextInputWrapper"
                 >
                   <div
                     className="css-1u4znjd"

--- a/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
+++ b/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
@@ -224,7 +224,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -245,7 +245,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"
@@ -266,7 +266,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
             className="css-hpo279-TextInputWrapper"
           >
             <div
-              className="css-1kf684z-TextInputWrapper"
+              className="css-1il6azq-TextInputWrapper"
             >
               <div
                 className="css-1u4znjd"

--- a/src/components/utils/TextInputWrapper/TextInputWrapper.style.ts
+++ b/src/components/utils/TextInputWrapper/TextInputWrapper.style.ts
@@ -106,7 +106,7 @@ export const textFieldStyle = ({ size = DEFAULT_SIZE, label = '', leftIcon, lean
     flex-direction: row;
     align-items: center;
     vertical-align: top;
-    width: calc(100% - ${rem(32)});
+    width: fill-available;
     ${!lean && getTextFieldSize(theme, label, Boolean(leftIcon))[size]}
 
     > div {


### PR DESCRIPTION
## Description

In TextFieldWrapper utils component there was a calc on width that was breaking all the textfields. Since we are using everywhere else the value `fill-available` I replaced the calc with it to resolve the problem.

[Ticket](https://orfium.atlassian.net/browse/DS-131)

## Screenshot

Visual proof of the error while using them:
![Capture (2)](https://user-images.githubusercontent.com/28539607/115516015-5fb9cd00-a28e-11eb-8fc6-4845c1fbc358.PNG)

## Test Plan

Updated snapshots