### PR TITLE
feat(table): test ids

### DIFF
--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -27,6 +27,7 @@ Regular Table with simple rows
   <Story name="Regular Table with simple rows">
     <Table
       columns={['Title', 'Name', 'Surname', 'Age']}
+      dataTestIdPrefix="ictinus"
       padded
       topLeftText={'topLeftText'}
       topRightArea={() => (
@@ -122,7 +123,7 @@ Table with expandable rows and nested header
       columns={['Title', 'Name', 'Surname', 'Age']}
       type="nested-header"
       padded
-      onCheck={g => console.log('on table change: ', g)}
+      onCheck={(g) => console.log('on table change: ', g)}
       topLeftText={'topLeftText'}
       topRightArea={() => (
         <div>
@@ -132,7 +133,13 @@ Table with expandable rows and nested header
       data={new Array(50).fill(null).map((item, index) => ({
         id: index + 1,
         cells: [
-          { content: <a href="www.youtube.com" onClick={(e) => e.stopPropagation()}>'title'</a> },
+          {
+            content: (
+              <a href="www.youtube.com" onClick={(e) => e.stopPropagation()}>
+                'title'
+              </a>
+            ),
+          },
           { content: 'firstname' },
           { content: 'lastname' },
           { content: 4.221 },

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -57,6 +57,8 @@ type Props<T> = {
   topLeftText?: string | JSX.Element;
   /** Top right area to define a custom component for buttons or other usage. */
   topRightArea?: (data: Row<T>[], selectionData?: Selection[]) => React.Component | JSX.Element;
+  /** Data test id prefix for all th/td elements */
+  dataTestIdPrefix?: string;
 };
 
 function Table<T>({
@@ -66,8 +68,9 @@ function Table<T>({
   fixedHeader = false,
   onCheck,
   padded = false,
-  topLeftText = '',
+  topLeftText,
   topRightArea,
+  dataTestIdPrefix,
 }: Props<T>) {
   const theme = useTheme();
   const [selectedIds, setSelectedIds] = React.useState<Selection[] | undefined>(undefined);
@@ -89,7 +92,7 @@ function Table<T>({
     setSelectedIds((selectedIds: Selection[] = []) =>
       selectedIds.indexOf(rowId) === -1
         ? [...selectedIds, rowId]
-        : selectedIds.filter(item => item !== rowId)
+        : selectedIds.filter((item) => item !== rowId)
     );
   }, []);
 
@@ -111,12 +114,20 @@ function Table<T>({
 
   return (
     <React.Fragment>
-      <table css={tableStyle()}>
-        {(onCheck || topRightArea || type === 'normal') && (
+      {(onCheck || topRightArea || topLeftText) && (
+        <table css={tableStyle()}>
           <thead>
             <TableRow>
               {onCheck && (
-                <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded}>
+                <TableCell
+                  component={'th'}
+                  sticky={fixedHeader}
+                  width={50}
+                  padded={padded}
+                  dataTestIdPrefix={dataTestIdPrefix}
+                  rowIndex={0}
+                  index={0}
+                >
                   <CheckBox
                     checked={Boolean(selectedIds && selectedIds.length > 0)}
                     intermediate={
@@ -132,7 +143,7 @@ function Table<T>({
                   />
                 </TableCell>
               )}
-              <TableCell padded={padded}>
+              <TableCell padded={padded} dataTestIdPrefix={dataTestIdPrefix} rowIndex={0} index={1}>
                 {selectedIds && selectedIds?.length > 0 ? (
                   <span>
                     <b>{selectedIds.length}</b> {pluralize('item', selectedIds.length)} selected
@@ -146,14 +157,18 @@ function Table<T>({
                   textAlign={'right'}
                   padded={padded}
                   colSpan={columnCount - (onCheck ? 2 : 1)}
+                  dataTestIdPrefix={dataTestIdPrefix}
+                  rowIndex={0}
+                  index={2}
                 >
                   {topRightArea(data, selectedIds)}
                 </TableCell>
               )}
             </TableRow>
           </thead>
-        )}
-      </table>
+        </table>
+      )}
+
       <table css={tableStyle()}>
         {(onCheck || topRightArea || type === 'normal') && (
           <thead>
@@ -170,7 +185,13 @@ function Table<T>({
                 ]}
               >
                 {onCheck && (
-                  <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded} />
+                  <TableCell
+                    component={'th'}
+                    sticky={fixedHeader}
+                    width={50}
+                    padded={padded}
+                    dataTestIdPrefix={dataTestIdPrefix}
+                  />
                 )}
                 {columns.map((item, index) => (
                   <TableCell
@@ -180,6 +201,7 @@ function Table<T>({
                     sticky={fixedHeader}
                     padded={padded}
                     width={columnsWithWidth[index] ? `${columnsWithWidth[index]}%` : 'initial'}
+                    dataTestIdPrefix={dataTestIdPrefix}
                   >
                     {item}
                   </TableCell>
@@ -189,7 +211,7 @@ function Table<T>({
           </thead>
         )}
         <tbody>
-          {data.map(row => (
+          {data.map((row, index) => (
             // @ts-ignore
             <TableRowWrapper<T>
               key={row.id}
@@ -207,6 +229,8 @@ function Table<T>({
                 onSelectionChangeExist: Boolean(onCheck),
                 expanded: !!row.expanded,
               }}
+              dataTestIdPrefix={dataTestIdPrefix}
+              rowIndex={index + 1}
             />
           ))}
         </tbody>

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -1349,14 +1349,14 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1vi827b"
-          data-testid="ictinus_row_0_cell_1"
+          data-testid="ictinus_table_row_0_cell_1"
         >
           topLeftText
         </td>
         <td
           className="css-b5djha"
           colSpan={3}
-          data-testid="ictinus_row_0_cell_2"
+          data-testid="ictinus_table_row_0_cell_2"
         >
           <div>
             <div>
@@ -1408,7 +1408,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_1_cell_1"
+          data-testid="ictinus_table_row_1_cell_1"
         >
           <span
             data-column="Title"
@@ -1418,7 +1418,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_1_cell_2"
+          data-testid="ictinus_table_row_1_cell_2"
         >
           <span
             data-column="Name"
@@ -1428,7 +1428,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_1_cell_3"
+          data-testid="ictinus_table_row_1_cell_3"
         >
           <span
             data-column="Surname"
@@ -1438,7 +1438,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_1_cell_4"
+          data-testid="ictinus_table_row_1_cell_4"
         >
           <span
             data-column="Age"
@@ -1453,7 +1453,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_2_cell_1"
+          data-testid="ictinus_table_row_2_cell_1"
         >
           <span
             data-column="Title"
@@ -1463,7 +1463,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_2_cell_2"
+          data-testid="ictinus_table_row_2_cell_2"
         >
           <span
             data-column="Name"
@@ -1473,7 +1473,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_2_cell_3"
+          data-testid="ictinus_table_row_2_cell_3"
         >
           <span
             data-column="Surname"
@@ -1483,7 +1483,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_2_cell_4"
+          data-testid="ictinus_table_row_2_cell_4"
         >
           <span
             data-column="Age"
@@ -1498,7 +1498,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_3_cell_1"
+          data-testid="ictinus_table_row_3_cell_1"
         >
           <span
             data-column="Title"
@@ -1508,7 +1508,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_3_cell_2"
+          data-testid="ictinus_table_row_3_cell_2"
         >
           <span
             data-column="Name"
@@ -1518,7 +1518,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_3_cell_3"
+          data-testid="ictinus_table_row_3_cell_3"
         >
           <span
             data-column="Surname"
@@ -1528,7 +1528,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_3_cell_4"
+          data-testid="ictinus_table_row_3_cell_4"
         >
           <span
             data-column="Age"
@@ -1543,7 +1543,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_4_cell_1"
+          data-testid="ictinus_table_row_4_cell_1"
         >
           <span
             data-column="Title"
@@ -1553,7 +1553,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_4_cell_2"
+          data-testid="ictinus_table_row_4_cell_2"
         >
           <span
             data-column="Name"
@@ -1563,7 +1563,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_4_cell_3"
+          data-testid="ictinus_table_row_4_cell_3"
         >
           <span
             data-column="Surname"
@@ -1573,7 +1573,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_4_cell_4"
+          data-testid="ictinus_table_row_4_cell_4"
         >
           <span
             data-column="Age"
@@ -1588,7 +1588,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_5_cell_1"
+          data-testid="ictinus_table_row_5_cell_1"
         >
           <span
             data-column="Title"
@@ -1598,7 +1598,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_5_cell_2"
+          data-testid="ictinus_table_row_5_cell_2"
         >
           <span
             data-column="Name"
@@ -1608,7 +1608,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_5_cell_3"
+          data-testid="ictinus_table_row_5_cell_3"
         >
           <span
             data-column="Surname"
@@ -1618,7 +1618,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_5_cell_4"
+          data-testid="ictinus_table_row_5_cell_4"
         >
           <span
             data-column="Age"
@@ -1633,7 +1633,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_6_cell_1"
+          data-testid="ictinus_table_row_6_cell_1"
         >
           <span
             data-column="Title"
@@ -1643,7 +1643,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_6_cell_2"
+          data-testid="ictinus_table_row_6_cell_2"
         >
           <span
             data-column="Name"
@@ -1653,7 +1653,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_6_cell_3"
+          data-testid="ictinus_table_row_6_cell_3"
         >
           <span
             data-column="Surname"
@@ -1663,7 +1663,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_6_cell_4"
+          data-testid="ictinus_table_row_6_cell_4"
         >
           <span
             data-column="Age"
@@ -1678,7 +1678,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_7_cell_1"
+          data-testid="ictinus_table_row_7_cell_1"
         >
           <span
             data-column="Title"
@@ -1688,7 +1688,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_7_cell_2"
+          data-testid="ictinus_table_row_7_cell_2"
         >
           <span
             data-column="Name"
@@ -1698,7 +1698,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_7_cell_3"
+          data-testid="ictinus_table_row_7_cell_3"
         >
           <span
             data-column="Surname"
@@ -1708,7 +1708,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_7_cell_4"
+          data-testid="ictinus_table_row_7_cell_4"
         >
           <span
             data-column="Age"
@@ -1723,7 +1723,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_8_cell_1"
+          data-testid="ictinus_table_row_8_cell_1"
         >
           <span
             data-column="Title"
@@ -1733,7 +1733,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_8_cell_2"
+          data-testid="ictinus_table_row_8_cell_2"
         >
           <span
             data-column="Name"
@@ -1743,7 +1743,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
-          data-testid="ictinus_row_8_cell_3"
+          data-testid="ictinus_table_row_8_cell_3"
         >
           <span
             data-column="Surname"
@@ -1753,7 +1753,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
-          data-testid="ictinus_row_8_cell_4"
+          data-testid="ictinus_table_row_8_cell_4"
         >
           <span
             data-column="Age"
@@ -1874,7 +1874,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_1_cell_undefined"
+          data-testid="table_row_1"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2025,7 +2025,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_2_cell_undefined"
+          data-testid="table_row_2"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2176,7 +2176,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_3_cell_undefined"
+          data-testid="table_row_3"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2327,7 +2327,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_4_cell_undefined"
+          data-testid="table_row_4"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2478,7 +2478,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_5_cell_undefined"
+          data-testid="table_row_5"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2629,7 +2629,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_6_cell_undefined"
+          data-testid="table_row_6"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2780,7 +2780,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_7_cell_undefined"
+          data-testid="table_row_7"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2931,7 +2931,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_8_cell_undefined"
+          data-testid="table_row_8"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3082,7 +3082,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_9_cell_undefined"
+          data-testid="table_row_9"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3233,7 +3233,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_10_cell_undefined"
+          data-testid="table_row_10"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3384,7 +3384,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_11_cell_undefined"
+          data-testid="table_row_11"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3535,7 +3535,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_12_cell_undefined"
+          data-testid="table_row_12"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3686,7 +3686,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_13_cell_undefined"
+          data-testid="table_row_13"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3837,7 +3837,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_14_cell_undefined"
+          data-testid="table_row_14"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3988,7 +3988,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_15_cell_undefined"
+          data-testid="table_row_15"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4139,7 +4139,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_16_cell_undefined"
+          data-testid="table_row_16"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4290,7 +4290,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_17_cell_undefined"
+          data-testid="table_row_17"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4441,7 +4441,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_18_cell_undefined"
+          data-testid="table_row_18"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4592,7 +4592,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_19_cell_undefined"
+          data-testid="table_row_19"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4743,7 +4743,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_20_cell_undefined"
+          data-testid="table_row_20"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4894,7 +4894,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_21_cell_undefined"
+          data-testid="table_row_21"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5045,7 +5045,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_22_cell_undefined"
+          data-testid="table_row_22"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5196,7 +5196,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_23_cell_undefined"
+          data-testid="table_row_23"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5347,7 +5347,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_24_cell_undefined"
+          data-testid="table_row_24"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5498,7 +5498,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_25_cell_undefined"
+          data-testid="table_row_25"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5649,7 +5649,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_26_cell_undefined"
+          data-testid="table_row_26"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5800,7 +5800,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_27_cell_undefined"
+          data-testid="table_row_27"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5951,7 +5951,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_28_cell_undefined"
+          data-testid="table_row_28"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6102,7 +6102,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_29_cell_undefined"
+          data-testid="table_row_29"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6253,7 +6253,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_30_cell_undefined"
+          data-testid="table_row_30"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6404,7 +6404,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_31_cell_undefined"
+          data-testid="table_row_31"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6555,7 +6555,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_32_cell_undefined"
+          data-testid="table_row_32"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6706,7 +6706,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_33_cell_undefined"
+          data-testid="table_row_33"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6857,7 +6857,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_34_cell_undefined"
+          data-testid="table_row_34"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7008,7 +7008,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_35_cell_undefined"
+          data-testid="table_row_35"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7159,7 +7159,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_36_cell_undefined"
+          data-testid="table_row_36"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7310,7 +7310,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_37_cell_undefined"
+          data-testid="table_row_37"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7461,7 +7461,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_38_cell_undefined"
+          data-testid="table_row_38"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7612,7 +7612,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_39_cell_undefined"
+          data-testid="table_row_39"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7763,7 +7763,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_40_cell_undefined"
+          data-testid="table_row_40"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7914,7 +7914,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_41_cell_undefined"
+          data-testid="table_row_41"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8065,7 +8065,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_42_cell_undefined"
+          data-testid="table_row_42"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8216,7 +8216,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_43_cell_undefined"
+          data-testid="table_row_43"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8367,7 +8367,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_44_cell_undefined"
+          data-testid="table_row_44"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8518,7 +8518,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_45_cell_undefined"
+          data-testid="table_row_45"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8669,7 +8669,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_46_cell_undefined"
+          data-testid="table_row_46"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8820,7 +8820,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_47_cell_undefined"
+          data-testid="table_row_47"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8971,7 +8971,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_48_cell_undefined"
+          data-testid="table_row_48"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -9122,7 +9122,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_49_cell_undefined"
+          data-testid="table_row_49"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -9273,7 +9273,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
-          data-testid="table_row_50_cell_undefined"
+          data-testid="table_row_50"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -42,6 +42,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       >
         <th
           className="css-1uwwufr"
+          data-testid="table_row_0_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -76,12 +77,14 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </th>
         <td
           className="css-1vi827b"
+          data-testid="table_row_0_cell_1"
         >
           topLeftText
         </td>
         <td
           className="css-b5djha"
           colSpan={3}
+          data-testid="table_row_0_cell_2"
         >
           <div>
             <div>
@@ -105,21 +108,25 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         />
         <th
           className="css-12rmf8a"
+          data-testid="table_header_title"
         >
           Title
         </th>
         <th
           className="css-12rmf8a"
+          data-testid="table_header_name"
         >
           Name
         </th>
         <th
           className="css-12rmf8a"
+          data-testid="table_header_surname"
         >
           Surname
         </th>
         <th
           className="css-1f3ahyp"
+          data-testid="table_header_age"
         >
           Age
         </th>
@@ -132,6 +139,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       >
         <th
           className="css-1uwwufr"
+          data-testid="table_row_1_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -166,6 +174,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_1_cell_1"
         >
           <span
             data-column="Title"
@@ -175,6 +184,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_1_cell_2"
         >
           <span
             data-column="Name"
@@ -184,6 +194,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_1_cell_3"
         >
           <span
             data-column="Surname"
@@ -193,6 +204,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_1_cell_4"
         >
           <span
             data-column="Age"
@@ -207,6 +219,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       >
         <th
           className="css-1uwwufr"
+          data-testid="table_row_2_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -241,6 +254,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_2_cell_1"
         >
           <span
             data-column="Title"
@@ -250,6 +264,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_2_cell_2"
         >
           <span
             data-column="Name"
@@ -259,6 +274,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_2_cell_3"
         >
           <span
             data-column="Surname"
@@ -268,6 +284,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_2_cell_4"
         >
           <span
             data-column="Age"
@@ -282,6 +299,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       >
         <th
           className="css-1uwwufr"
+          data-testid="table_row_3_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -316,6 +334,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_3_cell_1"
         >
           <span
             data-column="Title"
@@ -325,6 +344,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_3_cell_2"
         >
           <span
             data-column="Name"
@@ -334,6 +354,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_3_cell_3"
         >
           <span
             data-column="Surname"
@@ -343,6 +364,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_3_cell_4"
         >
           <span
             data-column="Age"
@@ -357,6 +379,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
       >
         <th
           className="css-1uwwufr"
+          data-testid="table_row_4_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -391,6 +414,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_4_cell_1"
         >
           <span
             data-column="Title"
@@ -401,6 +425,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         <td
           className="css-1myytz"
           colSpan={2}
+          data-testid="table_row_4_cell_2"
         >
           <span
             data-column="Name"
@@ -410,6 +435,7 @@ exports[`Storyshots Design System/Table Financial Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_4_cell_3"
         >
           <span
             data-column="Surname"
@@ -465,6 +491,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_0_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -499,12 +526,14 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1vi827b"
+          data-testid="table_row_0_cell_1"
         >
           topLeftText
         </td>
         <td
           className="css-b5djha"
           colSpan={3}
+          data-testid="table_row_0_cell_2"
         >
           <div>
             <div>
@@ -528,21 +557,25 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         />
         <th
           className="css-1fsvmxo"
+          data-testid="table_header_title"
         >
           Title
         </th>
         <th
           className="css-1fsvmxo"
+          data-testid="table_header_name"
         >
           Name
         </th>
         <th
           className="css-1fsvmxo"
+          data-testid="table_header_surname"
         >
           Surname
         </th>
         <th
           className="css-aytjtt"
+          data-testid="table_header_age"
         >
           Age
         </th>
@@ -555,6 +588,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_1_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -589,6 +623,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_1_cell_1"
         >
           <span
             data-column="Title"
@@ -598,6 +633,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_1_cell_2"
         >
           <span
             data-column="Name"
@@ -607,6 +643,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_1_cell_3"
         >
           <span
             data-column="Surname"
@@ -616,6 +653,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_1_cell_4"
         >
           <span
             data-column="Age"
@@ -630,6 +668,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_2_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -664,6 +703,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_2_cell_1"
         >
           <span
             data-column="Title"
@@ -673,6 +713,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_2_cell_2"
         >
           <span
             data-column="Name"
@@ -682,6 +723,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_2_cell_3"
         >
           <span
             data-column="Surname"
@@ -691,6 +733,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_2_cell_4"
         >
           <span
             data-column="Age"
@@ -705,6 +748,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_3_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -739,6 +783,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_3_cell_1"
         >
           <span
             data-column="Title"
@@ -748,6 +793,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_3_cell_2"
         >
           <span
             data-column="Name"
@@ -757,6 +803,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_3_cell_3"
         >
           <span
             data-column="Surname"
@@ -766,6 +813,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_3_cell_4"
         >
           <span
             data-column="Age"
@@ -780,6 +828,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_4_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -814,6 +863,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_4_cell_1"
         >
           <span
             data-column="Title"
@@ -823,6 +873,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_4_cell_2"
         >
           <span
             data-column="Name"
@@ -832,6 +883,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_4_cell_3"
         >
           <span
             data-column="Surname"
@@ -841,6 +893,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_4_cell_4"
         >
           <span
             data-column="Age"
@@ -855,6 +908,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_5_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -889,6 +943,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_5_cell_1"
         >
           <span
             data-column="Title"
@@ -898,6 +953,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_5_cell_2"
         >
           <span
             data-column="Name"
@@ -907,6 +963,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_5_cell_3"
         >
           <span
             data-column="Surname"
@@ -916,6 +973,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_5_cell_4"
         >
           <span
             data-column="Age"
@@ -930,6 +988,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_6_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -964,6 +1023,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_6_cell_1"
         >
           <span
             data-column="Title"
@@ -973,6 +1033,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_6_cell_2"
         >
           <span
             data-column="Name"
@@ -982,6 +1043,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_6_cell_3"
         >
           <span
             data-column="Surname"
@@ -991,6 +1053,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_6_cell_4"
         >
           <span
             data-column="Age"
@@ -1005,6 +1068,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_7_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -1039,6 +1103,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_7_cell_1"
         >
           <span
             data-column="Title"
@@ -1048,6 +1113,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_7_cell_2"
         >
           <span
             data-column="Name"
@@ -1057,6 +1123,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_7_cell_3"
         >
           <span
             data-column="Surname"
@@ -1066,6 +1133,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_7_cell_4"
         >
           <span
             data-column="Age"
@@ -1080,6 +1148,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_8_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -1114,6 +1183,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_8_cell_1"
         >
           <span
             data-column="Title"
@@ -1123,6 +1193,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_8_cell_2"
         >
           <span
             data-column="Name"
@@ -1132,6 +1203,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_8_cell_3"
         >
           <span
             data-column="Surname"
@@ -1141,6 +1213,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_8_cell_4"
         >
           <span
             data-column="Age"
@@ -1155,6 +1228,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
       >
         <th
           className="css-g3ttzj"
+          data-testid="table_row_9_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -1189,6 +1263,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </th>
         <td
           className="css-1myytz"
+          data-testid="table_row_9_cell_1"
         >
           <span
             data-column="Title"
@@ -1198,6 +1273,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="table_row_9_cell_2"
         >
           <span
             data-column="Name"
@@ -1207,6 +1283,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-13wcs4j"
+          data-testid="table_row_9_cell_3"
         >
           <span
             data-column="Surname"
@@ -1216,6 +1293,7 @@ exports[`Storyshots Design System/Table Fixed Header Table 1`] = `
         </td>
         <td
           className="css-1axpb9h"
+          data-testid="table_row_9_cell_4"
         >
           <span
             data-column="Age"
@@ -1271,12 +1349,14 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1vi827b"
+          data-testid="ictinus_row_0_cell_1"
         >
           topLeftText
         </td>
         <td
           className="css-b5djha"
           colSpan={3}
+          data-testid="ictinus_row_0_cell_2"
         >
           <div>
             <div>
@@ -1297,21 +1377,25 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <th
           className="css-12rmf8a"
+          data-testid="ictinus_table_header_title"
         >
           Title
         </th>
         <th
           className="css-12rmf8a"
+          data-testid="ictinus_table_header_name"
         >
           Name
         </th>
         <th
           className="css-12rmf8a"
+          data-testid="ictinus_table_header_surname"
         >
           Surname
         </th>
         <th
           className="css-1f3ahyp"
+          data-testid="ictinus_table_header_age"
         >
           Age
         </th>
@@ -1324,6 +1408,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_1_cell_1"
         >
           <span
             data-column="Title"
@@ -1333,6 +1418,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_1_cell_2"
         >
           <span
             data-column="Name"
@@ -1342,6 +1428,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_1_cell_3"
         >
           <span
             data-column="Surname"
@@ -1351,6 +1438,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_1_cell_4"
         >
           <span
             data-column="Age"
@@ -1365,6 +1453,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_2_cell_1"
         >
           <span
             data-column="Title"
@@ -1374,6 +1463,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_2_cell_2"
         >
           <span
             data-column="Name"
@@ -1383,6 +1473,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_2_cell_3"
         >
           <span
             data-column="Surname"
@@ -1392,6 +1483,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_2_cell_4"
         >
           <span
             data-column="Age"
@@ -1406,6 +1498,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_3_cell_1"
         >
           <span
             data-column="Title"
@@ -1415,6 +1508,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_3_cell_2"
         >
           <span
             data-column="Name"
@@ -1424,6 +1518,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_3_cell_3"
         >
           <span
             data-column="Surname"
@@ -1433,6 +1528,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_3_cell_4"
         >
           <span
             data-column="Age"
@@ -1447,6 +1543,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_4_cell_1"
         >
           <span
             data-column="Title"
@@ -1456,6 +1553,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_4_cell_2"
         >
           <span
             data-column="Name"
@@ -1465,6 +1563,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_4_cell_3"
         >
           <span
             data-column="Surname"
@@ -1474,6 +1573,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_4_cell_4"
         >
           <span
             data-column="Age"
@@ -1488,6 +1588,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_5_cell_1"
         >
           <span
             data-column="Title"
@@ -1497,6 +1598,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_5_cell_2"
         >
           <span
             data-column="Name"
@@ -1506,6 +1608,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_5_cell_3"
         >
           <span
             data-column="Surname"
@@ -1515,6 +1618,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_5_cell_4"
         >
           <span
             data-column="Age"
@@ -1529,6 +1633,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_6_cell_1"
         >
           <span
             data-column="Title"
@@ -1538,6 +1643,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_6_cell_2"
         >
           <span
             data-column="Name"
@@ -1547,6 +1653,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_6_cell_3"
         >
           <span
             data-column="Surname"
@@ -1556,6 +1663,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_6_cell_4"
         >
           <span
             data-column="Age"
@@ -1570,6 +1678,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_7_cell_1"
         >
           <span
             data-column="Title"
@@ -1579,6 +1688,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_7_cell_2"
         >
           <span
             data-column="Name"
@@ -1588,6 +1698,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_7_cell_3"
         >
           <span
             data-column="Surname"
@@ -1597,6 +1708,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_7_cell_4"
         >
           <span
             data-column="Age"
@@ -1611,6 +1723,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
       >
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_8_cell_1"
         >
           <span
             data-column="Title"
@@ -1620,6 +1733,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_8_cell_2"
         >
           <span
             data-column="Name"
@@ -1629,6 +1743,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-1myytz"
+          data-testid="ictinus_row_8_cell_3"
         >
           <span
             data-column="Surname"
@@ -1638,6 +1753,7 @@ exports[`Storyshots Design System/Table Regular Table with simple rows 1`] = `
         </td>
         <td
           className="css-2hnjbj"
+          data-testid="ictinus_row_8_cell_4"
         >
           <span
             data-column="Age"
@@ -1693,6 +1809,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
       >
         <th
           className="css-1uwwufr"
+          data-testid="table_row_0_cell_0"
         >
           <span
             className="css-58ep04-CheckBox"
@@ -1727,12 +1844,14 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         </th>
         <td
           className="css-1vi827b"
+          data-testid="table_row_0_cell_1"
         >
           topLeftText
         </td>
         <td
           className="css-b5djha"
           colSpan={3}
+          data-testid="table_row_0_cell_2"
         >
           <div>
             <div>
@@ -1755,6 +1874,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_1_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -1769,6 +1889,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_1_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -1803,6 +1924,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_1_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1822,6 +1944,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_1_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1836,6 +1959,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_1_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1850,6 +1974,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_1_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1864,6 +1989,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_1_cell_5"
                   >
                     <div>
                       <div
@@ -1899,6 +2025,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_2_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -1913,6 +2040,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_2_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -1947,6 +2075,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_2_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1966,6 +2095,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_2_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1980,6 +2110,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_2_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -1994,6 +2125,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_2_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2008,6 +2140,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_2_cell_5"
                   >
                     <div>
                       <div
@@ -2043,6 +2176,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_3_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2057,6 +2191,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_3_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2091,6 +2226,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_3_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2110,6 +2246,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_3_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2124,6 +2261,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_3_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2138,6 +2276,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_3_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2152,6 +2291,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_3_cell_5"
                   >
                     <div>
                       <div
@@ -2187,6 +2327,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_4_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2201,6 +2342,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_4_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2235,6 +2377,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_4_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2254,6 +2397,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_4_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2268,6 +2412,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_4_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2282,6 +2427,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_4_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2296,6 +2442,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_4_cell_5"
                   >
                     <div>
                       <div
@@ -2331,6 +2478,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_5_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2345,6 +2493,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_5_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2379,6 +2528,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_5_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2398,6 +2548,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_5_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2412,6 +2563,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_5_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2426,6 +2578,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_5_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2440,6 +2593,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_5_cell_5"
                   >
                     <div>
                       <div
@@ -2475,6 +2629,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_6_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2489,6 +2644,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_6_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2523,6 +2679,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_6_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2542,6 +2699,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_6_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2556,6 +2714,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_6_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2570,6 +2729,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_6_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2584,6 +2744,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_6_cell_5"
                   >
                     <div>
                       <div
@@ -2619,6 +2780,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_7_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2633,6 +2795,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_7_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2667,6 +2830,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_7_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2686,6 +2850,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_7_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2700,6 +2865,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_7_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2714,6 +2880,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_7_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2728,6 +2895,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_7_cell_5"
                   >
                     <div>
                       <div
@@ -2763,6 +2931,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_8_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2777,6 +2946,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_8_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2811,6 +2981,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_8_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2830,6 +3001,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_8_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2844,6 +3016,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_8_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2858,6 +3031,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_8_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2872,6 +3046,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_8_cell_5"
                   >
                     <div>
                       <div
@@ -2907,6 +3082,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_9_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -2921,6 +3097,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_9_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -2955,6 +3132,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_9_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2974,6 +3152,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_9_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -2988,6 +3167,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_9_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3002,6 +3182,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_9_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3016,6 +3197,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_9_cell_5"
                   >
                     <div>
                       <div
@@ -3051,6 +3233,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_10_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3065,6 +3248,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_10_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3099,6 +3283,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_10_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3118,6 +3303,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_10_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3132,6 +3318,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_10_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3146,6 +3333,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_10_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3160,6 +3348,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_10_cell_5"
                   >
                     <div>
                       <div
@@ -3195,6 +3384,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_11_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3209,6 +3399,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_11_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3243,6 +3434,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_11_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3262,6 +3454,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_11_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3276,6 +3469,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_11_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3290,6 +3484,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_11_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3304,6 +3499,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_11_cell_5"
                   >
                     <div>
                       <div
@@ -3339,6 +3535,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_12_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3353,6 +3550,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_12_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3387,6 +3585,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_12_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3406,6 +3605,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_12_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3420,6 +3620,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_12_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3434,6 +3635,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_12_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3448,6 +3650,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_12_cell_5"
                   >
                     <div>
                       <div
@@ -3483,6 +3686,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_13_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3497,6 +3701,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_13_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3531,6 +3736,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_13_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3550,6 +3756,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_13_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3564,6 +3771,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_13_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3578,6 +3786,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_13_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3592,6 +3801,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_13_cell_5"
                   >
                     <div>
                       <div
@@ -3627,6 +3837,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_14_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3641,6 +3852,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_14_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3675,6 +3887,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_14_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3694,6 +3907,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_14_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3708,6 +3922,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_14_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3722,6 +3937,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_14_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3736,6 +3952,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_14_cell_5"
                   >
                     <div>
                       <div
@@ -3771,6 +3988,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_15_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3785,6 +4003,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_15_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3819,6 +4038,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_15_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3838,6 +4058,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_15_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3852,6 +4073,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_15_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3866,6 +4088,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_15_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3880,6 +4103,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_15_cell_5"
                   >
                     <div>
                       <div
@@ -3915,6 +4139,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_16_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -3929,6 +4154,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_16_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -3963,6 +4189,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_16_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3982,6 +4209,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_16_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -3996,6 +4224,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_16_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4010,6 +4239,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_16_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4024,6 +4254,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_16_cell_5"
                   >
                     <div>
                       <div
@@ -4059,6 +4290,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_17_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4073,6 +4305,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_17_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4107,6 +4340,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_17_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4126,6 +4360,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_17_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4140,6 +4375,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_17_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4154,6 +4390,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_17_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4168,6 +4405,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_17_cell_5"
                   >
                     <div>
                       <div
@@ -4203,6 +4441,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_18_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4217,6 +4456,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_18_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4251,6 +4491,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_18_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4270,6 +4511,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_18_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4284,6 +4526,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_18_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4298,6 +4541,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_18_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4312,6 +4556,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_18_cell_5"
                   >
                     <div>
                       <div
@@ -4347,6 +4592,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_19_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4361,6 +4607,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_19_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4395,6 +4642,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_19_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4414,6 +4662,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_19_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4428,6 +4677,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_19_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4442,6 +4692,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_19_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4456,6 +4707,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_19_cell_5"
                   >
                     <div>
                       <div
@@ -4491,6 +4743,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_20_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4505,6 +4758,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_20_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4539,6 +4793,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_20_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4558,6 +4813,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_20_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4572,6 +4828,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_20_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4586,6 +4843,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_20_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4600,6 +4858,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_20_cell_5"
                   >
                     <div>
                       <div
@@ -4635,6 +4894,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_21_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4649,6 +4909,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_21_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4683,6 +4944,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_21_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4702,6 +4964,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_21_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4716,6 +4979,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_21_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4730,6 +4994,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_21_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4744,6 +5009,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_21_cell_5"
                   >
                     <div>
                       <div
@@ -4779,6 +5045,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_22_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4793,6 +5060,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_22_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4827,6 +5095,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_22_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4846,6 +5115,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_22_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4860,6 +5130,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_22_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4874,6 +5145,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_22_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4888,6 +5160,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_22_cell_5"
                   >
                     <div>
                       <div
@@ -4923,6 +5196,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_23_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -4937,6 +5211,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_23_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -4971,6 +5246,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_23_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -4990,6 +5266,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_23_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5004,6 +5281,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_23_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5018,6 +5296,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_23_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5032,6 +5311,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_23_cell_5"
                   >
                     <div>
                       <div
@@ -5067,6 +5347,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_24_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5081,6 +5362,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_24_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5115,6 +5397,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_24_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5134,6 +5417,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_24_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5148,6 +5432,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_24_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5162,6 +5447,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_24_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5176,6 +5462,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_24_cell_5"
                   >
                     <div>
                       <div
@@ -5211,6 +5498,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_25_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5225,6 +5513,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_25_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5259,6 +5548,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_25_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5278,6 +5568,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_25_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5292,6 +5583,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_25_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5306,6 +5598,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_25_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5320,6 +5613,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_25_cell_5"
                   >
                     <div>
                       <div
@@ -5355,6 +5649,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_26_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5369,6 +5664,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_26_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5403,6 +5699,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_26_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5422,6 +5719,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_26_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5436,6 +5734,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_26_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5450,6 +5749,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_26_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5464,6 +5764,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_26_cell_5"
                   >
                     <div>
                       <div
@@ -5499,6 +5800,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_27_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5513,6 +5815,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_27_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5547,6 +5850,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_27_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5566,6 +5870,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_27_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5580,6 +5885,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_27_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5594,6 +5900,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_27_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5608,6 +5915,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_27_cell_5"
                   >
                     <div>
                       <div
@@ -5643,6 +5951,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_28_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5657,6 +5966,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_28_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5691,6 +6001,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_28_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5710,6 +6021,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_28_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5724,6 +6036,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_28_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5738,6 +6051,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_28_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5752,6 +6066,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_28_cell_5"
                   >
                     <div>
                       <div
@@ -5787,6 +6102,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_29_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5801,6 +6117,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_29_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5835,6 +6152,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_29_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5854,6 +6172,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_29_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5868,6 +6187,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_29_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5882,6 +6202,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_29_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5896,6 +6217,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_29_cell_5"
                   >
                     <div>
                       <div
@@ -5931,6 +6253,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_30_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -5945,6 +6268,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_30_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -5979,6 +6303,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_30_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -5998,6 +6323,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_30_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6012,6 +6338,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_30_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6026,6 +6353,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_30_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6040,6 +6368,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_30_cell_5"
                   >
                     <div>
                       <div
@@ -6075,6 +6404,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_31_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6089,6 +6419,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_31_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6123,6 +6454,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_31_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6142,6 +6474,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_31_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6156,6 +6489,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_31_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6170,6 +6504,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_31_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6184,6 +6519,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_31_cell_5"
                   >
                     <div>
                       <div
@@ -6219,6 +6555,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_32_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6233,6 +6570,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_32_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6267,6 +6605,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_32_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6286,6 +6625,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_32_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6300,6 +6640,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_32_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6314,6 +6655,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_32_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6328,6 +6670,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_32_cell_5"
                   >
                     <div>
                       <div
@@ -6363,6 +6706,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_33_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6377,6 +6721,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_33_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6411,6 +6756,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_33_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6430,6 +6776,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_33_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6444,6 +6791,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_33_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6458,6 +6806,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_33_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6472,6 +6821,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_33_cell_5"
                   >
                     <div>
                       <div
@@ -6507,6 +6857,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_34_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6521,6 +6872,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_34_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6555,6 +6907,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_34_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6574,6 +6927,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_34_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6588,6 +6942,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_34_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6602,6 +6957,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_34_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6616,6 +6972,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_34_cell_5"
                   >
                     <div>
                       <div
@@ -6651,6 +7008,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_35_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6665,6 +7023,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_35_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6699,6 +7058,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_35_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6718,6 +7078,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_35_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6732,6 +7093,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_35_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6746,6 +7108,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_35_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6760,6 +7123,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_35_cell_5"
                   >
                     <div>
                       <div
@@ -6795,6 +7159,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_36_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6809,6 +7174,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_36_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6843,6 +7209,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_36_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6862,6 +7229,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_36_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6876,6 +7244,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_36_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6890,6 +7259,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_36_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -6904,6 +7274,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_36_cell_5"
                   >
                     <div>
                       <div
@@ -6939,6 +7310,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_37_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -6953,6 +7325,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_37_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -6987,6 +7360,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_37_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7006,6 +7380,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_37_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7020,6 +7395,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_37_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7034,6 +7410,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_37_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7048,6 +7425,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_37_cell_5"
                   >
                     <div>
                       <div
@@ -7083,6 +7461,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_38_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7097,6 +7476,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_38_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7131,6 +7511,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_38_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7150,6 +7531,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_38_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7164,6 +7546,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_38_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7178,6 +7561,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_38_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7192,6 +7576,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_38_cell_5"
                   >
                     <div>
                       <div
@@ -7227,6 +7612,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_39_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7241,6 +7627,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_39_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7275,6 +7662,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_39_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7294,6 +7682,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_39_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7308,6 +7697,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_39_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7322,6 +7712,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_39_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7336,6 +7727,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_39_cell_5"
                   >
                     <div>
                       <div
@@ -7371,6 +7763,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_40_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7385,6 +7778,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_40_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7419,6 +7813,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_40_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7438,6 +7833,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_40_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7452,6 +7848,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_40_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7466,6 +7863,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_40_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7480,6 +7878,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_40_cell_5"
                   >
                     <div>
                       <div
@@ -7515,6 +7914,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_41_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7529,6 +7929,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_41_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7563,6 +7964,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_41_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7582,6 +7984,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_41_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7596,6 +7999,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_41_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7610,6 +8014,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_41_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7624,6 +8029,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_41_cell_5"
                   >
                     <div>
                       <div
@@ -7659,6 +8065,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_42_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7673,6 +8080,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_42_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7707,6 +8115,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_42_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7726,6 +8135,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_42_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7740,6 +8150,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_42_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7754,6 +8165,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_42_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7768,6 +8180,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_42_cell_5"
                   >
                     <div>
                       <div
@@ -7803,6 +8216,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_43_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7817,6 +8231,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_43_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7851,6 +8266,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_43_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7870,6 +8286,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_43_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7884,6 +8301,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_43_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7898,6 +8316,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_43_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -7912,6 +8331,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_43_cell_5"
                   >
                     <div>
                       <div
@@ -7947,6 +8367,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_44_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -7961,6 +8382,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_44_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -7995,6 +8417,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_44_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8014,6 +8437,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_44_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8028,6 +8452,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_44_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8042,6 +8467,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_44_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8056,6 +8482,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_44_cell_5"
                   >
                     <div>
                       <div
@@ -8091,6 +8518,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_45_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8105,6 +8533,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_45_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -8139,6 +8568,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_45_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8158,6 +8588,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_45_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8172,6 +8603,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_45_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8186,6 +8618,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_45_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8200,6 +8633,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_45_cell_5"
                   >
                     <div>
                       <div
@@ -8235,6 +8669,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_46_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8249,6 +8684,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_46_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -8283,6 +8719,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_46_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8302,6 +8739,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_46_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8316,6 +8754,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_46_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8330,6 +8769,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_46_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8344,6 +8784,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_46_cell_5"
                   >
                     <div>
                       <div
@@ -8379,6 +8820,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_47_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8393,6 +8835,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_47_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -8427,6 +8870,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_47_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8446,6 +8890,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_47_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8460,6 +8905,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_47_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8474,6 +8920,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_47_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8488,6 +8935,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_47_cell_5"
                   >
                     <div>
                       <div
@@ -8523,6 +8971,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_48_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8537,6 +8986,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_48_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -8571,6 +9021,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_48_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8590,6 +9041,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_48_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8604,6 +9056,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_48_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8618,6 +9071,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_48_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8632,6 +9086,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_48_cell_5"
                   >
                     <div>
                       <div
@@ -8667,6 +9122,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_49_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8681,6 +9137,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_49_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -8715,6 +9172,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_49_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8734,6 +9192,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_49_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8748,6 +9207,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_49_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8762,6 +9222,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_49_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8776,6 +9237,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_49_cell_5"
                   >
                     <div>
                       <div
@@ -8811,6 +9273,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
         <td
           className="css-saq876"
           colSpan={5}
+          data-testid="table_row_50_cell_undefined"
         >
           <div
             className="css-9khkz5-RenderRowOrNestedRow"
@@ -8825,6 +9288,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                 >
                   <th
                     className="css-1uwwufr"
+                    data-testid="table_row_50_cell_0"
                   >
                     <span
                       className="css-58ep04-CheckBox"
@@ -8859,6 +9323,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </th>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_50_cell_1"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8878,6 +9343,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_50_cell_2"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8892,6 +9358,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-1myytz"
+                    data-testid="table_row_50_cell_3"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8906,6 +9373,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-2hnjbj"
+                    data-testid="table_row_50_cell_4"
                   >
                     <div
                       className="css-1ne5ei5-ContentCell"
@@ -8920,6 +9388,7 @@ exports[`Storyshots Design System/Table Table with expandable rows 1`] = `
                   </td>
                   <td
                     className="css-15t9qts"
+                    data-testid="table_row_50_cell_5"
                   >
                     <div>
                       <div

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -18,9 +18,13 @@ const RenderRowWithCells = React.memo(
   ({
     checked = false,
     toggleChecked = () => {},
+    dataTestIdPrefix,
+    rowIndex,
   }: {
     checked?: boolean;
     toggleChecked?: () => void;
+    dataTestIdPrefix?: string;
+    rowIndex?: number;
   }) => {
     const {
       columnsHasNumberArr,
@@ -48,7 +52,15 @@ const RenderRowWithCells = React.memo(
         }
       >
         {onSelectionChangeExist && (
-          <TableCell component={'th'} sticky={fixedHeader} width={50} padded={padded}>
+          <TableCell
+            component={'th'}
+            sticky={fixedHeader}
+            width={50}
+            padded={padded}
+            dataTestIdPrefix={dataTestIdPrefix}
+            rowIndex={rowIndex}
+            index={0}
+          >
             <CheckBox dataTestIdSuffix={'row-check'} checked={isRowSelected} onClick={tChange} />
           </TableCell>
         )}
@@ -65,6 +77,9 @@ const RenderRowWithCells = React.memo(
             cellType={cellType}
             rowType={type}
             align={align}
+            dataTestIdPrefix={dataTestIdPrefix}
+            rowIndex={rowIndex}
+            index={index + 1}
           />
         ))}
 
@@ -72,6 +87,9 @@ const RenderRowWithCells = React.memo(
           isExpandedExists={isExpandedExists}
           checked={checked}
           toggleChecked={toggleChecked}
+          dataTestIdPrefix={dataTestIdPrefix}
+          rowIndex={rowIndex}
+          index={row.cells.length + 1}
         />
       </TableRow>
     );
@@ -79,7 +97,15 @@ const RenderRowWithCells = React.memo(
 );
 RenderRowWithCells.displayName = 'RenderRowWithCells';
 
-const RenderRowOrNestedRow = <T extends { [key: string]: unknown }>({ row }: { row: Row<T> }) => {
+const RenderRowOrNestedRow = <T extends { [key: string]: unknown }>({
+  row,
+  dataTestIdPrefix,
+  rowIndex,
+}: {
+  row: Row<T>;
+  dataTestIdPrefix?: string;
+  rowIndex?: number;
+}) => {
   const { isRowSelected, columnCount } = React.useContext(TableRowContext);
   const theme = useTheme();
   const { expanded } = row;
@@ -91,10 +117,15 @@ const RenderRowOrNestedRow = <T extends { [key: string]: unknown }>({ row }: { r
   return (
     <React.Fragment>
       {!expanded ? (
-        <RenderRowWithCells />
+        <RenderRowWithCells dataTestIdPrefix={dataTestIdPrefix} rowIndex={rowIndex} />
       ) : (
         <TableRow nested selected={isRowSelected}>
-          <TableCell colSpan={columnCount} padded={false}>
+          <TableCell
+            colSpan={columnCount}
+            padded={false}
+            dataTestIdPrefix={dataTestIdPrefix}
+            rowIndex={rowIndex}
+          >
             <div
               css={{
                 flex: 1,
@@ -105,11 +136,23 @@ const RenderRowOrNestedRow = <T extends { [key: string]: unknown }>({ row }: { r
             >
               <table css={tableStyle()()}>
                 <tbody>
-                  <RenderRowWithCells {...{ checked, toggleChecked }} />
+                  <RenderRowWithCells
+                    {...{ checked, toggleChecked }}
+                    dataTestIdPrefix={dataTestIdPrefix}
+                    rowIndex={rowIndex}
+                  />
                   {checked && (
                     <TableRow nested>
                       {/* colSpan is +1 because of the tableCell added for the arrow icon */}
-                      <TableCell colSpan={columnCount + 1}>{ExpandedComponent}</TableCell>
+
+                      <TableCell
+                        colSpan={columnCount + 1}
+                        dataTestIdPrefix={dataTestIdPrefix}
+                        rowIndex={rowIndex}
+                        index={'expanded'}
+                      >
+                        {ExpandedComponent}
+                      </TableCell>
                     </TableRow>
                   )}
                 </tbody>

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
@@ -18,6 +18,9 @@ type Props = {
   align?: 'left' | 'right';
   rowType: TableType;
   cellCounter: number;
+  dataTestIdPrefix?: string;
+  rowIndex?: number;
+  index?: number;
 };
 
 const ContentCell: React.FC<Props> = ({
@@ -31,6 +34,9 @@ const ContentCell: React.FC<Props> = ({
   cellType,
   align,
   cellCounter,
+  dataTestIdPrefix,
+  rowIndex,
+  index,
 }) => {
   const theme = useTheme();
 
@@ -41,6 +47,9 @@ const ContentCell: React.FC<Props> = ({
       type={cellType}
       padded={padded}
       width={columnsWithWidth[cellCounter] ? `${columnsWithWidth[cellCounter]}%` : 'initial'}
+      dataTestIdPrefix={dataTestIdPrefix}
+      rowIndex={rowIndex}
+      index={index}
     >
       {rowType === 'nested-header' && (
         <div

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ExpandedButtonCell/ExpandedButtonCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ExpandedButtonCell/ExpandedButtonCell.tsx
@@ -7,13 +7,27 @@ import TableCell from '../../../TableCell';
 import rem from 'polished/lib/helpers/rem';
 import Icon from '../../../../../Icon';
 
-type Props = { isExpandedExists: boolean; checked: boolean; toggleChecked: () => void };
+type Props = {
+  isExpandedExists: boolean;
+  checked: boolean;
+  toggleChecked: () => void;
+  dataTestIdPrefix?: string;
+  rowIndex?: number;
+  index?: number;
+};
 
-const ExpandedButtonCell: React.FC<Props> = ({ isExpandedExists, checked, toggleChecked }) => {
+const ExpandedButtonCell: React.FC<Props> = ({
+  isExpandedExists,
+  checked,
+  toggleChecked,
+  dataTestIdPrefix,
+  rowIndex,
+  index,
+}) => {
   const theme = useTheme();
 
   return isExpandedExists ? (
-    <TableCell width={67}>
+    <TableCell width={67} dataTestIdPrefix={dataTestIdPrefix} rowIndex={rowIndex} index={index}>
       <div>
         <div
           data-testid="expanded-button"
@@ -28,7 +42,7 @@ const ExpandedButtonCell: React.FC<Props> = ({ isExpandedExists, checked, toggle
             transition: '0.2s all ease-in-out',
             cursor: 'pointer',
           }}
-          onClick={e => {
+          onClick={(e) => {
             e.stopPropagation();
             toggleChecked();
           }}

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -36,12 +36,15 @@ const TableCell: React.FC<Props> = React.memo(
 
     const tableCellTestId = children
       ? component === 'th' && typeof children === 'string'
-        ? (dataTestIdPrefix ? dataTestIdPrefix + '_table_header_' : 'table_header_') +
-          children.split(' ').join('_').toLowerCase()
-        : (dataTestIdPrefix ? dataTestIdPrefix + '_row_' : 'table_row_') +
-          rowIndex +
-          '_cell_' +
-          index
+        ? (dataTestIdPrefix ? dataTestIdPrefix + '_' : '') +
+          'table_header_' +
+          children
+            .split(' ')
+            .join('_')
+            .toLowerCase()
+        : (dataTestIdPrefix ? dataTestIdPrefix + '_' : '') +
+          (rowIndex != undefined ? 'table_row_' + rowIndex : '') +
+          (index != undefined ? '_cell_' + index : '')
       : undefined;
 
     return (

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -12,6 +12,9 @@ type Props = {
   colSpan?: number;
   type?: 'financial' | 'normal';
   padded?: boolean;
+  dataTestIdPrefix?: string;
+  rowIndex?: number;
+  index?: number | string;
 };
 
 const TableCell: React.FC<Props> = React.memo(
@@ -24,9 +27,22 @@ const TableCell: React.FC<Props> = React.memo(
     children,
     type = 'normal',
     padded = false,
+    dataTestIdPrefix,
+    rowIndex,
+    index,
   }) => {
     const theme = useTheme();
     const Component = component;
+
+    const tableCellTestId = children
+      ? component === 'th' && typeof children === 'string'
+        ? (dataTestIdPrefix ? dataTestIdPrefix + '_table_header_' : 'table_header_') +
+          children.split(' ').join('_').toLowerCase()
+        : (dataTestIdPrefix ? dataTestIdPrefix + '_row_' : 'table_row_') +
+          rowIndex +
+          '_cell_' +
+          index
+      : undefined;
 
     return (
       <Component
@@ -57,6 +73,7 @@ const TableCell: React.FC<Props> = React.memo(
             borderLeft: `1px solid ${theme.utils.getColor('lightGray', 400)}`,
           },
         ]}
+        data-testid={tableCellTestId}
       >
         {children}
       </Component>

--- a/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
+++ b/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
@@ -19,6 +19,8 @@ type TableRowWrapperProps<T> = {
   fixedHeader: boolean;
   type: TableType;
   expanded: boolean;
+  dataTestIdPrefix?: string;
+  rowIndex?: number;
 };
 
 const TableRowWrapper = <T extends Record<string, unknown>>(props: TableRowWrapperProps<T>) => {
@@ -35,6 +37,8 @@ const TableRowWrapper = <T extends Record<string, unknown>>(props: TableRowWrapp
     columnCount,
     onSelectionChangeExist,
     expanded,
+    dataTestIdPrefix,
+    rowIndex,
   } = props;
 
   const tChange = React.useCallback(() => {
@@ -58,7 +62,7 @@ const TableRowWrapper = <T extends Record<string, unknown>>(props: TableRowWrapp
         bordered: !expanded,
       }}
     >
-      <RenderRowOrNestedRow<T> row={row} />
+      <RenderRowOrNestedRow<T> row={row} dataTestIdPrefix={dataTestIdPrefix} rowIndex={rowIndex} />
     </TableRowContext.Provider>
   );
 };


### PR DESCRIPTION
## Description

In this PR test-ids for all `th` and `td` table elements are added:

- `th` : test-id based on the column name (e.g.  column name `First Name` -> `table_header_first_name`)
- `td` : generic test-id with 2d indexing (row and column, e.g. `table_row_4_cell_2` )

Also the user can enter an optional dataTestIdPrefix (e.g. `cmo_table_header_first_name` or `cmo_table_row_4_cell_2`)


