### PR TITLE
refactor: old text bases and introduce button base

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -1,90 +1,6 @@
-import { rem, transparentize } from 'polished';
-
 import { Theme } from '../../theme';
-import { pickTextColorFromSwatches } from '../../theme/palette';
 import { RequiredProperties } from '../../utils/common';
-import { ColorShapeFromComponent } from '../../utils/themeFunctions';
 import { Props } from './Button';
-import { defineBackgroundColor, stateBackgroundColor } from './utils';
-
-/** Calculates the button specific height based on the size passed to it
- * These sizes are specific to this button thus these are placed here and not in the config **/
-export const heightBasedOnSize = (size: 'lg' | 'md' | 'sm') => {
-  switch (size) {
-    case 'lg':
-      return rem(56);
-    case 'sm':
-      return rem(36);
-    default:
-      return rem(46);
-  }
-};
-
-/** Calculates the button specific font size based on the size passed to it
- * These sizes are specific to this button thus these are placed here and not in the config **/
-const fontSizeBasedOnSize = (theme: Theme, size: 'lg' | 'md' | 'sm') => {
-  switch (size) {
-    case 'sm':
-      return theme.typography.fontSizes['14'];
-    default:
-      return theme.typography.fontSizes['16'];
-  }
-};
-
-export const buttonStyle = ({
-  type,
-  filled,
-  calculatedColor,
-  size,
-  iconExists,
-  disabled,
-  transparent,
-  childrenCount,
-}: RequiredProperties<
-  Props & {
-    calculatedColor: ColorShapeFromComponent;
-    iconExists: boolean;
-    childrenCount: number;
-  }
->) => (theme: Theme) => {
-  return {
-    fontSize: fontSizeBasedOnSize(theme, size),
-    color:
-      filled && !transparent
-        ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
-        : defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0),
-    backgroundColor:
-      filled && !transparent
-        ? defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0)
-        : 'transparent',
-    padding:
-      size === 'sm' || size === 'md'
-        ? `${theme.spacing.sm} ${theme.spacing.md}`
-        : `${theme.spacing.md} ${theme.spacing.lg}`,
-    height: heightBasedOnSize(size),
-    opacity: disabled ? 0.5 : 1,
-    borderRadius: theme.spacing.xsm,
-    border:
-      filled || transparent
-        ? 'none'
-        : `solid 1px ${transparentize(
-            0.5,
-            defineBackgroundColor(theme, calculatedColor, type, iconExists, childrenCount > 0)
-          )}`,
-    cursor: 'pointer',
-    transition: 'background-color 150ms linear',
-    ':hover': {
-      backgroundColor: !disabled
-        ? stateBackgroundColor(theme, 'hover', calculatedColor, filled && !transparent)
-        : undefined,
-    },
-    ':active': {
-      backgroundColor: !disabled
-        ? stateBackgroundColor(theme, 'active', calculatedColor, filled && !transparent)
-        : undefined,
-    },
-  };
-};
 
 export const buttonSpanStyle = () => () => {
   return {
@@ -101,7 +17,9 @@ export const childrenWrapperStyle = ({
   iconLeft,
   iconRight,
   hasChildren,
-}: RequiredProperties<Props & { hasChildren: boolean }>) => (theme: Theme) => {
+}: RequiredProperties<Omit<Props, 'isIconButton'> & { hasChildren: boolean }>) => (
+  theme: Theme
+) => {
   const rightIconExists = hasChildren && iconRight;
   const leftIconExists = hasChildren && iconLeft;
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,34 +1,11 @@
 import * as React from 'react';
 
-import { useTypeColorToColorMatch } from '../../hooks/useTypeColorToColorMatch';
 import { EventProps } from '../../utils/common';
-import { generateTestDataId } from '../../utils/helpers';
-import { AcceptedColorComponentTypes } from '../../utils/themeFunctions';
-import { TestId } from '../../utils/types';
-import { buttonSpanStyle, buttonStyle, childrenWrapperStyle, iconStyle } from './Button.style';
+import { TestProps } from '../../utils/types';
+import ButtonBase, { Props as ButtonBaseProps } from '../ButtonBase/ButtonBase';
+import { buttonSpanStyle, childrenWrapperStyle, iconStyle } from './Button.style';
 
-export type Props = {
-  /** Type indicating the type of the button */
-  type?: AcceptedColorComponentTypes;
-  /** the color of the button based on our colors eg. red-400 */
-  color?: string;
-  /** This property define the size of the button. Defaults to 'md' */
-  size?: 'lg' | 'md' | 'sm';
-  /** Property indicating if the component is filled with a color based on the type */
-  filled?: boolean;
-  /** Property indicating if the component is transparent with a color based on the type */
-  transparent?: boolean;
-  /** An optional icon to put on the right of the button */
-  iconRight?: React.Component | JSX.Element | null;
-  /** An optional icon to put on the left of the button */
-  iconLeft?: React.Component | JSX.Element | null;
-  /** Define if the button is in disabled state */
-  disabled?: boolean;
-};
-
-export type TestProps = {
-  dataTestId?: TestId;
-};
+export type Props = ButtonBaseProps;
 
 const Button: React.FC<Props & TestProps & EventProps> = props => {
   const {
@@ -41,34 +18,10 @@ const Button: React.FC<Props & TestProps & EventProps> = props => {
     iconRight = null,
     disabled = false,
     children,
-    dataTestId = '',
-    onClick,
-    onBlur,
   } = props;
 
-  const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
-  const calculatedColor = calculateColorBetweenColorAndType(color, type);
-
   return (
-    <button
-      data-testid={generateTestDataId('button', dataTestId)}
-      css={buttonStyle({
-        type,
-        filled,
-        size,
-        color,
-        transparent,
-        calculatedColor,
-        iconExists: Boolean(iconLeft || iconRight),
-        disabled,
-        iconLeft,
-        iconRight,
-        childrenCount: React.Children.count(children),
-      })}
-      onClick={onClick}
-      onBlur={onBlur}
-      disabled={disabled}
-    >
+    <ButtonBase {...props}>
       <span css={buttonSpanStyle()}>
         {iconLeft && <span css={iconStyle()}>{iconLeft}</span>}
         <span
@@ -89,7 +42,7 @@ const Button: React.FC<Props & TestProps & EventProps> = props => {
 
         {iconRight && <span css={iconStyle()}>{iconRight}</span>}
       </span>
-    </button>
+    </ButtonBase>
   );
 };
 

--- a/src/components/ButtonBase/ButtonBase.style.ts
+++ b/src/components/ButtonBase/ButtonBase.style.ts
@@ -1,0 +1,132 @@
+import { rem, transparentize } from 'polished';
+
+import { Theme } from '../../theme';
+import { pickTextColorFromSwatches } from '../../theme/palette';
+import { RequiredProperties } from '../../utils/common';
+import { ColorShapeFromComponent } from '../../utils/themeFunctions';
+import { Props } from './ButtonBase';
+import { defineBackgroundColor, stateBackgroundColor } from './utils';
+
+/** Calculates the button specific height based on the size passed to it
+ * These sizes are specific to this button thus these are placed here and not in the config **/
+export const heightBasedOnSize = (size: 'lg' | 'md' | 'sm') => {
+  switch (size) {
+    case 'lg':
+      return rem(56);
+    case 'sm':
+      return rem(36);
+    default:
+      return rem(46);
+  }
+};
+
+/** Calculates the button specific font size based on the size passed to it
+ * These sizes are specific to this button thus these are placed here and not in the config **/
+const fontSizeBasedOnSize = (theme: Theme, size: 'lg' | 'md' | 'sm') => {
+  switch (size) {
+    case 'sm':
+      return theme.typography.fontSizes['14'];
+    default:
+      return theme.typography.fontSizes['16'];
+  }
+};
+
+export const buttonBaseStyle = ({
+  type,
+  filled,
+  calculatedColor,
+  size,
+  iconLeft,
+  iconRight,
+  isIconButton,
+  disabled,
+  transparent,
+  childrenCount,
+}: RequiredProperties<
+  Props & {
+    calculatedColor: ColorShapeFromComponent;
+    childrenCount: number;
+  }
+>) => (theme: Theme) => {
+  const hasSupplementaryIcons = Boolean(iconLeft || iconRight);
+  const baseButtonStyles = {
+    fontSize: fontSizeBasedOnSize(theme, size),
+    color:
+      filled && !transparent
+        ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
+        : defineBackgroundColor(
+            theme,
+            calculatedColor,
+            type,
+            hasSupplementaryIcons,
+            childrenCount > 0
+          ),
+    backgroundColor:
+      filled && !transparent
+        ? defineBackgroundColor(
+            theme,
+            calculatedColor,
+            type,
+            hasSupplementaryIcons,
+            childrenCount > 0
+          )
+        : 'transparent',
+    padding:
+      size === 'sm' || size === 'md'
+        ? `${theme.spacing.sm} ${theme.spacing.md}`
+        : `${theme.spacing.md} ${theme.spacing.lg}`,
+    height: heightBasedOnSize(size),
+    opacity: disabled ? 0.5 : 1,
+    borderRadius: theme.spacing.xsm,
+    border:
+      filled || transparent
+        ? 'none'
+        : `solid 1px ${transparentize(
+            0.5,
+            defineBackgroundColor(
+              theme,
+              calculatedColor,
+              type,
+              hasSupplementaryIcons,
+              childrenCount > 0
+            )
+          )}`,
+    cursor: 'pointer',
+    transition: 'background-color 150ms linear',
+    ':hover': {
+      backgroundColor: !disabled
+        ? stateBackgroundColor(theme, 'hover', calculatedColor, filled && !transparent)
+        : undefined,
+    },
+    ':active': {
+      backgroundColor: !disabled
+        ? stateBackgroundColor(theme, 'active', calculatedColor, filled && !transparent)
+        : undefined,
+    },
+  };
+
+  if (isIconButton) {
+    return {
+      ...baseButtonStyles,
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: '100%',
+      padding: 0,
+      width: heightBasedOnSize(size),
+    };
+  }
+
+  return baseButtonStyles;
+};
+
+export const buttonSpanStyle = () => () => {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+  };
+};
+
+export const iconStyle = () => () => ({
+  display: 'inline-flex',
+});

--- a/src/components/ButtonBase/ButtonBase.tsx
+++ b/src/components/ButtonBase/ButtonBase.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { useTypeColorToColorMatch } from '../../hooks/useTypeColorToColorMatch';
+import { EventProps } from '../../utils/common';
+import { generateTestDataId } from '../../utils/helpers';
+import { AcceptedColorComponentTypes } from '../../utils/themeFunctions';
+import { TestProps } from '../../utils/types';
+import { buttonBaseStyle } from './ButtonBase.style';
+
+export type Props = {
+  /** Type indicating the type of the button */
+  type?: AcceptedColorComponentTypes;
+  /** the color of the button based on our colors eg. red-400 */
+  color?: string;
+  /** This property define the size of the button. Defaults to 'md' */
+  size?: 'lg' | 'md' | 'sm';
+  /** Property indicating if the component is filled with a color based on the type */
+  filled?: boolean;
+  /** Property indicating if the component is transparent with a color based on the type */
+  transparent?: boolean;
+  /** An optional boolean to show if the button is icon */
+  isIconButton?: boolean;
+  /** An optional icon to put on the right of the button */
+  iconRight?: React.Component | JSX.Element | null;
+  /** An optional icon to put on the left of the button */
+  iconLeft?: React.Component | JSX.Element | null;
+  /** Define if the button is in disabled state */
+  disabled?: boolean;
+};
+
+const ButtonBase: React.FC<Props & TestProps & EventProps> = props => {
+  const {
+    size = 'md',
+    type = 'primary',
+    color = '',
+    filled = true,
+    transparent = false,
+    isIconButton = false,
+    iconLeft = null,
+    iconRight = null,
+    disabled = false,
+    children,
+    dataTestId = '',
+    onClick,
+    onBlur,
+  } = props;
+
+  const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
+  const calculatedColor = calculateColorBetweenColorAndType(color, type);
+  const testIdName = `${isIconButton ? 'icon-' : ''}button`;
+
+  return (
+    <button
+      data-testid={generateTestDataId(testIdName, dataTestId)}
+      css={buttonBaseStyle({
+        type,
+        filled,
+        size,
+        color,
+        transparent,
+        calculatedColor,
+        isIconButton,
+        disabled,
+        iconLeft,
+        iconRight,
+        childrenCount: React.Children.count(children),
+      })}
+      onClick={onClick}
+      onBlur={onBlur}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default ButtonBase;

--- a/src/components/ButtonBase/index.ts
+++ b/src/components/ButtonBase/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ButtonBase';

--- a/src/components/ButtonBase/utils.ts
+++ b/src/components/ButtonBase/utils.ts
@@ -1,0 +1,56 @@
+import isEmpty from 'lodash/isEmpty';
+import { darken, lighten, transparentize } from 'polished';
+
+import { Theme } from '../../theme';
+import { mainTypes } from '../../theme/palette';
+import { ColorShapeFromComponent, getColorFromType } from '../../utils/themeFunctions';
+
+/**
+ * This function defines what background-color to show based on type or color passed
+ * if color it retrieves the color directly from the palette
+ * if type it gets the specific type color from the palette
+ */
+export const defineBackgroundColor = (
+  theme: Theme,
+  color: ColorShapeFromComponent | undefined,
+  type?: typeof mainTypes[number],
+  iconExists?: boolean,
+  childrenExists?: boolean
+): string => {
+  if (!childrenExists && iconExists) {
+    return 'transparent';
+  }
+
+  if (color && !isEmpty(color)) {
+    return theme.utils.getColor(color.color, color.shade);
+  }
+
+  if (childrenExists && type) {
+    return getColorFromType(type, theme);
+  }
+
+  return 'transparent';
+};
+
+/**
+ * return the correct color to show based on the state that is passed
+ * The state must be 'hover' or 'active' for now
+ * It is being defined by the team that the values will always be 10% and 20%
+ * for transparentize there is a revert to these values to match 90% and 80% accordingly
+ */
+export const stateBackgroundColor = (
+  theme: Theme,
+  state: 'hover' | 'active',
+  calculatedColor: ColorShapeFromComponent,
+  filled: boolean
+) => {
+  const value = state === 'hover' ? 0.1 : 0.2;
+  const color = defineBackgroundColor(theme, calculatedColor);
+
+  if (!filled) {
+    // value here is reverted to follow tranparentize e.g (1 - 0.1 = 0.9)
+    return transparentize(1 - value, color);
+  }
+
+  return calculatedColor.shade > 400 ? lighten(value, color) : darken(value, color);
+};

--- a/src/components/IconButton/IconButton.style.ts
+++ b/src/components/IconButton/IconButton.style.ts
@@ -2,19 +2,10 @@ import { Theme } from '../../theme';
 import { RequiredProperties } from '../../utils/common';
 import { ColorShapeFromComponent } from '../../utils/themeFunctions';
 import { Props } from '../Button/Button';
-import { buttonStyle, heightBasedOnSize } from '../Button/Button.style';
+import { buttonBaseStyle, heightBasedOnSize } from '../ButtonBase/ButtonBase.style';
 
 export const iconButtonStyle = ({
-  type,
-  filled,
-  transparent,
-  calculatedColor,
   size,
-  iconExists,
-  disabled,
-  color,
-  iconLeft,
-  iconRight,
 }: RequiredProperties<
   Props & {
     calculatedColor: ColorShapeFromComponent;
@@ -22,22 +13,7 @@ export const iconButtonStyle = ({
     childrenCount: number;
   }
 >) => (theme: Theme) => {
-  const baseButtonStyles = buttonStyle({
-    type,
-    filled,
-    size,
-    color,
-    calculatedColor,
-    iconExists,
-    transparent,
-    disabled,
-    iconLeft,
-    iconRight,
-    childrenCount: 1,
-  })(theme);
-
   return {
-    ...baseButtonStyles,
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -9,9 +9,8 @@ import { TestProps } from '../../utils/types';
 import { defineBackgroundColor } from '../Button/utils';
 import Icon from '../Icon';
 import { AcceptedIconNames } from '../Icon/types';
-import { iconButtonStyle } from './IconButton.style';
 
-export type Props = ButtonBaseProps & {
+export type Props = Omit<ButtonBaseProps, 'isIconButton' | 'iconLeft' | 'iconRight'> & {
   /** Property indicating the size of the icon. Defaults to 16 */
   iconSize?: number;
   /** This property defines witch icon to use */
@@ -19,7 +18,7 @@ export type Props = ButtonBaseProps & {
 };
 
 const IconButton: React.FC<Props & TestProps & EventProps> = props => {
-  const { iconSize, color = '', type = 'primary', filled = true, name, size } = props;
+  const { iconSize, color = '', type = 'primary', filled = true, name } = props;
   const theme = useTheme();
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const calculatedColor = calculateColorBetweenColorAndType(color, type);

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,53 +1,25 @@
+import ButtonBase, { Props as ButtonBaseProps } from 'components/ButtonBase/ButtonBase';
 import * as React from 'react';
 
 import { useTypeColorToColorMatch } from '../../hooks/useTypeColorToColorMatch';
 import { useTheme } from '../../index';
 import { pickTextColorFromSwatches } from '../../theme/palette';
 import { EventProps } from '../../utils/common';
-import { generateTestDataId } from '../../utils/helpers';
-import { AcceptedColorComponentTypes } from '../../utils/themeFunctions';
-import { TestId } from '../../utils/types';
+import { TestProps } from '../../utils/types';
 import { defineBackgroundColor } from '../Button/utils';
 import Icon from '../Icon';
 import { AcceptedIconNames } from '../Icon/types';
 import { iconButtonStyle } from './IconButton.style';
 
-export type Props = {
-  /** Type indicating the type of the button */
-  type?: AcceptedColorComponentTypes;
-  /** the color of the button based on our colors eg. red-400 */
-  color?: string;
+export type Props = ButtonBaseProps & {
   /** Property indicating the size of the icon. Defaults to 16 */
   iconSize?: number;
-  /** This property define the size of the button. Defaults to 'md' */
-  size?: 'lg' | 'md' | 'sm';
-  /** Property indicating if the component is filled with a color based on the type */
-  filled?: boolean;
-  /** Property indicating if the component is transparent with a color based on the type */
-  transparent?: boolean;
   /** This property defines witch icon to use */
   name: AcceptedIconNames;
-  /** Define if the button is in disabled state */
-  disabled?: boolean;
 };
 
-export type TestProps = {
-  dataTestId?: TestId;
-};
-
-const IconButton: React.FC<Props & TestProps & EventProps> = ({
-  size = 'md',
-  iconSize,
-  color = '',
-  type = 'primary',
-  filled = true,
-  name,
-  dataTestId = '',
-  onClick,
-  onBlur,
-  disabled = false,
-  transparent = false,
-}) => {
+const IconButton: React.FC<Props & TestProps & EventProps> = props => {
+  const { iconSize, color = '', type = 'primary', filled = true, name, size } = props;
   const theme = useTheme();
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const calculatedColor = calculateColorBetweenColorAndType(color, type);
@@ -56,28 +28,9 @@ const IconButton: React.FC<Props & TestProps & EventProps> = ({
     : defineBackgroundColor(theme, calculatedColor, type, true, true);
 
   return (
-    <button
-      data-testid={generateTestDataId('icon-button', dataTestId)}
-      css={iconButtonStyle({
-        type,
-        filled,
-        size,
-        color,
-        transparent,
-        calculatedColor,
-        iconExists: true,
-        disabled,
-        iconLeft: null,
-        iconRight: null,
-        childrenCount: 1,
-      })}
-      onClick={onClick}
-      onBlur={onBlur}
-      color={color}
-      disabled={disabled}
-    >
+    <ButtonBase {...props} isIconButton>
       <Icon name={name} color={iconColor} size={iconSize} />
-    </button>
+    </ButtonBase>
   );
 };
 

--- a/src/components/IconButton/__snapshots__/IconButton.stories.storyshot
+++ b/src/components/IconButton/__snapshots__/IconButton.stories.storyshot
@@ -119,7 +119,6 @@ exports[`Storyshots Design System/IconButton IconButton Playground 1`] = `
     >
       <button
         className="emotion-2"
-        color=""
         data-testid="icon-button"
         disabled={false}
       >
@@ -326,7 +325,6 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
     >
       <button
         className="emotion-2"
-        color=""
         data-testid="icon-button-size-lg"
         disabled={false}
       >
@@ -349,7 +347,6 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
     >
       <button
         className="emotion-5"
-        color=""
         data-testid="icon-button"
         disabled={false}
       >
@@ -372,7 +369,6 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
     >
       <button
         className="emotion-8"
-        color=""
         data-testid="icon-button"
         disabled={false}
       >
@@ -589,7 +585,6 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
     >
       <button
         className="emotion-2"
-        color=""
         data-testid="icon-button-size-lg"
         disabled={false}
       >
@@ -612,7 +607,6 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
     >
       <button
         className="emotion-5"
-        color=""
         data-testid="icon-button-size-lg"
         disabled={false}
       >
@@ -635,7 +629,6 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
     >
       <button
         className="emotion-8"
-        color=""
         data-testid="icon-button-size-lg"
         disabled={false}
       >

--- a/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
+++ b/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
@@ -146,7 +146,6 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
   >
     <button
       className="emotion-2"
-      color="neutralBlack-700"
       data-testid="icon-button"
       disabled={true}
       onClick={[Function]}
@@ -162,7 +161,6 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
     </button>
     <button
       className="emotion-2"
-      color="neutralBlack-700"
       data-testid="icon-button"
       disabled={true}
       onClick={[Function]}
@@ -184,7 +182,6 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
     </div>
     <button
       className="emotion-8"
-      color="neutralBlack-700"
       data-testid="icon-button"
       disabled={false}
       onClick={[Function]}
@@ -200,7 +197,6 @@ exports[`Storyshots Design System/Pagination Pagination 1`] = `
     </button>
     <button
       className="emotion-8"
-      color="neutralBlack-700"
       data-testid="icon-button"
       disabled={false}
       onClick={[Function]}
@@ -364,7 +360,6 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
   >
     <button
       className="emotion-2"
-      color="neutralBlack-700"
       data-testid="icon-button"
       disabled={true}
       onClick={[Function]}
@@ -386,7 +381,6 @@ exports[`Storyshots Design System/Pagination Pagination without all buttons 1`] 
     </div>
     <button
       className="emotion-5"
-      color="neutralBlack-700"
       data-testid="icon-button"
       disabled={false}
       onClick={[Function]}

--- a/src/components/TextArea/TextArea.style.ts
+++ b/src/components/TextArea/TextArea.style.ts
@@ -1,5 +1,5 @@
 import { css, SerializedStyles } from '@emotion/react';
-import { Props as TextInputWrapperProps } from 'components/TextInputBase/TextInputBase';
+import { Props as TextInputWrapperProps } from 'components/TextInputBase';
 
 import { Theme } from '../../theme';
 import { Props } from './TextArea';

--- a/src/components/TextArea/TextArea.style.ts
+++ b/src/components/TextArea/TextArea.style.ts
@@ -1,7 +1,7 @@
 import { css, SerializedStyles } from '@emotion/react';
+import { Props as TextInputWrapperProps } from 'components/TextInputBase/TextInputBase';
 
 import { Theme } from '../../theme';
-import { Props as TextInputWrapperProps } from '../utils/TextInputWrapper/TextInputWrapper';
 import { Props } from './TextArea';
 
 export const inputStyle = ({

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { formFieldStyles } from '../../theme/palette';
-import TextInputWrapper from '../utils/TextInputWrapper/TextInputWrapper';
+import TextInputBase from '../TextInputBase/TextInputBase';
 import { inputStyle } from './TextArea.style';
 
 export type Props = {
@@ -45,7 +45,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
 
   return (
     <React.Fragment>
-      <TextInputWrapper {...props}>
+      <TextInputBase {...props}>
         <div css={{ width: '100% ' }}>
           <textarea
             css={inputStyle({ placeholder, resizeEnabled })}
@@ -57,7 +57,7 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
             ref={ref}
           />
         </div>
-      </TextInputWrapper>
+      </TextInputBase>
     </React.Fragment>
   );
 });

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,7 +1,7 @@
 import { AcceptedIconNames } from 'components/Icon/types';
-import TextInputWrapper, {
+import TextInputBase, {
   Props as TextInputWrapperProps,
-} from 'components/utils/TextInputWrapper/TextInputWrapper';
+} from 'components/TextInputBase/TextInputBase';
 import useTheme from 'hooks/useTheme';
 import React, { FC, InputHTMLAttributes } from 'react';
 import { DEFAULT_SIZE } from 'utils/size-utils';
@@ -67,7 +67,7 @@ const TextField = React.forwardRef<HTMLInputElement, Props & InputProps>((props,
 
   return (
     <React.Fragment>
-      <TextInputWrapper {...props}>
+      <TextInputBase {...props}>
         {leftIcon && <IconWrapper iconPosition={'left'}>{getIcon(leftIcon)}</IconWrapper>}
         <div css={{ width: '100% ' }}>
           <input
@@ -103,7 +103,7 @@ const TextField = React.forwardRef<HTMLInputElement, Props & InputProps>((props,
             />
           </IconWrapper>
         )}
-      </TextInputWrapper>
+      </TextInputBase>
     </React.Fragment>
   );
 });

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,7 +1,5 @@
 import { AcceptedIconNames } from 'components/Icon/types';
-import TextInputBase, {
-  Props as TextInputWrapperProps,
-} from 'components/TextInputBase/TextInputBase';
+import TextInputBase, { Props as TextInputWrapperProps } from 'components/TextInputBase';
 import useTheme from 'hooks/useTheme';
 import React, { FC, InputHTMLAttributes } from 'react';
 import { DEFAULT_SIZE } from 'utils/size-utils';

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -3,7 +3,7 @@ import { darken, lighten, rem } from 'polished';
 import { Theme } from 'theme';
 import { DEFAULT_SIZE, getTextFieldSize } from 'utils/size-utils';
 
-import { Props } from './TextInputWrapper';
+import { Props } from './TextInputBase';
 
 const wrapperStyleSwitch = (
   theme: Theme,

--- a/src/components/TextInputBase/TextInputBase.tsx
+++ b/src/components/TextInputBase/TextInputBase.tsx
@@ -5,7 +5,7 @@ import React, { FC } from 'react';
 import { formFieldStyles } from 'theme/palette';
 import { DEFAULT_SIZE } from 'utils/size-utils';
 
-import { errorMsgStyle, textFieldStyle, wrapperStyle } from './TextInputWrapper.style';
+import { errorMsgStyle, textFieldStyle, wrapperStyle } from './TextInputBase.style';
 
 export type Props = {
   /** The label of the text field that will be used as a placeholder and a label */
@@ -40,7 +40,7 @@ export type Props = {
 
 /** This Component is a wrapper for all primitives that hold text like Select, TextArea, TextInput. Here we keep the
  * logic of all the hover, focus status etc and the styling of these centralized **/
-const TextInputWrapper: FC<Props> = ({
+const TextInputBase: FC<Props> = ({
   leftIcon = null,
   label,
   lean = false,
@@ -84,4 +84,4 @@ const TextInputWrapper: FC<Props> = ({
   );
 };
 
-export default TextInputWrapper;
+export default TextInputBase;

--- a/src/components/TextInputBase/index.ts
+++ b/src/components/TextInputBase/index.ts
@@ -1,0 +1,2 @@
+export * from './TextInputBase';
+export { default } from './TextInputBase';


### PR DESCRIPTION
## Description

In this PR i tried to simplify how we use bases on the system. I introduce the `ButtonBase` in order to use a single responsibility component for both of our Button and IconButton. 

Furthermore i moved the TextWrapper and use it as TextInputBase in order to much the previous logic.

Those components are going to be without the usual readme file for storybook.

## Test Plan

Secure all old snapshots are working without a problem
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
