### PR TITLE
Feat/breadcrumb make data props optional

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,7 @@ import { BreadcrumbItemData } from './types';
 
 export type Props = {
   /** Defines the data for constructing the related breadcrumb items */
-  data: BreadcrumbItemData[];
+  data?: BreadcrumbItemData[];
 };
 
 const MAX_LIMIT_BREADCRUMB_LENGTH = 4;


### PR DESCRIPTION
## Description

In this PR we make the data prop passed to breadcrumb optional in order to allow it to work with children without errors.

