### PR TITLE
[No-Jira] Feat/select area width fix

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -3475,7 +3475,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-71prqf-TextInputWrapper"
+                className="css-1wqyga6-TextInputWrapper"
               >
                 <div
                   className="css-19bjb4x-TextInputWrapper"
@@ -3533,7 +3533,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-71prqf-TextInputWrapper"
+                className="css-1wqyga6-TextInputWrapper"
               >
                 <div
                   className="css-1il6azq-TextInputWrapper"
@@ -3640,7 +3640,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                   className="css-o66dxn-TextInputWrapper"
                 >
                   <div
-                    className="css-hpo279-TextInputWrapper"
+                    className="css-20auem-TextInputWrapper"
                   >
                     <div
                       className="css-1il6azq-TextInputWrapper"
@@ -3698,7 +3698,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                   className="css-o66dxn-TextInputWrapper"
                 >
                   <div
-                    className="css-71prqf-TextInputWrapper"
+                    className="css-1wqyga6-TextInputWrapper"
                   >
                     <div
                       className="css-1il6azq-TextInputWrapper"
@@ -3756,7 +3756,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                   className="css-o66dxn-TextInputWrapper"
                 >
                   <div
-                    className="css-fpor5m-TextInputWrapper"
+                    className="css-1gozuy0-TextInputWrapper"
                   >
                     <div
                       className="css-1il6azq-TextInputWrapper"
@@ -3826,7 +3826,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                   className="css-o66dxn-TextInputWrapper"
                 >
                   <div
-                    className="css-8zmr6c-TextInputWrapper"
+                    className="css-whf5wf-TextInputWrapper"
                   >
                     <div
                       className="css-1il6azq-TextInputWrapper"
@@ -3897,7 +3897,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                   className="css-o66dxn-TextInputWrapper"
                 >
                   <div
-                    className="css-hpo279-TextInputWrapper"
+                    className="css-20auem-TextInputWrapper"
                   >
                     <div
                       className="css-1il6azq-TextInputWrapper"
@@ -4009,7 +4009,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-71prqf-TextInputWrapper"
+                className="css-1wqyga6-TextInputWrapper"
               >
                 <div
                   className="css-19bjb4x-TextInputWrapper"
@@ -4067,7 +4067,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-71prqf-TextInputWrapper"
+                className="css-1wqyga6-TextInputWrapper"
               >
                 <div
                   className="css-1il6azq-TextInputWrapper"
@@ -4164,7 +4164,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-hpo279-TextInputWrapper"
+                className="css-20auem-TextInputWrapper"
               >
                 <div
                   className="css-1il6azq-TextInputWrapper"
@@ -4251,7 +4251,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with predefined values 1`
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -4336,7 +4336,7 @@ exports[`Storyshots Design System/DatePicker Dynamic disableDates with all optio
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -146,7 +146,7 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -253,7 +253,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1p4z2la-TextInputWrapper"
+              className="css-yfhbt3-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -321,7 +321,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1e1zkk7-TextInputWrapper"
+              className="css-ydv4vx-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -389,7 +389,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-yklu5p-TextInputWrapper"
+              className="css-1j7sit7-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -496,7 +496,7 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-hpo279-TextInputWrapper"
+              className="css-20auem-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -603,7 +603,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-19bjb4x-TextInputWrapper"
@@ -671,7 +671,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -778,7 +778,7 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-hpo279-TextInputWrapper"
+              className="css-20auem-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -882,7 +882,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -943,7 +943,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-hpo279-TextInputWrapper"
+          className="css-20auem-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -1010,7 +1010,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -1116,7 +1116,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-19bjb4x-TextInputWrapper"
@@ -1198,7 +1198,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1264,7 +1264,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1393,7 +1393,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                 className="css-o66dxn-TextInputWrapper"
               >
                 <div
-                  className="css-8zmr6c-TextInputWrapper"
+                  className="css-whf5wf-TextInputWrapper"
                 >
                   <div
                     className="css-1il6azq-TextInputWrapper"
@@ -1474,7 +1474,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                 className="css-o66dxn-TextInputWrapper"
               >
                 <div
-                  className="css-alwr26-TextInputWrapper"
+                  className="css-1atk2z-TextInputWrapper"
                 >
                   <div
                     className="css-1il6azq-TextInputWrapper"
