### PR TITLE
fix: improve import/order eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,12 @@
     "plugin:react-hooks/recommended",
     "plugin:react/recommended"
   ],
-  "plugins": ["react", "@emotion", "@typescript-eslint", "import"],
+  "plugins": [
+    "react",
+    "@emotion",
+    "@typescript-eslint",
+    "import"
+  ],
   "env": {
     "node": true,
     "browser": true,
@@ -31,10 +36,8 @@
     "react/button-has-type": "warn",
     "react/no-array-index-key": "warn",
     "react/no-render-return-value": 0,
-
     /* JSX rules */
     "react/jsx-key": "error",
-
     /* eslint basic rules */
     "padding-line-between-statements": [
       "error",
@@ -64,13 +67,29 @@
     "import/order": [
       "error",
       {
-        "groups": ["builtin", "external", "internal"],
+        "groups": [
+          "builtin",
+          "external",
+          [
+            "internal",
+            "parent",
+            "sibling",
+            "index",
+            "object"
+          ]
+        ],
         "pathGroups": [
           {
             "pattern": "react",
-            "group": "external",
-            "position": "before"
+            "group": "external"
+          },
+          {
+            "pattern": "components/**",
+            "group": "internal"
           }
+        ],
+        "pathGroupsExcludedImportTypes": [
+          "react"
         ],
         "alphabetize": {
           "order": "asc",

--- a/src/components/AssetMatching/components/ActionsToolbox/ActionsToolbox.style.ts
+++ b/src/components/AssetMatching/components/ActionsToolbox/ActionsToolbox.style.ts
@@ -1,8 +1,9 @@
 import { css, SerializedStyles } from '@emotion/react';
-import { cardElevation } from 'components/Card/Card.style';
 import { rem } from 'polished';
 import { Theme } from 'theme';
 import { flex } from 'theme/functions';
+
+import { cardElevation } from 'components/Card/Card.style';
 
 const list = (theme: Theme): SerializedStyles => css`
   flex-direction: column;

--- a/src/components/AssetMatching/components/ActionsToolbox/SecondaryActions.tsx
+++ b/src/components/AssetMatching/components/ActionsToolbox/SecondaryActions.tsx
@@ -1,11 +1,11 @@
-import IconButton from 'components/IconButton';
-import ClickAwayListener from 'components/utils/ClickAwayListener';
 import React, { FC, useState } from 'react';
 import { generateUniqueID } from 'utils/helpers';
 
 import { MatchingAction } from '../../types';
 import { useMatchingActions } from '../utils';
 import Styles from './ActionsToolbox.style';
+import IconButton from 'components/IconButton';
+import ClickAwayListener from 'components/utils/ClickAwayListener';
 
 interface Props {
   secondaryActions: MatchingAction[];

--- a/src/components/AssetMatching/components/Asset/AssetExternalLink.tsx
+++ b/src/components/AssetMatching/components/Asset/AssetExternalLink.tsx
@@ -1,9 +1,9 @@
 import Tippy from '@tippyjs/react';
 import React, { FC } from 'react';
+import 'tippy.js/dist/tippy.css';
 
 import Icon from '../../../Icon';
 import Styles from './Asset.style';
-import 'tippy.js/dist/tippy.css';
 
 export interface ExternalLinkProps {
   url: string;

--- a/src/components/AssetMatching/components/Asset/AssetHeading.tsx
+++ b/src/components/AssetMatching/components/Asset/AssetHeading.tsx
@@ -1,10 +1,10 @@
-import Icon from 'components/Icon';
-import { AcceptedIconNames } from 'components/Icon/types';
 import React, { FC } from 'react';
 import { flex } from 'theme/functions';
 
 import Styles from './Asset.style';
 import AssetExternalLink, { ExternalLinkProps } from './AssetExternalLink';
+import Icon from 'components/Icon';
+import { AcceptedIconNames } from 'components/Icon/types';
 
 
 export interface AssetHeadingProps {

--- a/src/components/AssetMatching/components/Categories/Categories.test.tsx
+++ b/src/components/AssetMatching/components/Categories/Categories.test.tsx
@@ -3,7 +3,6 @@ import { render, fireEvent } from 'test';
 
 import { SelectedItemProvider } from '../SelectedItemContext';
 import { Categories } from './index';
-import '@testing-library/jest-dom';
 
 jest.mock('lodash/debounce', () =>
   jest.fn(fn => {

--- a/src/components/AssetMatching/components/CheckBoxContainer/CheckBoxContainer.tsx
+++ b/src/components/AssetMatching/components/CheckBoxContainer/CheckBoxContainer.tsx
@@ -1,7 +1,7 @@
-import CheckBox from 'components/CheckBox';
 import React, { ChangeEvent, FC, Fragment } from 'react';
 
 import Styles from './CheckBoxContainer.style';
+import CheckBox from 'components/CheckBox';
 
 interface Props {
   handleCheck?(val: boolean, e: ChangeEvent): void;

--- a/src/components/AssetMatching/components/SectionHeader/SectionHeader.test.tsx
+++ b/src/components/AssetMatching/components/SectionHeader/SectionHeader.test.tsx
@@ -1,9 +1,8 @@
-import mocks from 'components/storyUtils/AssetMatchingShowcase/mocks';
 import React from 'react';
 
 import { render, fireEvent } from '../../../../test';
 import SectionHeader from './SectionHeader';
-import '@testing-library/jest-dom';
+import mocks from 'components/storyUtils/AssetMatchingShowcase/mocks';
 
 describe('Asset Matching - SectionHeader', () => {
   let matchingActions: any;

--- a/src/components/AssetMatching/components/utils.tsx
+++ b/src/components/AssetMatching/components/utils.tsx
@@ -1,10 +1,10 @@
-import Button from 'components/Button';
-import Icon from 'components/Icon';
 import debounce from 'lodash/debounce';
 import React, { useMemo, useCallback } from 'react';
 
 import { MatchingAction } from '../types';
 import { useSelectedItem } from './SelectedItemContext';
+import Button from 'components/Button';
+import Icon from 'components/Icon';
 
 const SEARCH_REG_EXPRESSION = /\s/g;
 const REPLACE_WITH = '-';

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
@@ -1,8 +1,8 @@
-import Separator from 'components/Breadcrumb/Separator/Separator';
 import React from 'react';
 
 import BreadcrumbAdvancedItem from './BreadcrumbAdvancedItem';
 import { breadcrumbItemStyles } from './BreadcrumbItem.style';
+import Separator from 'components/Breadcrumb/Separator/Separator';
 
 type Props = {
   /** Defines the child element that will be rendered inside the list element */

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,4 +1,3 @@
-import Icon from 'components/Icon';
 import { useTypeColorToColorMatch } from 'hooks/useTypeColorToColorMatch';
 import * as React from 'react';
 import { ChangeEvent, useEffect } from 'react';
@@ -13,6 +12,7 @@ import {
   wrapperStyle,
   markerStyle,
 } from './CheckBox.style';
+import Icon from 'components/Icon';
 
 export type Props = {
   /** The label of the checkbox. */

--- a/src/components/CheckBox/tests/Checkbox.test.tsx
+++ b/src/components/CheckBox/tests/Checkbox.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
 import { render, fireEvent } from '../../../test';
 import CheckBox from '../CheckBox';
 

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
 import { render, fireEvent } from '../../test';
 import { Theme } from '../../theme';
 import { pickTextColorFromSwatches } from '../../theme/palette';

--- a/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.tsx
+++ b/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.tsx
@@ -1,8 +1,3 @@
-import Button from 'components/Button';
-import Icon from 'components/Icon';
-import SelectMenu from 'components/Select/components/SelectMenu';
-import { SelectOption } from 'components/Select/Select';
-import ClickAwayListener from 'components/utils/ClickAwayListener';
 import { Dayjs } from 'dayjs';
 import useTheme from 'hooks/useTheme';
 import range from 'lodash/range';
@@ -18,6 +13,11 @@ import {
   monthHeaderWrapperStyle,
   monthWrapperStyle,
 } from './MonthWrapper.style';
+import Button from 'components/Button';
+import Icon from 'components/Icon';
+import SelectMenu from 'components/Select/components/SelectMenu';
+import { SelectOption } from 'components/Select/Select';
+import ClickAwayListener from 'components/utils/ClickAwayListener';
 
 type Props = {
   showedArrows?: 'left' | 'right' | 'both';

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import '@testing-library/jest-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import { createMockMediaMatcher } from '../../hooks/useBreakpoints.test';

--- a/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
+++ b/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
@@ -1,6 +1,3 @@
-import { MenuItem as MenuItemProps } from 'components/Drawer/types';
-import ExpandCollapse from 'components/ExpandCollapse';
-import Icon from 'components/Icon';
 import { useTypeColorToColorMatch } from 'hooks/useTypeColorToColorMatch';
 import React, { memo, useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
@@ -16,6 +13,9 @@ import {
   subMenuIconStyle,
   menuLinkStyle,
 } from '../Navigation.style';
+import { MenuItem as MenuItemProps } from 'components/Drawer/types';
+import ExpandCollapse from 'components/ExpandCollapse';
+import Icon from 'components/Icon';
 
 type Props = {
   /** Defines the current menu item whose submenu item is currently selected */

--- a/src/components/Drawer/types.ts
+++ b/src/components/Drawer/types.ts
@@ -1,6 +1,7 @@
-import { AcceptedIconNames } from 'components/Icon/types';
 import { Location, LocationState } from 'history';
 import { match } from 'react-router';
+
+import { AcceptedIconNames } from 'components/Icon/types';
 
 export type MenuItem = {
   name: string;

--- a/src/components/Filter/Filter.test.tsx
+++ b/src/components/Filter/Filter.test.tsx
@@ -1,6 +1,5 @@
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
 
 import { render, screen } from '../../test';
 import Filter from './Filter';

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,3 @@
-import ButtonBase, { Props as ButtonBaseProps } from 'components/ButtonBase/ButtonBase';
 import * as React from 'react';
 
 import { useTypeColorToColorMatch } from '../../hooks/useTypeColorToColorMatch';
@@ -9,6 +8,7 @@ import { TestProps } from '../../utils/types';
 import { defineBackgroundColor } from '../Button/utils';
 import Icon from '../Icon';
 import { AcceptedIconNames } from '../Icon/types';
+import ButtonBase, { Props as ButtonBaseProps } from 'components/ButtonBase/ButtonBase';
 
 export type Props = Omit<ButtonBaseProps, 'isIconButton' | 'iconLeft' | 'iconRight'> & {
   /** Property indicating the size of the icon. Defaults to 16 */

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render, fireEvent } from '../../test';
 import Modal from './Modal';
 import ModalContent from './ModalContent';
-import '@testing-library/jest-dom';
 
 describe('Modal', () => {
   const data = {

--- a/src/components/Notification/Notification.test.tsx
+++ b/src/components/Notification/Notification.test.tsx
@@ -8,7 +8,6 @@ import { NotificationTypes } from './Notification';
 import NotificationsContainer from './NotificationsContainer';
 import NotificationVisual from './NotificationVisual';
 import Snackbar from './Snackbar';
-import '@testing-library/jest-dom';
 
 describe('Inline Notification', () => {
   const data = {

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -1,4 +1,3 @@
-import Icon from 'components/Icon';
 import * as React from 'react';
 
 import useTheme from '../../../hooks/useTheme';
@@ -15,6 +14,7 @@ import {
 } from '../Notification.style';
 import { typeToIconName } from '../subcomponents/CompactNotification/CompactNotification';
 import { cardContainer, topContainer, infoContainer, descriptionContainer } from './Snackbar.style';
+import Icon from 'components/Icon';
 
 export type Props = {
   /** The informative message of the Toast */

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
@@ -1,4 +1,3 @@
-import { AcceptedIconNames } from 'components/Icon/types';
 import * as React from 'react';
 
 import useTheme from '../../../../hooks/useTheme';
@@ -14,6 +13,7 @@ import {
   headContainer,
   primaryActionContainer,
 } from './CompactNotification.style';
+import { AcceptedIconNames } from 'components/Icon/types';
 
 export type CompactNotificationVariants = 'inline' | 'banner' | 'card';
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,6 +1,5 @@
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
 
 import { render, screen, selectDropdownOption, waitFor } from '../../test';
 import Select from './Select';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react';
-import Loader from 'components/Loader';
 import { debounce } from 'lodash';
 import { rem } from 'polished';
 import React, { InputHTMLAttributes, useEffect, useMemo, KeyboardEvent } from 'react';
@@ -11,6 +10,7 @@ import TextField from '../TextField';
 import { Props as TextFieldProps } from '../TextField/TextField';
 import ClickAwayListener from '../utils/ClickAwayListener';
 import SelectMenu from './components/SelectMenu/SelectMenu';
+import Loader from 'components/Loader';
 
 export type SelectOption = {
   value: string | number;

--- a/src/components/TextArea/TextArea.style.ts
+++ b/src/components/TextArea/TextArea.style.ts
@@ -1,8 +1,9 @@
 import { css, SerializedStyles } from '@emotion/react';
-import { Props as TextInputWrapperProps } from 'components/TextInputBase';
+
 
 import { Theme } from '../../theme';
 import { Props } from './TextArea';
+import { Props as TextInputWrapperProps } from 'components/TextInputBase';
 
 export const inputStyle = ({
   label,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,5 +1,3 @@
-import { AcceptedIconNames } from 'components/Icon/types';
-import TextInputBase, { Props as TextInputWrapperProps } from 'components/TextInputBase';
 import useTheme from 'hooks/useTheme';
 import React, { FC, InputHTMLAttributes } from 'react';
 import { DEFAULT_SIZE } from 'utils/size-utils';
@@ -7,6 +5,8 @@ import { DEFAULT_SIZE } from 'utils/size-utils';
 import Icon from '../Icon';
 import Label from '../Label';
 import { iconWrapperStyle, inputStyle } from './TextField.style';
+import { AcceptedIconNames } from 'components/Icon/types';
+import TextInputBase, { Props as TextInputWrapperProps } from 'components/TextInputBase';
 
 export type Props = {
   /** The id of the text field that will be used as for in label too */

--- a/src/components/TextInputBase/TextInputBase.tsx
+++ b/src/components/TextInputBase/TextInputBase.tsx
@@ -1,11 +1,11 @@
-import Icon from 'components/Icon';
-import { AcceptedIconNames } from 'components/Icon/types';
 import useTheme from 'hooks/useTheme';
 import React, { FC } from 'react';
 import { formFieldStyles } from 'theme/palette';
 import { DEFAULT_SIZE } from 'utils/size-utils';
 
 import { errorMsgStyle, textFieldStyle, wrapperStyle } from './TextInputBase.style';
+import Icon from 'components/Icon';
+import { AcceptedIconNames } from 'components/Icon/types';
 
 export type Props = {
   /** The label of the text field that will be used as a placeholder and a label */

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { render, fireEvent } from '../../test';
 import Toast from './Toast';
-import '@testing-library/jest-dom';
 
 describe('Generic Toast', () => {
   const data = {

--- a/src/components/storyUtils/BreadcrumbShowcase/BreadcrumbShowcase.tsx
+++ b/src/components/storyUtils/BreadcrumbShowcase/BreadcrumbShowcase.tsx
@@ -1,10 +1,10 @@
-import Breadcrumb from 'components/Breadcrumb';
 import { createBrowserHistory } from 'history';
 import { uniqueId } from 'lodash';
 import React, { useState, useEffect } from 'react';
 import { Router, Switch, Route } from 'react-router-dom';
 
 import { BreadcrumbItemData } from '../../Breadcrumb/types';
+import Breadcrumb from 'components/Breadcrumb';
 interface Props {
   initData: BreadcrumbItemData[];
 }

--- a/src/components/storyUtils/EdgeCasesSelectShowcase/EdgeCasesSelectShowcase.tsx
+++ b/src/components/storyUtils/EdgeCasesSelectShowcase/EdgeCasesSelectShowcase.tsx
@@ -1,5 +1,6 @@
-import Select from 'components/Select';
 import React from 'react';
+
+import Select from 'components/Select';
 
 const options = [
   { value: 'chocolate', label: 'Chocolate' },

--- a/src/components/storyUtils/FilterShowcase/FilterShowcase.tsx
+++ b/src/components/storyUtils/FilterShowcase/FilterShowcase.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import Filter from 'components/Filter';
 import { FilterOption, StyleType } from 'components/Filter/types';
-import React from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const dummyUnrefinedData = Array.from({ length: 15 }, (value, index) => ({

--- a/src/components/storyUtils/MenuShowcase/MenuShowcase.tsx
+++ b/src/components/storyUtils/MenuShowcase/MenuShowcase.tsx
@@ -1,5 +1,6 @@
-import Menu from 'components/Menu';
 import React from 'react';
+
+import Menu from 'components/Menu';
 
 const MenuShowcase = () => {
   const [selectedItem, setSelectedItem] = React.useState('');

--- a/src/components/storyUtils/RadioButtonsShowcase/RadioButtonsShowcase.tsx
+++ b/src/components/storyUtils/RadioButtonsShowcase/RadioButtonsShowcase.tsx
@@ -1,5 +1,6 @@
-import Radio from 'components/Radio';
 import React, { ReactEventHandler, useState } from 'react';
+
+import Radio from 'components/Radio';
 
 function RadioButtonsShowcase() {
   const [selectedValue, setSelectedValue] = useState('c');


### PR DESCRIPTION
Based on the previous work of @Christos-Zacharopoulos here: [Github](https://github.com/Orfium/orfium-ictinus/pull/271), this PR will extend the configuration of the eslint plugin, better encapsulating all kinds of imports.

NOTE: As noted in the library, imports like `import 'tippy.js/dist/tippy.css';` are left untouched because order might be important.

Also, removed some leftover imports that were unnecessary in some test files, since it was already added in the test's `setup.ts` file.