### PR TITLE
fix(select): on focus stroke issue

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -177,9 +177,9 @@ const Select = React.forwardRef<HTMLInputElement, Props & InputProps>(
             max-width: ${rem(620)};
             & > div:nth-of-type(1) > div {
               ${open &&
-                status != 'error' &&
+                status !== 'error' &&
                 `border: 2px solid ${theme.utils.getColor('lightGray', 400)};`}
-              ${open && status != 'error' && styleType == 'outlined' && `box-shadow: none;`}
+              ${open && status !== 'error' && styleType === 'outlined' && `box-shadow: none;`}
             }
           `}
         >

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -71,6 +71,7 @@ const Select = React.forwardRef<HTMLInputElement, Props & InputProps>(
       minCharactersToSearch = 0,
       highlightSearch = false,
       isSearchable = true,
+      styleType,
       dataTestId,
       ...restInputProps
     },
@@ -174,9 +175,14 @@ const Select = React.forwardRef<HTMLInputElement, Props & InputProps>(
             position: relative;
             min-width: ${rem(150)};
             max-width: ${rem(620)};
+            & > div:nth-of-type(1) > div {
+              ${open && `border: 2px solid ${theme.utils.getColor('lightGray', 400)};`}
+              ${open && styleType == 'outlined' && `box-shadow: none;`}
+            }
           `}
         >
           <TextField
+            styleType={styleType}
             onFocus={() => setOpen(true)}
             rightIcon={rightIconRender}
             onKeyDown={handleOnKeyDown}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -176,8 +176,10 @@ const Select = React.forwardRef<HTMLInputElement, Props & InputProps>(
             min-width: ${rem(150)};
             max-width: ${rem(620)};
             & > div:nth-of-type(1) > div {
-              ${open && `border: 2px solid ${theme.utils.getColor('lightGray', 400)};`}
-              ${open && styleType == 'outlined' && `box-shadow: none;`}
+              ${open &&
+                status != 'error' &&
+                `border: 2px solid ${theme.utils.getColor('lightGray', 400)};`}
+              ${open && status != 'error' && styleType == 'outlined' && `box-shadow: none;`}
             }
           `}
         >

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -39,7 +39,7 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
       role="button"
     >
       <div
-        className="css-17wyy39"
+        className="css-ual1e8"
       >
         <div
           className="css-o66dxn-TextInputWrapper"
@@ -138,7 +138,7 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
       role="button"
     >
       <div
-        className="css-17wyy39"
+        className="css-ual1e8"
       >
         <div
           className="css-o66dxn-TextInputWrapper"
@@ -244,7 +244,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -311,7 +311,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -378,7 +378,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -484,7 +484,7 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -590,7 +590,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -657,7 +657,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -763,7 +763,7 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -866,7 +866,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
       role="button"
     >
       <div
-        className="css-17wyy39"
+        className="css-ual1e8"
       >
         <div
           className="css-o66dxn-TextInputWrapper"
@@ -926,7 +926,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
     role="button"
   >
     <div
-      className="css-17wyy39"
+      className="css-ual1e8"
     >
       <div
         className="css-o66dxn-TextInputWrapper"
@@ -992,7 +992,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
       role="button"
     >
       <div
-        className="css-17wyy39"
+        className="css-ual1e8"
       >
         <div
           className="css-o66dxn-TextInputWrapper"
@@ -1097,7 +1097,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -1178,7 +1178,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -1243,7 +1243,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -1371,7 +1371,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
             role="button"
           >
             <div
-              className="css-17wyy39"
+              className="css-ual1e8"
             >
               <div
                 className="css-o66dxn-TextInputWrapper"
@@ -1451,7 +1451,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
             role="button"
           >
             <div
-              className="css-17wyy39"
+              className="css-ual1e8"
             >
               <div
                 className="css-o66dxn-TextInputWrapper"
@@ -1531,7 +1531,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
             role="button"
           >
             <div
-              className="css-17wyy39"
+              className="css-ual1e8"
             >
               <div
                 className="css-o66dxn-TextInputWrapper"
@@ -1623,7 +1623,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
             role="button"
           >
             <div
-              className="css-17wyy39"
+              className="css-ual1e8"
             >
               <div
                 className="css-o66dxn-TextInputWrapper"
@@ -1703,7 +1703,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
             role="button"
           >
             <div
-              className="css-17wyy39"
+              className="css-ual1e8"
             >
               <div
                 className="css-o66dxn-TextInputWrapper"
@@ -1783,7 +1783,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
             role="button"
           >
             <div
-              className="css-17wyy39"
+              className="css-ual1e8"
             >
               <div
                 className="css-o66dxn-TextInputWrapper"
@@ -1904,7 +1904,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -1971,7 +1971,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"
@@ -2038,7 +2038,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
         role="button"
       >
         <div
-          className="css-17wyy39"
+          className="css-ual1e8"
         >
           <div
             className="css-o66dxn-TextInputWrapper"


### PR DESCRIPTION
## Description

[DS-101](https://orfium.atlassian.net/browse/DS-101)

When the Select component is onFocus state the stroke style is not applied always. The stroke appears only if you click on the input field; if you click the downArrow icon the stroke is not applied. With this PR the stroke is applied in both cases (input field click or downArrow icon click)

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/57801353/119799441-bdbc7e80-bee4-11eb-8a96-6b01f00c8f53.gif)


### After


![after](https://user-images.githubusercontent.com/57801353/119799450-c01ed880-bee4-11eb-8b6e-164ea23a5429.gif)