@@ -1555,7 +1555,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                 className="css-o66dxn-TextInputWrapper"
               >
                 <div
-                  className="css-1r0s33d-TextInputWrapper"
+                  className="css-18rfawf-TextInputWrapper"
                 >
                   <div
                     className="css-1il6azq-TextInputWrapper"
@@ -1648,7 +1648,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                 className="css-o66dxn-TextInputWrapper"
               >
                 <div
-                  className="css-hpo279-TextInputWrapper"
+                  className="css-20auem-TextInputWrapper"
                 >
                   <div
                     className="css-1il6azq-TextInputWrapper"
@@ -1729,7 +1729,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                 className="css-o66dxn-TextInputWrapper"
               >
                 <div
-                  className="css-71prqf-TextInputWrapper"
+                  className="css-1wqyga6-TextInputWrapper"
                 >
                   <div
                     className="css-1il6azq-TextInputWrapper"
@@ -1810,7 +1810,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                 className="css-o66dxn-TextInputWrapper"
               >
                 <div
-                  className="css-fpor5m-TextInputWrapper"
+                  className="css-1gozuy0-TextInputWrapper"
                 >
                   <div
                     className="css-1il6azq-TextInputWrapper"
@@ -1932,7 +1932,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-hpo279-TextInputWrapper"
+              className="css-20auem-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -2000,7 +2000,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -2068,7 +2068,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-fpor5m-TextInputWrapper"
+              className="css-1gozuy0-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"

--- a/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
+++ b/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -78,7 +78,7 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -149,7 +149,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-hpo279-TextInputWrapper"
+          className="css-20auem-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -179,7 +179,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -209,7 +209,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-fpor5m-TextInputWrapper"
+          className="css-1gozuy0-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -278,7 +278,7 @@ exports[`Storyshots Design System/TextArea Text Area with KNOBS 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-hpo279-TextInputWrapper"
+          className="css-20auem-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -350,7 +350,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-1p4z2la-TextInputWrapper"
+          className="css-yfhbt3-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -381,7 +381,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-1e1zkk7-TextInputWrapper"
+          className="css-ydv4vx-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -412,7 +412,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-yklu5p-TextInputWrapper"
+          className="css-1j7sit7-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -492,7 +492,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-8zmr6c-TextInputWrapper"
+              className="css-whf5wf-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -537,7 +537,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-alwr26-TextInputWrapper"
+              className="css-1atk2z-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -582,7 +582,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1r0s33d-TextInputWrapper"
+              className="css-18rfawf-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -639,7 +639,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-hpo279-TextInputWrapper"
+              className="css-20auem-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -684,7 +684,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -729,7 +729,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-fpor5m-TextInputWrapper"
+              className="css-1gozuy0-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -82,7 +82,7 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-1il6azq-TextInputWrapper"
@@ -157,7 +157,7 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-hpo279-TextInputWrapper"
+          className="css-20auem-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -193,7 +193,7 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -229,7 +229,7 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-fpor5m-TextInputWrapper"
+          className="css-1gozuy0-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -304,7 +304,7 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -364,7 +364,7 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -463,7 +463,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -499,7 +499,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -529,7 +529,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -597,7 +597,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -647,7 +647,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -697,7 +697,7 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-71prqf-TextInputWrapper"
+          className="css-1wqyga6-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -800,7 +800,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-1p4z2la-TextInputWrapper"
+          className="css-yfhbt3-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -836,7 +836,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-1e1zkk7-TextInputWrapper"
+          className="css-ydv4vx-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -872,7 +872,7 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
         className="css-o66dxn-TextInputWrapper"
       >
         <div
-          className="css-yklu5p-TextInputWrapper"
+          className="css-1j7sit7-TextInputWrapper"
         >
           <div
             className="css-19bjb4x-TextInputWrapper"
@@ -957,7 +957,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1hsfcrv-TextInputWrapper"
+              className="css-100dwfc-TextInputWrapper"
             >
               <div
                 className="css-19bjb4x-TextInputWrapper"
@@ -1005,7 +1005,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1sl0795-TextInputWrapper"
+              className="css-1b1sc74-TextInputWrapper"
             >
               <div
                 className="css-19bjb4x-TextInputWrapper"
