### PR TITLE
Feat/breadcrumb updates

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.style.ts
+++ b/src/components/Breadcrumb/Breadcrumb.style.ts
@@ -5,10 +5,10 @@ export const breadcrumbStyles = () => (theme: Theme) => css`
   display: flex;
   flex-wrap: nowrap;
   list-style: none;
-  padding: ${theme.spacing.md} 0;
+  padding: 0;
+  margin: 0;
 
   & > li {
-    padding: ${theme.spacing.md} 0;
     margin: auto;
   }
 `;

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.style.ts
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.style.ts
@@ -12,7 +12,7 @@ export const breadcrumbItemStyles = ({ active }: RequiredProperties<StyleProps>)
 ) => css`
   display: flex;
   cursor: default;
-  color: ${active ? theme.utils.getColor('darkGray', 400) : theme.utils.getColor('lightGray', 400)};
+  color: ${active ? theme.utils.getColor('darkGray', 400) : theme.utils.getColor('lightGray', 600)};
 
   & button {
     height: auto;

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.style.ts
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.style.ts
@@ -12,7 +12,8 @@ export const breadcrumbItemStyles = ({ active }: RequiredProperties<StyleProps>)
 ) => css`
   display: flex;
   cursor: default;
-  color: ${active ? theme.utils.getColor('darkGray', 400) : theme.utils.getColor('lightGray', 600)};
+  font-weight: ${active ? theme.typography.weights.medium : theme.typography.weights.regular};
+  color: ${active ? theme.palette.black : theme.utils.getColor('lightGray', 600)};
 
   & button {
     height: auto;

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
@@ -44,11 +44,11 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
     >
       <ol
         aria-label="Breadcrumb"
-        className="css-fih44h-Breadcrumb"
+        className="css-jayjlm-Breadcrumb"
       >
         <li>
           <div
-            className="css-1po3gjx-BreadcrumbItem"
+            className="css-1r93knd-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -111,7 +111,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
         </li>
         <li>
           <div
-            className="css-1po3gjx-BreadcrumbItem"
+            className="css-1r93knd-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -235,11 +235,11 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
         </button>
         <ol
           aria-label="Breadcrumb"
-          className="css-fih44h-Breadcrumb"
+          className="css-jayjlm-Breadcrumb"
         >
           <li>
             <div
-              className="css-1po3gjx-BreadcrumbItem"
+              className="css-1r93knd-BreadcrumbItem"
             >
               <a
                 className="css-kllbug"
@@ -302,7 +302,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
           </li>
           <li>
             <div
-              className="css-1po3gjx-BreadcrumbItem"
+              className="css-1r93knd-BreadcrumbItem"
             >
               <a
                 className="css-kllbug"
@@ -420,11 +420,11 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
     >
       <ol
         aria-label="Breadcrumb"
-        className="css-fih44h-Breadcrumb"
+        className="css-jayjlm-Breadcrumb"
       >
         <li>
           <div
-            className="css-1po3gjx-BreadcrumbItem"
+            className="css-1r93knd-BreadcrumbItem"
           >
             <div>
               First Level
@@ -445,7 +445,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
         </li>
         <li>
           <div
-            className="css-1po3gjx-BreadcrumbItem"
+            className="css-1r93knd-BreadcrumbItem"
           >
             <div>
               Second Level
@@ -523,11 +523,11 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
     >
       <ol
         aria-label="Breadcrumb"
-        className="css-fih44h-Breadcrumb"
+        className="css-jayjlm-Breadcrumb"
       >
         <li>
           <div
-            className="css-1po3gjx-BreadcrumbItem"
+            className="css-1r93knd-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -590,7 +590,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
         </li>
         <li>
           <div
-            className="css-1po3gjx-BreadcrumbItem"
+            className="css-1r93knd-BreadcrumbItem"
           >
             <a
               className="css-kllbug"

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
@@ -48,7 +48,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
       >
         <li>
           <div
-            className="css-1r93knd-BreadcrumbItem"
+            className="css-1fgfgne-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -111,7 +111,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
         </li>
         <li>
           <div
-            className="css-1r93knd-BreadcrumbItem"
+            className="css-1fgfgne-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -136,7 +136,7 @@ exports[`Storyshots Design System/Breadcrumb Advanced Breadcrumbs with options p
         </li>
         <li>
           <div
-            className="css-e8ptyq-BreadcrumbItem"
+            className="css-1jaqcwz-BreadcrumbItem"
           >
             <div
               role="button"
@@ -239,7 +239,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
         >
           <li>
             <div
-              className="css-1r93knd-BreadcrumbItem"
+              className="css-1fgfgne-BreadcrumbItem"
             >
               <a
                 className="css-kllbug"
@@ -302,7 +302,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
           </li>
           <li>
             <div
-              className="css-1r93knd-BreadcrumbItem"
+              className="css-1fgfgne-BreadcrumbItem"
             >
               <a
                 className="css-kllbug"
@@ -327,7 +327,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
           </li>
           <li>
             <div
-              className="css-e8ptyq-BreadcrumbItem"
+              className="css-1jaqcwz-BreadcrumbItem"
             >
               <div
                 role="button"
@@ -424,7 +424,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
       >
         <li>
           <div
-            className="css-1r93knd-BreadcrumbItem"
+            className="css-1fgfgne-BreadcrumbItem"
           >
             <div>
               First Level
@@ -445,7 +445,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
         </li>
         <li>
           <div
-            className="css-1r93knd-BreadcrumbItem"
+            className="css-1fgfgne-BreadcrumbItem"
           >
             <div>
               Second Level
@@ -466,7 +466,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
         </li>
         <li>
           <div
-            className="css-e8ptyq-BreadcrumbItem"
+            className="css-1jaqcwz-BreadcrumbItem"
           >
             <div>
               Third Level
@@ -527,7 +527,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
       >
         <li>
           <div
-            className="css-1r93knd-BreadcrumbItem"
+            className="css-1fgfgne-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -590,7 +590,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
         </li>
         <li>
           <div
-            className="css-1r93knd-BreadcrumbItem"
+            className="css-1fgfgne-BreadcrumbItem"
           >
             <a
               className="css-kllbug"
@@ -615,7 +615,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs with options 1`]
         </li>
         <li>
           <div
-            className="css-e8ptyq-BreadcrumbItem"
+            className="css-1jaqcwz-BreadcrumbItem"
           >
             <a
               className="css-kllbug"


### PR DESCRIPTION
## Description

In this PR we make some fixes to the Breadcrumb component.

- Change color to make it accessible.
- Remove top and bottom paddings. Allow the user to decide the positioning of the Breadcrumb 

tickets: [DS-171](https://orfium.atlassian.net/browse/DS-171,  [DS-175](https://orfium.atlassian.net/browse/DS-175)

## Screenshot

![image](https://user-images.githubusercontent.com/28539607/120626354-41d5af80-c46b-11eb-8167-a0a37faf301d.png)

## Test Plan

No functionality changed or introduced. Updated snapshots.