### PR TITLE
fix: fix label position in text elements [DS-152]

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -3484,7 +3484,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-13akgc3"
+                      className="css-bndjq4"
                       disabled={false}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3542,7 +3542,7 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-g6bat3"
+                      className="css-1ty6lk"
                       disabled={false}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -3649,7 +3649,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                         className="css-1u4znjd"
                       >
                         <input
-                          className="css-g6bat3"
+                          className="css-1ty6lk"
                           disabled={false}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3707,7 +3707,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                         className="css-1u4znjd"
                       >
                         <input
-                          className="css-g6bat3"
+                          className="css-1ty6lk"
                           disabled={false}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3765,7 +3765,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                         className="css-1u4znjd"
                       >
                         <input
-                          className="css-g6bat3"
+                          className="css-1ty6lk"
                           disabled={false}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3835,7 +3835,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                         className="css-1u4znjd"
                       >
                         <input
-                          className="css-g6bat3"
+                          className="css-1ty6lk"
                           disabled={false}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3906,7 +3906,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
                         className="css-1u4znjd"
                       >
                         <input
-                          className="css-g6bat3"
+                          className="css-1ty6lk"
                           disabled={false}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -4018,7 +4018,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-13akgc3"
+                      className="css-bndjq4"
                       disabled={false}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -4076,7 +4076,7 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-g6bat3"
+                      className="css-1ty6lk"
                       disabled={false}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -4173,7 +4173,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-g6bat3"
+                      className="css-1ty6lk"
                       disabled={false}
                       onChange={[Function]}
                       onFocus={[Function]}
