### PR TITLE
Feat/outlined notifications

### DIFF
--- a/src/components/Notification/Banner/Banner.tsx
+++ b/src/components/Notification/Banner/Banner.tsx
@@ -16,7 +16,7 @@ export type Props = {
   /** The type of the Notification */
   type: NotificationTypes;
   /** The style type of the Notification. Defaults to elevated */
-  styleType: NotificationStyleType;
+  styleType?: NotificationStyleType;
   /** The primary call-to-action label of the Notification */
   primaryCTALabel?: string;
   /** The primary call-to-action of the Notification */

--- a/src/components/Notification/Banner/Banner.tsx
+++ b/src/components/Notification/Banner/Banner.tsx
@@ -3,7 +3,7 @@
 import { jsx } from '@emotion/core';
 import * as React from 'react';
 import CompactNotification from '../subcomponents/CompactNotification';
-import { NotificationTypes } from '../Notification';
+import { NotificationStyleType, NotificationTypes } from '../Notification';
 import { TestId } from '../../../utils/types';
 
 export type Props = {
@@ -15,6 +15,8 @@ export type Props = {
   message: string;
   /** The type of the Notification */
   type: NotificationTypes;
+  /** The style type of the Notification. Defaults to elevated */
+  styleType: NotificationStyleType;
   /** The primary call-to-action label of the Notification */
   primaryCTALabel?: string;
   /** The primary call-to-action of the Notification */
@@ -30,6 +32,7 @@ const Banner: React.FC<Props> = ({
   title,
   message,
   type,
+  styleType = 'elevated',
   primaryCTALabel,
   primaryCTA = undefined,
   closeCTA = undefined,
@@ -42,6 +45,7 @@ const Banner: React.FC<Props> = ({
       title={title}
       variant="banner"
       type={type}
+      styleType={styleType}
       primaryCTALabel={primaryCTALabel}
       primaryCTA={primaryCTA}
       closeCTA={closeCTA}

--- a/src/components/Notification/InlineNotification/InlineNotification.tsx
+++ b/src/components/Notification/InlineNotification/InlineNotification.tsx
@@ -3,7 +3,7 @@
 import { jsx } from '@emotion/core';
 import * as React from 'react';
 import CompactNotification from '../subcomponents/CompactNotification';
-import { NotificationTypes } from '../Notification';
+import { NotificationStyleType, NotificationTypes } from '../Notification';
 import { TestId } from '../../../utils/types';
 
 export type Props = {
@@ -13,6 +13,8 @@ export type Props = {
   message: string;
   /** The type of the Notification */
   type: NotificationTypes;
+  /** The style type of the Notification. Defaults to elevated */
+  styleType: NotificationStyleType;
   /** The primary call-to-action label of the Notification */
   primaryCTALabel?: string;
   /** The primary call-to-action of the Notification */
@@ -27,6 +29,7 @@ const InlineNotification: React.FC<Props> = ({
   withIcon = false,
   message,
   type,
+  styleType = 'elevated',
   primaryCTALabel,
   primaryCTA = undefined,
   closeCTA = undefined,
@@ -38,6 +41,7 @@ const InlineNotification: React.FC<Props> = ({
       message={message}
       variant="inline"
       type={type}
+      styleType={styleType}
       primaryCTALabel={primaryCTALabel}
       primaryCTA={primaryCTA}
       closeCTA={closeCTA}

--- a/src/components/Notification/InlineNotification/InlineNotification.tsx
+++ b/src/components/Notification/InlineNotification/InlineNotification.tsx
@@ -14,7 +14,7 @@ export type Props = {
   /** The type of the Notification */
   type: NotificationTypes;
   /** The style type of the Notification. Defaults to elevated */
-  styleType: NotificationStyleType;
+  styleType?: NotificationStyleType;
   /** The primary call-to-action label of the Notification */
   primaryCTALabel?: string;
   /** The primary call-to-action of the Notification */

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -263,6 +263,7 @@ import { Snackbar } from '@orfium/ictinus';
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             primaryCTALabel={text('primaryCTALabel', 'Primary CTA')}
             primaryCTA={() => console.log('primary action clicked')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             secondaryCTALabel={text('secondaryCTALabel', 'Secondary CTA')}
             secondaryCTA={() => console.log('secondary action clicked')}
             description={text(

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -201,6 +201,7 @@ import { Toast, NotificationVisual } from '@orfium/ictinus';
             message={text('message', 'Informative Message')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             expanded
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             closeCTA={() => console.log('close action clicked')}
           >
             <NotificationVisual

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -46,6 +46,7 @@ import { InlineNotification } from '@orfium/ictinus';
       <PresentComponent name="" width={768}>
         <InlineNotification
           withIcon={boolean('withIcon', true)}
+          styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
           message={text('message', 'Informative Message')}
           type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
         />
@@ -55,6 +56,7 @@ import { InlineNotification } from '@orfium/ictinus';
           withIcon={boolean('withIcon', true)}
           message={text('message', 'Informative Message')}
           type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+          styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
           primaryCTALabel={text('primaryCTALabel', 'Action')}
           primaryCTA={() => console.log('action clicked')}
           closeCTA={() => console.log('close action clicked')}
@@ -64,6 +66,7 @@ import { InlineNotification } from '@orfium/ictinus';
         <InlineNotification
           withIcon={boolean('withIcon', true)}
           message={text('message', 'Informative Message')}
+          styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
           type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
           primaryCTALabel={text('primaryCTALabel', 'Action')}
           primaryCTA={() => console.log('action clicked')}
@@ -74,6 +77,7 @@ import { InlineNotification } from '@orfium/ictinus';
           withIcon={boolean('withIcon', true)}
           message={text('message', 'Informative Message')}
           type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+          styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
           closeCTA={() => console.log('close action clicked')}
         />
       </PresentComponent>
@@ -125,6 +129,7 @@ import { NotificationsContainer, Banner } from '@orfium/ictinus';
             primaryCTALabel={text('primaryCTALabel', 'Action')}
             primaryCTA={() => console.log('action clicked')}
             closeCTA={() => console.log('close action clicked')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
           />
           <Banner
             withIcon={boolean('icon', true)}
@@ -133,6 +138,7 @@ import { NotificationsContainer, Banner } from '@orfium/ictinus';
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             primaryCTALabel={text('primaryCTALabel', 'Action')}
             primaryCTA={() => console.log('action clicked')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             closeCTA={() => console.log('close action clicked')}
           />
           <Banner
@@ -142,6 +148,7 @@ import { NotificationsContainer, Banner } from '@orfium/ictinus';
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             primaryCTALabel={text('primaryCTALabel', 'Action')}
             primaryCTA={() => console.log('action clicked')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             closeCTA={() => console.log('close action clicked')}
           />
         </NotificationsContainer>

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -303,6 +303,7 @@ import { Snackbar } from '@orfium/ictinus';
             message={text('message', 'This is the info')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             primaryCTALabel={text('primaryCTALabel', 'Action')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             primaryCTA={() => console.log('action clicked')}
             closeCTA={() => console.log('close action clicked')}
           />
@@ -311,6 +312,7 @@ import { Snackbar } from '@orfium/ictinus';
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             primaryCTALabel={text('primaryCTALabel', 'Primary CTA')}
             primaryCTA={() => console.log('primary action clicked')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             secondaryCTALabel={text('secondaryCTALabel', 'Secondary CTA')}
             secondaryCTA={() => console.log('secondary action clicked')}
             description={text(
@@ -322,6 +324,7 @@ import { Snackbar } from '@orfium/ictinus';
           <Toast
             message={text('message', 'Informative Message')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             expanded
             closeCTA={() => console.log('close action clicked')}
           >
@@ -342,6 +345,7 @@ import { Snackbar } from '@orfium/ictinus';
             title={text('title', 'This is the heading:')}
             message={text('message', 'This is the info')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             primaryCTALabel={text('primaryCTALabel', 'Action')}
             primaryCTA={() => console.log('action clicked')}
             closeCTA={() => console.log('close action clicked')}
@@ -349,6 +353,7 @@ import { Snackbar } from '@orfium/ictinus';
           <Toast
             message={text('message', 'Informative Message')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             expanded
             closeCTA={() => console.log('close action clicked')}
           >
@@ -394,6 +399,7 @@ import { Snackbar } from '@orfium/ictinus';
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             primaryCTALabel={text('primaryCTALabel', 'Primary CTA')}
             primaryCTA={() => console.log('primary action clicked')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             secondaryCTALabel={text('secondaryCTALabel', 'Secondary CTA')}
             secondaryCTA={() => console.log('secondary action clicked')}
             description={text(
@@ -405,6 +411,7 @@ import { Snackbar } from '@orfium/ictinus';
           <Toast
             message={text('message', 'Informative Message')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             expanded
             closeCTA={() => console.log('close action clicked')}
           >

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -21,7 +21,7 @@ export const notificationsContainerPerType = (
         border-left: ${typeToThemePalette(theme, type)} 4px solid;
         background: ${tint(0.95, typeToThemePalette(theme, type))};
         box-shadow: ${theme.elevation['02']};
-      `;
+`;
 
 export const actionsContainer = () => (theme: Theme): SerializedStyles => css`
   display: flex;

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -13,14 +13,14 @@ export const notificationsContainerPerType = (
   styleType: NotificationStyleType,
   theme: Theme
 ): string =>
-  styleType === 'elevated'
+  styleType === 'outlined'
     ? `
+        border: ${rem(2)} solid ${typeToThemePalette(theme, type)};
+      `
+    : `
         border-left: ${typeToThemePalette(theme, type)} 4px solid;
         background: ${tint(0.95, typeToThemePalette(theme, type))};
         box-shadow: ${theme.elevation['02']};
-      `
-    : `
-        border: ${rem(2)} solid ${typeToThemePalette(theme, type)};
       `;
 
 export const actionsContainer = () => (theme: Theme): SerializedStyles => css`

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -1,7 +1,27 @@
 import { Theme } from '../../theme';
 import { css, SerializedStyles } from '@emotion/core';
+import { NotificationStyleType, NotificationTypes } from './Notification';
+import { rem, tint } from 'polished';
+
+export const typeToThemePalette = (theme: Theme, type: NotificationTypes): string =>
+  theme.utils.getColor(type, 400, 'normal');
 
 // Generic SerializedStyles for all Notification Types
+
+export const notificationsContainerPerType = (
+  type: NotificationTypes,
+  styleType: NotificationStyleType,
+  theme: Theme
+): string =>
+  styleType === 'elevated'
+    ? `
+        border-left: ${typeToThemePalette(theme, type)} 4px solid;
+        background: ${tint(0.95, typeToThemePalette(theme, type))};
+        box-shadow: ${theme.elevation['02']};
+      `
+    : `
+        border: ${rem(2)} solid ${typeToThemePalette(theme, type)};
+      `;
 
 export const actionsContainer = () => (theme: Theme): SerializedStyles => css`
   display: flex;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,3 +1,5 @@
 export type NotificationTypes = 'success' | 'error' | 'info' | 'warning';
 
 export type NotificationVariants = 'inline' | 'banner';
+
+export type NotificationStyleType = 'elevated' | 'outlined';

--- a/src/components/Notification/Snackbar/Snackbar.style.ts
+++ b/src/components/Notification/Snackbar/Snackbar.style.ts
@@ -1,10 +1,26 @@
 import { Theme } from '../../../theme';
-import { rem, transparentize } from 'polished';
-import { NotificationTypes } from '../Notification';
+import { rem } from 'polished';
+import { NotificationStyleType, NotificationTypes } from '../Notification';
 import { css, SerializedStyles } from '@emotion/core';
 import { typeToThemePalette } from '../Notification.style';
 
-export const cardContainer = (type: NotificationTypes) => (theme: Theme): SerializedStyles => css`
+const snackbarContainerPerType = (
+  type: NotificationTypes,
+  styleType: NotificationStyleType,
+  theme: Theme
+) =>
+  styleType === 'outlined'
+    ? `
+        border: ${rem(2)} solid ${typeToThemePalette(theme, type)};
+      `
+    : ` 
+    border-left: ${typeToThemePalette(theme, type)} ${rem(4)} solid;
+    box-shadow: ${theme.elevation['02']};
+`;
+
+export const cardContainer = (type: NotificationTypes, styleType: NotificationStyleType) => (
+  theme: Theme
+): SerializedStyles => css`
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -12,11 +28,9 @@ export const cardContainer = (type: NotificationTypes) => (theme: Theme): Serial
   box-sizing: border-box;
   min-height: ${rem(164)};
   max-height: ${rem(294)};
-  border-left: ${typeToThemePalette(theme, type)} 4px solid;
+  border-radius: ${rem(8)};
   background: ${theme.palette.white};
-  border-radius: ${theme.spacing.xsm};
-  // TODO: box-shadow's last parameter to change when elevated is introduced
-  box-shadow: ${rem(0)} ${rem(2)} ${rem(4)} ${rem(0)} ${transparentize(0.85, theme.palette.black)};
+  ${snackbarContainerPerType(type, styleType, theme)};
 `;
 
 export const topContainer = () => (theme: Theme): SerializedStyles => css`

--- a/src/components/Notification/Snackbar/Snackbar.style.ts
+++ b/src/components/Notification/Snackbar/Snackbar.style.ts
@@ -2,7 +2,7 @@ import { Theme } from '../../../theme';
 import { rem, transparentize } from 'polished';
 import { NotificationTypes } from '../Notification';
 import { css, SerializedStyles } from '@emotion/core';
-import { typeToThemePalette } from '../subcomponents/CompactNotification/CompactNotification.style';
+import { typeToThemePalette } from '../Notification.style';
 
 export const cardContainer = (type: NotificationTypes) => (theme: Theme): SerializedStyles => css`
   display: flex;

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -3,7 +3,7 @@
 import { jsx } from '@emotion/core';
 import Icon from 'components/Icon';
 import * as React from 'react';
-import { NotificationTypes } from '../Notification';
+import { NotificationStyleType, NotificationTypes } from '../Notification';
 import { typeToIconName } from '../subcomponents/CompactNotification/CompactNotification';
 import {
   actionContainer,
@@ -23,6 +23,8 @@ export type Props = {
   message: string;
   /** The type of the Notification */
   type: NotificationTypes;
+  /** The style type of the Notification. Defaults to elevated */
+  styleType?: NotificationStyleType;
   /** The primary call-to-action label of the Notification */
   primaryCTALabel: string | undefined;
   /** The primary call-to-action of the Notification */
@@ -42,6 +44,7 @@ export type Props = {
 const Snackbar: React.FC<Props> = ({
   message,
   type,
+  styleType = 'elevated',
   primaryCTALabel = 'OK',
   primaryCTA,
   secondaryCTALabel = 'Cancel',
@@ -53,7 +56,7 @@ const Snackbar: React.FC<Props> = ({
   const { utils } = useTheme();
 
   return (
-    <div css={cardContainer(type)} notification-type="snackbar">
+    <div css={cardContainer(type, styleType)} notification-type="snackbar">
       <div css={topContainer()}>
         <div css={infoContainer()}>
           <div css={iconContainer()}>

--- a/src/components/Notification/__snapshots__/Notification.stories.storyshot
+++ b/src/components/Notification/__snapshots__/Notification.stories.storyshot
@@ -137,7 +137,7 @@ exports[`Storyshots Design System/Notification Inline Notification 1`] = `
         }
       >
         <div
-          className="css-ut1m8d-CompactNotification"
+          className="css-41zu99-CompactNotification"
         >
           <div
             className="css-1qxbj8g-CompactNotification"
@@ -193,7 +193,7 @@ exports[`Storyshots Design System/Notification Inline Notification 1`] = `
         }
       >
         <div
-          className="css-ut1m8d-CompactNotification"
+          className="css-41zu99-CompactNotification"
         >
           <div
             className="css-1qxbj8g-CompactNotification"
@@ -271,7 +271,7 @@ exports[`Storyshots Design System/Notification Inline Notification 1`] = `
         }
       >
         <div
-          className="css-ut1m8d-CompactNotification"
+          className="css-41zu99-CompactNotification"
         >
           <div
             className="css-1qxbj8g-CompactNotification"
@@ -335,7 +335,7 @@ exports[`Storyshots Design System/Notification Inline Notification 1`] = `
         }
       >
         <div
-          className="css-ut1m8d-CompactNotification"
+          className="css-41zu99-CompactNotification"
         >
           <div
             className="css-1qxbj8g-CompactNotification"

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.style.ts
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.style.ts
@@ -1,24 +1,21 @@
 import { Theme } from '../../../../theme';
-import { rem, tint } from 'polished';
-import { NotificationTypes } from '../../Notification';
+import { rem } from 'polished';
+import { NotificationStyleType, NotificationTypes } from '../../Notification';
 import { css, SerializedStyles } from '@emotion/core';
+import { notificationsContainerPerType } from '../../Notification.style';
 
-export const typeToThemePalette = (theme: Theme, type: NotificationTypes): string =>
-  theme.utils.getColor(type, 400, 'normal');
-
-export const notificationsContainer = (type: NotificationTypes) => (
-  theme: Theme
-): SerializedStyles => css`
+export const notificationsContainer = (
+  type: NotificationTypes,
+  styleType: NotificationStyleType
+) => (theme: Theme): SerializedStyles => css`
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
   overflow: hidden;
   width: 100%;
   height: ${rem(56)};
-  border-left: ${typeToThemePalette(theme, type)} 4px solid;
-  background: ${tint(0.95, typeToThemePalette(theme, type))};
   border-radius: ${theme.spacing.xsm};
-  box-shadow: ${theme.elevation['02']};
+  ${notificationsContainerPerType(type, styleType, theme)};
 `;
 
 export const infoContainer = () => (theme: Theme): SerializedStyles => css`

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
@@ -11,7 +11,7 @@ import {
   primaryActionContainer,
 } from './CompactNotification.style';
 import Icon from '../../../Icon';
-import { NotificationTypes } from '../../Notification';
+import { NotificationStyleType, NotificationTypes } from '../../Notification';
 import { AcceptedIconNames } from 'components/Icon/types';
 import { generateTestDataId } from '../../../../utils/helpers';
 import { TestId } from '../../../../utils/types';
@@ -28,6 +28,8 @@ export type Props = {
   variant: CompactNotificationVariants;
   /** The type of the Notification */
   type: NotificationTypes;
+  /** The style type of the Notification. Defaults to elevated */
+  styleType: NotificationStyleType;
   /** The primary call-to-action label of the Notification */
   primaryCTALabel?: string;
   /** The primary call-to-action of the Notification */
@@ -56,6 +58,7 @@ const CompactNotification: React.FC<Props> = ({
   message,
   variant,
   type,
+  styleType = 'elevated',
   primaryCTALabel,
   primaryCTA,
   closeCTA,
@@ -66,7 +69,7 @@ const CompactNotification: React.FC<Props> = ({
 
   return (
     <div
-      css={notificationsContainer(type)}
+      css={notificationsContainer(type, styleType)}
       {...(variant == 'banner' && { 'notification-type': 'banner' })}
     >
       <div css={infoContainer()}>

--- a/src/components/Toast/Toast.style.ts
+++ b/src/components/Toast/Toast.style.ts
@@ -1,22 +1,35 @@
 import { Theme } from '../../theme';
-import { rem, transparentize } from 'polished';
+import { rem } from 'polished';
 import { css, SerializedStyles } from '@emotion/core';
 import { transition, flexCenter } from '../../theme/functions';
 import { AcceptedColorComponentTypes } from '../../utils/themeFunctions';
 import { isNotificationTypes } from './Toast';
+import { NotificationStyleType } from '../Notification/Notification';
 
 const maxHeightOptions = {
   notification: `max-height: ${rem(294)};`,
   generic: `max-height: none;`,
 };
 
-export const toastContainer = () => (theme: Theme): SerializedStyles => css`
+const toastContainerPerType = (
+  type: AcceptedColorComponentTypes,
+  styleType: NotificationStyleType,
+  theme: Theme
+) =>
+  styleType === 'outlined'
+    ? `border: ${rem(2)} solid ${theme.utils.getColor(type, 400, 'normal')}`
+    : `box-shadow: ${theme.elevation['02']}
+`;
+
+export const toastContainer = (
+  type: AcceptedColorComponentTypes,
+  styleType: NotificationStyleType
+) => (theme: Theme): SerializedStyles => css`
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-radius: ${theme.spacing.xsm};
-  // TODO: box-shadow's last parameter to change when elevated is introduced
-  box-shadow: ${rem(0)} ${rem(2)} ${rem(4)} ${rem(0)} ${transparentize(0.85, theme.palette.black)};
+  border-radius: ${rem(8)};
+  ${toastContainerPerType(type, styleType, theme)};
 `;
 
 export const topContainer = (type: AcceptedColorComponentTypes) => (

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -15,7 +15,7 @@ import {
 } from './Toast.style';
 import { typeToIconName } from '../Notification/subcomponents/CompactNotification/CompactNotification';
 import Icon from '../Icon';
-import { NotificationTypes } from '../Notification/Notification';
+import { NotificationStyleType, NotificationTypes } from '../Notification/Notification';
 import { AcceptedColorComponentTypes } from '../../utils/themeFunctions';
 import { TestId } from '../../utils/types';
 import { generateTestDataId } from '../../utils/helpers';
@@ -25,6 +25,8 @@ export type Props = {
   message: string;
   /** The type of the Toast, will determine the color and the icon */
   type?: AcceptedColorComponentTypes;
+  /** The style type of the Notification. Defaults to elevated */
+  styleType?: NotificationStyleType;
   /** The closing call-to-action of the Toast */
   closeCTA: (() => void) | undefined;
   /** Initialize toast as expanded */
@@ -40,6 +42,7 @@ export const isNotificationTypes = (type: string): type is NotificationTypes => 
 const Toast: React.FC<Props> = ({
   message,
   type = 'branded1',
+  styleType = 'elevated',
   closeCTA,
   expanded = false,
   children,
@@ -49,7 +52,7 @@ const Toast: React.FC<Props> = ({
 
   return (
     <div
-      css={toastContainer()}
+      css={toastContainer(type, styleType)}
       {...(isNotificationTypes(type) && { 'notification-type': 'toast' })}
     >
       <div css={topContainer(type)}>

--- a/src/components/Toast/__snapshots__/Toast.stories.storyshot
+++ b/src/components/Toast/__snapshots__/Toast.stories.storyshot
@@ -55,7 +55,7 @@ exports[`Storyshots Design System/Toast Generic Toast 1`] = `
         }
       >
         <div
-          className="css-1krxp0-Toast"
+          className="css-m7r07e-Toast"
         >
           <div
             className="css-ty67bz-Toast"
@@ -114,7 +114,7 @@ exports[`Storyshots Design System/Toast Generic Toast 1`] = `
         }
       >
         <div
-          className="css-1krxp0-Toast"
+          className="css-m7r07e-Toast"
         >
           <div
             className="css-1i9864f-Toast"
@@ -173,7 +173,7 @@ exports[`Storyshots Design System/Toast Generic Toast 1`] = `
         }
       >
         <div
-          className="css-1krxp0-Toast"
+          className="css-m7r07e-Toast"
         >
           <div
             className="css-iaxkm7-Toast"


### PR DESCRIPTION
## Description

This PR introduces the styleType Prop on the Notifications Components.  These are InlineNotification, Banner, Toast and Snackbar.

The styleProp is optional with default value `'elevated'` and takes as values `'elevated'` or `'outlined'`


[design](https://www.figma.com/file/8kMPBNYHHXz2AtkzeeDmk5/Design-System?node-id=201%3A5004)
[ticket](https://orfium.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=DS&modal=detail&selectedIssue=DS-115)

## Screenshot

![banner](https://user-images.githubusercontent.com/28539607/117146924-63387280-adbd-11eb-925c-70b66376115d.PNG)
![inline](https://user-images.githubusercontent.com/28539607/117146931-63d10900-adbd-11eb-8426-ead1e781a2f2.PNG)
![snackbar](https://user-images.githubusercontent.com/28539607/117146932-64699f80-adbd-11eb-9f49-ecc466a8a97e.PNG)
![toast](https://user-images.githubusercontent.com/28539607/117146934-64699f80-adbd-11eb-9fae-cf50d3770e95.PNG)

## Test Plan

Updated snapshots
