### PR TITLE
fix: design qa fixes for table

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -241,6 +241,7 @@ function Table<T>({
                       padded={padded}
                       width={columnsWithWidth[index] ? `${columnsWithWidth[index]}%` : 'initial'}
                       isSortable={!isItemString(item) && item.isSortable}
+                      isActive={!isItemString(item) ? item.content === sorting.column : false}
                       onClick={() => {
                         if (!isItemString(item) && item.isSortable) {
                           handleSorting(item.content);

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -1950,7 +1950,7 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
         onClick={[Function]}
       >
         <th
-          className="css-u3gjhf"
+          className="css-gn6cdz"
           data-testid="ictinus_title_"
           onClick={[Function]}
         >
@@ -2094,7 +2094,7 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
                   onClick={[Function]}
                 >
                   <span
-                    className="css-l3bzzy-Icon"
+                    className="css-yktg9d-Icon"
                   />
                 </span>
               </div>
@@ -2245,7 +2245,7 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
           </div>
         </th>
         <th
-          className="css-yclvo3"
+          className="css-14rlfqt"
           data-testid="ictinus_age_"
           onClick={[Function]}
         >

--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -1950,7 +1950,7 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
         onClick={[Function]}
       >
         <th
-          className="css-1rjnu80"
+          className="css-u3gjhf"
           data-testid="ictinus_title_"
           onClick={[Function]}
         >
@@ -2094,7 +2094,7 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
                   onClick={[Function]}
                 >
                   <span
-                    className="css-1gnrqdj-Icon"
+                    className="css-l3bzzy-Icon"
                   />
                 </span>
               </div>
@@ -2245,7 +2245,7 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
           </div>
         </th>
         <th
-          className="css-wkif5c"
+          className="css-yclvo3"
           data-testid="ictinus_age_"
           onClick={[Function]}
         >

--- a/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
+++ b/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
@@ -40,7 +40,7 @@ const ExtendedColumnItem: React.FC<Props> = ({ item, sorting, isNumerical }) => 
           dataTestId={`table_icon_sort_${itemContentLowerCase}_${
             sorting.order === 'desc' ? 'desc' : 'asc'
           }`}
-          color="neutralBlack-700"
+          color={theme.utils.getColor('neutralBlack', 700)}
         />
       </div>
     ) : (

--- a/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
+++ b/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
@@ -40,7 +40,7 @@ const ExtendedColumnItem: React.FC<Props> = ({ item, sorting, isNumerical }) => 
           dataTestId={`table_icon_sort_${itemContentLowerCase}_${
             sorting.order === 'desc' ? 'desc' : 'asc'
           }`}
-          color={theme.utils.getColor('lightGray', 600)}
+          color="neutralBlack-700"
         />
       </div>
     ) : (

--- a/src/components/Table/components/TableCell/TableCell.style.tsx
+++ b/src/components/Table/components/TableCell/TableCell.style.tsx
@@ -3,17 +3,22 @@ import { rem } from 'polished';
 
 import { Theme } from 'theme';
 
-export const parentStyles = () => (theme: Theme): SerializedStyles => css`
+const activeStateStyles = (): SerializedStyles => css`
+  & > div > span {
+    color: black !important;
+    font-weight: 700 !important;
+  }
+`;
+
+export const parentStyles = (isActive: boolean) => (theme: Theme): SerializedStyles => css`
   cursor: pointer;
   position: relative;
   height: ${rem(64)};
 
-  &:hover {
-    & * {
-      color: black;
-      font-weight: 700;
-    }
+  ${isActive && activeStateStyles()}
 
+  &:hover {
+    ${activeStateStyles()};
     background-color: ${theme.utils.getColor('lightGray', 100)};
   }
 `;

--- a/src/components/Table/components/TableCell/TableCell.style.tsx
+++ b/src/components/Table/components/TableCell/TableCell.style.tsx
@@ -5,12 +5,14 @@ import { Theme } from 'theme';
 
 const activeStateStyles = (): SerializedStyles => css`
   & > div > span {
-    color: black !important;
-    font-weight: 700 !important;
+    color: black;
+    font-weight: 700;
   }
 `;
 
-export const parentStyles = (isActive: boolean) => (theme: Theme): SerializedStyles => css`
+export const parentStyles = ({ isActive }: { isActive: boolean }) => (
+  theme: Theme
+): SerializedStyles => css`
   cursor: pointer;
   position: relative;
   height: ${rem(64)};

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -18,6 +18,7 @@ type Props = {
   rowIndex?: number;
   index?: number | string;
   isSortable?: boolean;
+  isActive?: boolean;
   onClick?: () => void;
 };
 
@@ -30,6 +31,7 @@ const TableCell: React.FC<Props> = React.memo(
     colSpan,
     children,
     isSortable = false,
+    isActive = false,
     type = 'normal',
     padded = false,
     dataTestIdPrefix,
@@ -69,7 +71,7 @@ const TableCell: React.FC<Props> = React.memo(
             fontWeight: theme.typography.weights.bold,
             fontSize: theme.typography.fontSizes['14'],
           },
-          component === 'th' && isSortable && { ...parentStyles()(theme) },
+          component === 'th' && isSortable && { ...parentStyles(isActive)(theme) },
           sticky && {
             top: 0,
             left: 0,

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -71,7 +71,7 @@ const TableCell: React.FC<Props> = React.memo(
             fontWeight: theme.typography.weights.bold,
             fontSize: theme.typography.fontSizes['14'],
           },
-          component === 'th' && isSortable && { ...parentStyles(isActive)(theme) },
+          component === 'th' && isSortable && { ...parentStyles({ isActive })(theme) },
           sticky && {
             top: 0,
             left: 0,


### PR DESCRIPTION
Design QA Fixes for Table. 

When sorting is applied, the respective column's text should have the 'active state' styles applied.

In the screenshot below, you can see the active state (first column), the normal state and the hover state (last column).

![image](https://user-images.githubusercontent.com/13350837/123104704-d8303c00-d43f-11eb-82e0-dbce7819f3a8.png)

