### PR TITLE
[DS-100] Feat / Notifications buttons style change

### DIFF
--- a/src/components/Notification/NotificationVisual/NotificationVisual.tsx
+++ b/src/components/Notification/NotificationVisual/NotificationVisual.tsx
@@ -43,12 +43,12 @@ const NotificationVisual: React.FC<Props> = ({
           css={actionContainer()}
           data-testid={generateTestDataId('visual-secondary', dataTestId)}
         >
-          <Button filled={false} size="sm" onClick={secondaryCTA}>
+          <Button transparent size="sm" onClick={secondaryCTA}>
             {secondaryCTALabel}
           </Button>
         </div>
         <div css={actionContainer()} data-testid={generateTestDataId('visual-primary', dataTestId)}>
-          <Button type="branded1" size="sm" onClick={primaryCTA}>
+          <Button filled={true} size="sm" onClick={primaryCTA}>
             {primaryCTALabel}
           </Button>
         </div>

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -78,7 +78,7 @@ const Snackbar: React.FC<Props> = ({
           css={actionContainer()}
           data-testid={generateTestDataId('snackbar-secondary', dataTestId)}
         >
-          <Button filled={false} size="sm" onClick={secondaryCTA}>
+          <Button transparent size="sm" onClick={secondaryCTA}>
             {secondaryCTALabel}
           </Button>
         </div>
@@ -86,7 +86,7 @@ const Snackbar: React.FC<Props> = ({
           css={actionContainer()}
           data-testid={generateTestDataId('snackbar-primary', dataTestId)}
         >
-          <Button type="branded1" size="sm" onClick={primaryCTA}>
+          <Button filled={true} size="sm" onClick={primaryCTA}>
             {primaryCTALabel}
           </Button>
         </div>


### PR DESCRIPTION
## Description

In this PR we change the buttons on Toast and Snackbar to have primary color ( the default ) and the secondary CTA to be transparent.

[ticket](https://orfium.atlassian.net/browse/DS-100)
[designs](https://www.figma.com/file/8kMPBNYHHXz2AtkzeeDmk5/Design-System?node-id=201%3A5004)

## Screenshot

![image](https://user-images.githubusercontent.com/28539607/117937059-3ed51c80-b30e-11eb-9ca7-95efd5912f52.png)