### PR TITLE
Feat/datepicker disabled dates

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -21,6 +21,9 @@ const dateFormatOptions = {
   'MMM D, YYYY': 'MMM D, YYYY',
   'ddd, MMM D, YYYY': 'ddd, MMM D, YYYY'
 }
+const disableDates = {
+    days: [mockDate.toDate(), mockDate.subtract(1, 'day').toDate() , mockDate.subtract(2, 'day').toDate(), mockDate.subtract(5, 'day').toDate()]
+}
 
 
 <Meta title="Design System/DatePicker" component={DatePicker} />
@@ -158,9 +161,11 @@ Some disable dates functionality
 
 <Preview>
   <Story name="DayPicker with disabled dates">
+  <Stack>
     <DatePicker
-      disableDates={{ daysOfWeek: [0, 6] }}
+      disableDates={disableDates}
     />
+    </Stack>
   </Story>
 </Preview>
 

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -5,12 +5,16 @@ import { currentDay } from './utils';
 import dayjs from 'dayjs';
 import Stack from '../storyUtils/Stack'; import OverlayComponent from './OverlayComponent';
 const mockDate = currentDay;
+const disableDates = {
+    days: [mockDate.toDate(), mockDate.subtract(1, 'day').toDate() , mockDate.subtract(2, 'day').toDate(), mockDate.subtract(4, 'day').toDate()]
+}
 const options = {
   'Disable days of week (only Monday)': { daysOfWeek: [0, 2, 3, 4, 5, 6] },
   'Disable dates after this day': { after: mockDate },
   'Disable dates before this day': { before: mockDate },
   'Disable dates before and after a date (-/+ 7 days)': { before: mockDate.subtract(7, 'day').toDate(), after: mockDate.add(7, 'day').toDate() },
   'Enable dates from/to a date (7 days)': { before: mockDate.subtract(7, 'day').toDate(), after: mockDate.add(7, 'day').toDate() },
+  'Array of disabled dates(Today, last 2 days, and the 4th day to today)': disableDates
 }
 const dateFormatOptions = {
   'Enables system\'s locale format' : undefined,
@@ -20,9 +24,6 @@ const dateFormatOptions = {
   'M/D/YYYY':  'M/D/YYYY',
   'MMM D, YYYY': 'MMM D, YYYY',
   'ddd, MMM D, YYYY': 'ddd, MMM D, YYYY'
-}
-const disableDates = {
-    days: [mockDate.toDate(), mockDate.subtract(1, 'day').toDate() , mockDate.subtract(2, 'day').toDate(), mockDate.subtract(5, 'day').toDate()]
 }
 
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import { currentDay, datepickerPropValue } from './utils';
 
 export type DisabledDates = {
   daysOfWeek?: number[];
+  days?: Date[];
   after?: Date;
   before?: Date;
 };

--- a/src/components/DatePicker/Month/Month.test.tsx
+++ b/src/components/DatePicker/Month/Month.test.tsx
@@ -40,10 +40,14 @@ describe('Month', () => {
       before: mockDate.subtract(1, 'day').toDate(),
       after: mockDate.add(1, 'day').toDate(),
     });
+    const disabledArray = calculateDisabledDays(day, month, year, {
+      days: [mockDate.subtract(1, 'day').toDate()],
+    });
 
     expect(disabledAfter).toBeTruthy();
     expect(disabledBefore).toBeTruthy();
     expect(disabledBeforeAndAfter).toBeFalsy();
+    expect(disabledArray).toBeFalsy();
   });
 
   it('should check calculatedDayIsBetween', () => {

--- a/src/components/DatePicker/Month/Month.utils.ts
+++ b/src/components/DatePicker/Month/Month.utils.ts
@@ -27,6 +27,9 @@ export const calculateDisabledDays = (
   if (disabledDates?.daysOfWeek) {
     return disabledDates?.daysOfWeek.includes(date.day());
   }
+  if (disabledDates?.days) {
+    return Boolean(disabledDates?.days.find((cur) =>dayjs(cur).isSame(dayjs(date), 'day')));
+  }
 
   return false;
 };

--- a/src/components/DatePicker/Month/Month.utils.ts
+++ b/src/components/DatePicker/Month/Month.utils.ts
@@ -28,7 +28,7 @@ export const calculateDisabledDays = (
     return disabledDates?.daysOfWeek.includes(date.day());
   }
   if (disabledDates?.days) {
-    return Boolean(disabledDates?.days.find((cur) =>dayjs(cur).isSame(dayjs(date), 'day')));
+    return Boolean(disabledDates?.days.find(cur => dayjs(cur).isSame(dayjs(date), 'day')));
   }
 
   return false;

--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -4142,48 +4142,60 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
     </button>
   </div>
   <div
-    role="button"
+    className="css-ptimel-Stack"
   >
     <div
-      className="css-qxwdtl-PositionInScreen"
+      style={
+        Object {
+          "margin": 5,
+        }
+      }
     >
       <div
-        className="css-d6j72o"
+        role="button"
       >
         <div
-          className="css-o66dxn-TextInputWrapper"
+          className="css-qxwdtl-PositionInScreen"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-d6j72o"
           >
             <div
-              className="css-1il6azq-TextInputWrapper"
+              className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-1u4znjd"
+                className="css-hpo279-TextInputWrapper"
               >
-                <input
-                  className="css-g6bat3"
-                  disabled={false}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  placeholder="MM/DD/YYYY "
-                  required={false}
-                  value="11/03/2020"
-                />
-              </div>
-              <div
-                className="css-bhexrx-IconWrapper"
-              >
-                <span
-                  className="css-1gnbc76-Icon"
-                  onClick={[Function]}
+                <div
+                  className="css-1il6azq-TextInputWrapper"
                 >
-                  <span
-                    className="css-137pzfe-Icon"
-                  />
-                </span>
+                  <div
+                    className="css-1u4znjd"
+                  >
+                    <input
+                      className="css-g6bat3"
+                      disabled={false}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      placeholder="MM/DD/YYYY "
+                      required={false}
+                      value="11/03/2020"
+                    />
+                  </div>
+                  <div
+                    className="css-bhexrx-IconWrapper"
+                  >
+                    <span
+                      className="css-1gnbc76-Icon"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="css-137pzfe-Icon"
+                      />
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/utils/PositionInScreen/PositionInScreen.tsx
+++ b/src/components/utils/PositionInScreen/PositionInScreen.tsx
@@ -31,6 +31,9 @@ const usePositionInScreen = (
 
     if (itemYOutOfScreenHeight) {
       itemY -= height;
+      if (itemY < 0) {
+        itemY = 0;
+      }
     } else {
       itemY += parrentOffsetHeight;
     }


### PR DESCRIPTION
## Description

In this PR we introduce again the functionality to calculate if the day of the calendar is disabled or not based on an array of dates. We had only have past/future dates and we are not comparing based on actual dates.

[Ticket](https://orfium.atlassian.net/browse/DS-140)

## Screenshot

![image](https://user-images.githubusercontent.com/28539607/118796100-f1bff000-b8a3-11eb-85a8-0596924b27d5.png)

## Test Plan

Updated stories and snapshots.

Tested `calculateDisabledDays` on new `disabledDates` props.