### PR TITLE
fix(notification): add background color [DS-141]

### DIFF
--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -16,6 +16,7 @@ export const notificationsContainerPerType = (
   styleType === 'outlined'
     ? `
         border: ${rem(2)} solid ${typeToThemePalette(theme, type)};
+        background: white;
       `
     : `
         border-left: ${typeToThemePalette(theme, type)} 4px solid;


### PR DESCRIPTION
[DS-141]

The Notification component's background-color property defaults to `transparent`, when the `styleType` is `outlined`. This PR applies the `white` color to the `outlined` type, so that no overrides are needed in the clients that use it.

[DS-141]: https://orfium.atlassian.net/browse/DS-141