@@ -1053,7 +1053,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1v3snu0-TextInputWrapper"
+              className="css-172peed-TextInputWrapper"
             >
               <div
                 className="css-19bjb4x-TextInputWrapper"
@@ -1113,7 +1113,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1hsfcrv-TextInputWrapper"
+              className="css-100dwfc-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1161,7 +1161,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1sl0795-TextInputWrapper"
+              className="css-1b1sc74-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1209,7 +1209,7 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1v3snu0-TextInputWrapper"
+              className="css-172peed-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1308,7 +1308,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-8zmr6c-TextInputWrapper"
+              className="css-whf5wf-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1357,7 +1357,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-alwr26-TextInputWrapper"
+              className="css-1atk2z-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1406,7 +1406,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-1r0s33d-TextInputWrapper"
+              className="css-18rfawf-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1462,7 +1462,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-8zmr6c-TextInputWrapper"
+                className="css-whf5wf-TextInputWrapper"
               >
                 <div
                   className="css-1il6azq-TextInputWrapper"
@@ -1524,7 +1524,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-hpo279-TextInputWrapper"
+              className="css-20auem-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1573,7 +1573,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-71prqf-TextInputWrapper"
+              className="css-1wqyga6-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1622,7 +1622,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
             className="css-o66dxn-TextInputWrapper"
           >
             <div
-              className="css-fpor5m-TextInputWrapper"
+              className="css-1gozuy0-TextInputWrapper"
             >
               <div
                 className="css-1il6azq-TextInputWrapper"
@@ -1678,7 +1678,7 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
               className="css-o66dxn-TextInputWrapper"
             >
               <div
-                className="css-hpo279-TextInputWrapper"
+                className="css-20auem-TextInputWrapper"
               >
                 <div
                   className="css-1il6azq-TextInputWrapper"

--- a/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
+++ b/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
@@ -221,7 +221,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -242,7 +242,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"
@@ -263,7 +263,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
           className="css-o66dxn-TextInputWrapper"
         >
           <div
-            className="css-hpo279-TextInputWrapper"
+            className="css-20auem-TextInputWrapper"
           >
             <div
               className="css-1il6azq-TextInputWrapper"

--- a/src/components/utils/TextInputWrapper/TextInputWrapper.style.ts
+++ b/src/components/utils/TextInputWrapper/TextInputWrapper.style.ts
@@ -19,12 +19,13 @@ const wrapperStyleSwitch = (
   switch (styleType) {
     case 'outlined':
       return `
-        box-shadow: 0 0 0 1px
+      padding: 2px;
+        border: 1px solid
           ${error ? 'transparent' : theme.utils.getColor('lightGray', 400)};
         &:focus-within, &:hover {
-          box-shadow: 0 0 0 1px ${
-            !disabled ? 'transparent' : theme.utils.getColor('lightGray', 400)
-          };
+              padding: 1px;
+
+          border: 2px solid ${!disabled ? 'transparent' : theme.utils.getColor('lightGray', 400)};
         }
       `;
     case 'elevated':
@@ -47,7 +48,7 @@ export const wrapperStyle = ({ disabled, locked, status, lean, styleType, dark }
   const backgroundColor = dark ? theme.utils.getColor('darkGray', 600) : theme.palette.white;
 
   return css`
-    transition: background-color 0.25s, box-shadow 0.25s, border-color 0.25s;
+    transition: background-color 0.25s, box-shadow 0.25s, border 0.25s, padding 0.25s;
     border-radius: ${theme.spacing.xsm};
     cursor: ${disabled || locked ? 'not-allowed' : 'auto'};
     flex: 1 1 100%;


### PR DESCRIPTION
## Description

This PR resolves a minor issue on DS on sizing of outlined TextField.

The outlined TextField has it's border visually created by a box-shadow. This results that the width of the component is larger than the width that the DOM gives to the component.

No ticket exists for this. If we consider it useful , I will create one to pass this for Design QA.

## Screenshot

Before the proposed change
![before](https://user-images.githubusercontent.com/28539607/121672306-5132a980-cab8-11eb-8b45-fcd9f1e05715.PNG)

with the proposed change
![after](https://user-images.githubusercontent.com/28539607/121672363-614a8900-cab8-11eb-9dd6-941da8f0d663.PNG)

## Test Plan

Updated snapshots