@@ -4260,7 +4260,7 @@ exports[`Storyshots Design System/DatePicker DayPicker with predefined values 1`
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-g6bat3"
+                  className="css-1ty6lk"
                   disabled={false}
                   onChange={[Function]}
                   onFocus={[Function]}
@@ -4345,7 +4345,7 @@ exports[`Storyshots Design System/DatePicker Dynamic disableDates with all optio
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-g6bat3"
+                  className="css-1ty6lk"
                   disabled={false}
                   onChange={[Function]}
                   onFocus={[Function]}

--- a/src/components/Label/Label.style.ts
+++ b/src/components/Label/Label.style.ts
@@ -1,5 +1,8 @@
 import { css, SerializedStyles } from '@emotion/core';
+
 import { Theme } from '../../theme';
+
+export const LABEL_TRANSFORM_LEFT_SPACING = '3';
 
 export const labelStyle = ({
   size,
@@ -15,7 +18,9 @@ export const labelStyle = ({
   width: 100%;
   position: absolute;
   user-select: none;
-  transform: ${!animateToTop ? 'translate(1%, 0)' : 'translate(1%, -95%) scale(0.8);'};
+  transform: ${!animateToTop
+    ? `translate(${LABEL_TRANSFORM_LEFT_SPACING}px, 0)`
+    : `translate(${LABEL_TRANSFORM_LEFT_SPACING}px, -95%) scale(0.8);`};
   font-size: ${theme.typography.fontSizes['16']};
   font-weight: ${theme.typography.weights.regular};
   color: ${error

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -55,7 +55,7 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-1h245c6"
+                  className="css-193mfgp"
                   data-testid="select-input"
                   disabled={false}
                   onChange={[Function]}
@@ -68,7 +68,7 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
                   value=""
                 />
                 <label
-                  className="css-6ez3qq-Label"
+                  className="css-u10266-Label"
                 >
                   Flavour
                    
@@ -154,7 +154,7 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-1h245c6"
+                  className="css-193mfgp"
                   data-testid="select-input"
                   disabled={false}
                   onChange={[Function]}
@@ -167,7 +167,7 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
                   value=""
                 />
                 <label
-                  className="css-6ez3qq-Label"
+                  className="css-u10266-Label"
                 >
                   Flavour
                    
@@ -260,7 +260,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={true}
                     onChange={[Function]}
@@ -272,7 +272,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
                     value=""
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Flavour
                      
@@ -327,7 +327,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={true}
                     onChange={[Function]}
@@ -339,7 +339,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
                     value=""
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Flavour
                      
@@ -394,7 +394,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={true}
                     onChange={[Function]}
@@ -406,7 +406,7 @@ exports[`Storyshots Design System/Select Disabled Select 1`] = `
                     value=""
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Flavour
                      
@@ -500,7 +500,7 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -512,7 +512,7 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
                     value=""
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Flavour
                      
@@ -606,7 +606,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-bzlo54"
+                    className="css-13caovv"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -618,7 +618,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -673,7 +673,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -685,7 +685,7 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -779,7 +779,7 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -791,7 +791,7 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
                     value=""
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Flavour
                      
@@ -882,7 +882,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-1h245c6"
+                  className="css-193mfgp"
                   data-testid="select-input"
                   disabled={false}
                   onChange={[Function]}
@@ -894,7 +894,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
                   value="Chocolate"
                 />
                 <label
-                  className="css-1avh9vo-Label"
+                  className="css-f4rmxh-Label"
                 >
                   Flavour
                    
@@ -942,7 +942,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-1h245c6"
+                className="css-193mfgp"
                 data-testid="select-input"
                 disabled={false}
                 onChange={[Function]}
@@ -954,7 +954,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
                 value="Chocolate"
               />
               <label
-                className="css-1avh9vo-Label"
+                className="css-f4rmxh-Label"
               >
                 Flavour
                  
@@ -1008,7 +1008,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-1h245c6"
+                  className="css-193mfgp"
                   data-testid="select-input"
                   disabled={false}
                   onChange={[Function]}
@@ -1020,7 +1020,7 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
                   value="Chocolate"
                 />
                 <label
-                  className="css-1avh9vo-Label"
+                  className="css-f4rmxh-Label"
                 >
                   Flavour
                    
@@ -1127,7 +1127,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-bzlo54"
+                    className="css-13caovv"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -1139,7 +1139,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -1194,7 +1194,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -1206,7 +1206,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -1273,7 +1273,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -1285,7 +1285,7 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -1387,7 +1387,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                       className="css-1u4znjd"
                     >
                       <input
-                        className="css-1h245c6"
+                        className="css-193mfgp"
                         data-testid="select-input"
                         disabled={false}
                         onChange={[Function]}
@@ -1399,7 +1399,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         value="Chocolate"
                       />
                       <label
-                        className="css-1crpb0-Label"
+                        className="css-mavza5-Label"
                       >
                         Label
                          
@@ -1467,7 +1467,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                       className="css-1u4znjd"
                     >
                       <input
-                        className="css-1h245c6"
+                        className="css-193mfgp"
                         data-testid="select-input"
                         disabled={false}
                         onChange={[Function]}
@@ -1479,7 +1479,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         value="Chocolate"
                       />
                       <label
-                        className="css-1crpb0-Label"
+                        className="css-mavza5-Label"
                       >
                         Label
                          
@@ -1547,7 +1547,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                       className="css-1u4znjd"
                     >
                       <input
-                        className="css-1h245c6"
+                        className="css-193mfgp"
                         data-testid="select-input"
                         disabled={false}
                         onChange={[Function]}
@@ -1559,7 +1559,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         value="Chocolate"
                       />
                       <label
-                        className="css-1crpb0-Label"
+                        className="css-mavza5-Label"
                       >
                         Label
                          
@@ -1639,7 +1639,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                       className="css-1u4znjd"
                     >
                       <input
-                        className="css-1h245c6"
+                        className="css-193mfgp"
                         data-testid="select-input"
                         disabled={false}
                         onChange={[Function]}
@@ -1651,7 +1651,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         value=""
                       />
                       <label
-                        className="css-6ez3qq-Label"
+                        className="css-u10266-Label"
                       >
                         Label
                          
@@ -1719,7 +1719,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                       className="css-1u4znjd"
                     >
                       <input
-                        className="css-1h245c6"
+                        className="css-193mfgp"
                         data-testid="select-input"
                         disabled={false}
                         onChange={[Function]}
@@ -1731,7 +1731,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         value=""
                       />
                       <label
-                        className="css-6ez3qq-Label"
+                        className="css-u10266-Label"
                       >
                         Label
                          
@@ -1799,7 +1799,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                       className="css-1u4znjd"
                     >
                       <input
-                        className="css-1h245c6"
+                        className="css-193mfgp"
                         data-testid="select-input"
                         disabled={false}
                         onChange={[Function]}
@@ -1811,7 +1811,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         value=""
                       />
                       <label
-                        className="css-6ez3qq-Label"
+                        className="css-u10266-Label"
                       >
                         Label
                          
@@ -1920,7 +1920,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -1932,7 +1932,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -1987,7 +1987,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -1999,7 +1999,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      
@@ -2054,7 +2054,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     data-testid="select-input"
                     disabled={false}
                     onChange={[Function]}
@@ -2066,7 +2066,7 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                     value="Chocolate"
                   />
                   <label
-                    className="css-1avh9vo-Label"
+                    className="css-f4rmxh-Label"
                   >
                     Flavour
                      

--- a/src/components/TextArea/TextArea.style.ts
+++ b/src/components/TextArea/TextArea.style.ts
@@ -1,7 +1,9 @@
 import { css, SerializedStyles } from '@emotion/core';
+
 import { Props } from './TextArea';
 import { Theme } from '../../theme';
 import { Props as TextInputWrapperProps } from '../utils/TextInputWrapper/TextInputWrapper';
+import { LABEL_TRANSFORM_LEFT_SPACING } from 'components/Label/Label.style';
 
 export const inputStyle = ({
   label,
@@ -43,7 +45,7 @@ export const inputStyle = ({
   &:focus,
   &:not(:placeholder-shown) {
     & + label {
-      transform: translate(1%, -35%) scale(0.8);
+      transform: translate(${LABEL_TRANSFORM_LEFT_SPACING}px, -35%) scale(0.8);
       font-weight: ${theme.typography.weights.bold};
     }
   }

--- a/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
+++ b/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
@@ -55,7 +55,7 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 cols={10}
                 placeholder="Label"
                 required={false}
@@ -87,7 +87,7 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 cols={35}
                 placeholder="Label"
                 required={false}
@@ -158,7 +158,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 placeholder="placeholder here"
                 required={false}
                 styleType="filled"
@@ -188,7 +188,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 placeholder="placeholder here"
                 required={false}
                 styleType="outlined"
@@ -218,7 +218,7 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 placeholder="placeholder here"
                 required={false}
                 styleType="elevated"
@@ -287,7 +287,7 @@ exports[`Storyshots Design System/TextArea Text Area with KNOBS 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 disabled={false}
                 hintMsg="Hint in Text Area"
                 placeholder="Label"
@@ -359,7 +359,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 disabled={true}
                 placeholder="Label"
                 required={false}
@@ -390,7 +390,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 disabled={true}
                 placeholder="Label"
                 required={false}
@@ -421,7 +421,7 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
               className="css-1u4znjd"
             >
               <textarea
-                className="css-ybcei0"
+                className="css-9c1zd"
                 disabled={true}
                 placeholder="Label"
                 required={false}
@@ -501,7 +501,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
                   className="css-1u4znjd"
                 >
                   <textarea
-                    className="css-ybcei0"
+                    className="css-9c1zd"
                     hintMsg="Error in Text Area"
                     placeholder="Label"
                     required={false}
@@ -546,7 +546,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
                   className="css-1u4znjd"
                 >
                   <textarea
-                    className="css-ybcei0"
+                    className="css-9c1zd"
                     hintMsg="Error in Text Area"
                     placeholder="Label"
                     required={false}
@@ -591,7 +591,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
                   className="css-1u4znjd"
                 >
                   <textarea
-                    className="css-ybcei0"
+                    className="css-9c1zd"
                     hintMsg="Error in Text Area"
                     placeholder="Label"
                     required={false}
@@ -648,7 +648,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
                   className="css-1u4znjd"
                 >
                   <textarea
-                    className="css-ybcei0"
+                    className="css-9c1zd"
                     hintMsg="Error in Text Area"
                     placeholder="Label"
                     required={false}
@@ -693,7 +693,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
                   className="css-1u4znjd"
                 >
                   <textarea
-                    className="css-ybcei0"
+                    className="css-9c1zd"
                     hintMsg="Error in Text Area"
                     placeholder="Label"
                     required={false}
@@ -738,7 +738,7 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
                   className="css-1u4znjd"
                 >
                   <textarea
-                    className="css-ybcei0"
+                    className="css-9c1zd"
                     hintMsg="Error in Text Area"
                     placeholder="Label"
                     required={false}

--- a/src/components/TextField/TextField.style.ts
+++ b/src/components/TextField/TextField.style.ts
@@ -1,6 +1,8 @@
 import { css, SerializedStyles } from '@emotion/core';
+
 import { Props } from './TextField';
-import { Theme } from '../../theme';
+import { Theme } from 'theme';
+import { LABEL_TRANSFORM_LEFT_SPACING } from 'components/Label/Label.style';
 
 export const iconWrapperStyle = ({ iconPosition }: { iconPosition: 'left' | 'right' }) => (
   theme: Theme
@@ -50,7 +52,7 @@ export const inputStyle = ({ label, placeholder, size, dark }: Props) => (
   &:focus,
   &:not(:placeholder-shown) {
     & + label {
-      transform: translate(1%, -35%) scale(0.8);
+      transform: translate(${LABEL_TRANSFORM_LEFT_SPACING}px, -35%) scale(0.8);
       font-weight: ${theme.typography.weights.bold};
     }
   }

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -55,13 +55,13 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -91,13 +91,13 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-1h245c6"
+                className="css-193mfgp"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -166,13 +166,13 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -202,13 +202,13 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -238,13 +238,13 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -325,13 +325,13 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -385,13 +385,13 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -472,13 +472,13 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -508,7 +508,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-13akgc3"
+                className="css-bndjq4"
                 disabled={false}
                 placeholder="Label "
                 required={false}
@@ -538,7 +538,7 @@ exports[`Storyshots Design System/TextField Text Field with Label 1`] = `
               className="css-1u4znjd"
             >
               <input
-                className="css-19vexqt"
+                className="css-tr3si0"
                 disabled={false}
                 required={false}
               />
@@ -620,13 +620,13 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -656,13 +656,13 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -720,13 +720,13 @@ exports[`Storyshots Design System/TextField Text Field with Placeholder, icon an
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={false}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -809,13 +809,13 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={true}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -845,13 +845,13 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={true}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -881,13 +881,13 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
               className="css-1u4znjd"
             >
               <input
-                className="css-bzlo54"
+                className="css-13caovv"
                 disabled={true}
                 placeholder="Label"
                 required={false}
               />
               <label
-                className="css-6ez3qq-Label"
+                className="css-u10266-Label"
               >
                 Label
                  
@@ -966,13 +966,13 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-bzlo54"
+                    className="css-13caovv"
                     disabled={true}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1014,13 +1014,13 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-bzlo54"
+                    className="css-13caovv"
                     disabled={true}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1062,13 +1062,13 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-bzlo54"
+                    className="css-13caovv"
                     disabled={true}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1122,13 +1122,13 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={true}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1170,13 +1170,13 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={true}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1218,13 +1218,13 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={true}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1317,13 +1317,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={false}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-7gxkgw-Label"
+                    className="css-xsz24r-Label"
                   >
                     Label
                      
@@ -1366,13 +1366,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={false}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-7gxkgw-Label"
+                    className="css-xsz24r-Label"
                   >
                     Label
                      
@@ -1415,13 +1415,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={false}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-7gxkgw-Label"
+                    className="css-xsz24r-Label"
                   >
                     Label
                      
@@ -1471,13 +1471,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-1h245c6"
+                      className="css-193mfgp"
                       disabled={false}
                       placeholder="Label"
                       required={false}
                     />
                     <label
-                      className="css-7gxkgw-Label"
+                      className="css-xsz24r-Label"
                     >
                       Label
                        
@@ -1533,13 +1533,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={false}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1582,13 +1582,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={false}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1631,13 +1631,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                   className="css-1u4znjd"
                 >
                   <input
-                    className="css-1h245c6"
+                    className="css-193mfgp"
                     disabled={false}
                     placeholder="Label"
                     required={false}
                   />
                   <label
-                    className="css-6ez3qq-Label"
+                    className="css-u10266-Label"
                   >
                     Label
                      
@@ -1687,13 +1687,13 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
                     className="css-1u4znjd"
                   >
                     <input
-                      className="css-1h245c6"
+                      className="css-193mfgp"
                       disabled={false}
                       placeholder="Label"
                       required={false}
                     />
                     <label
-                      className="css-6ez3qq-Label"
+                      className="css-u10266-Label"
                     >
                       Label
                        

--- a/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
+++ b/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
@@ -230,7 +230,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-wizu6"
+                  className="css-1qs85o4"
                   disabled={false}
                   required={false}
                 />
@@ -251,7 +251,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-wizu6"
+                  className="css-1qs85o4"
                   disabled={false}
                   required={false}
                 />
@@ -272,7 +272,7 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
                 className="css-1u4znjd"
               >
                 <input
-                  className="css-wizu6"
+                  className="css-1qs85o4"
                   disabled={false}
                   required={false}
                 />

--- a/src/components/utils/TextInputWrapper/TextInputWrapper.style.ts
+++ b/src/components/utils/TextInputWrapper/TextInputWrapper.style.ts
@@ -1,8 +1,10 @@
 import { css, SerializedStyles } from '@emotion/core';
 import { darken, lighten, rem } from 'polished';
+
 import { Props } from './TextInputWrapper';
 import { Theme } from 'theme';
 import { DEFAULT_SIZE, getTextFieldSize } from 'utils/size-utils';
+import { LABEL_TRANSFORM_LEFT_SPACING } from 'components/Label/Label.style';
 
 const wrapperStyleSwitch = (
   theme: Theme,
@@ -150,7 +152,7 @@ export const inputStyle = ({ label, placeholder, size, dark }: Props) => (
   &:focus,
   &:not(:placeholder-shown) {
     & + label {
-      transform: translate(1%, -35%) scale(0.8);
+      transform: translate(${LABEL_TRANSFORM_LEFT_SPACING}px, -35%) scale(0.8);
       font-weight: ${theme.typography.weights.bold};
     }
   }


### PR DESCRIPTION
[DS-152]

Fixes issue where resizing a text field would result in the Label rendering in inconsistent positions, because of a percentage-based value. 


Issue: 
![label](https://user-images.githubusercontent.com/13350837/121905608-02447880-cd33-11eb-9e0a-2a747e714139.gif)


[DS-152]: https://orfium.atlassian.net/browse/DS-152