### PR TITLE
fix: [DS-240] truncated content to Filter menu

### DIFF
--- a/src/components/Filter/Filter.stories.mdx
+++ b/src/components/Filter/Filter.stories.mdx
@@ -85,7 +85,14 @@ A filter with colors and a selection handler to return selection on change and t
        <FilterShowcase
             styleType="filled"
             defaultValue={{
-                 label: 'default item is a very long text that should be overflow ellipsis',
+                 label: 'default item is a very long text that should not be overflow ellipsis',
+                 value: '1',
+            }}
+        />
+        <FilterShowcase
+            styleType="filled"
+            defaultValue={{
+                 label: 'default item is a very long text that should be overflow ellipsis because the max width of the component is smaller than the width of the text',
                  value: '1',
             }}
         />

--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -223,11 +223,12 @@ export const menuStyle = () => (theme: Theme) => css`
   top: ${rem(48)};
   min-width: ${rem(280)};
   left: 0;
-  width: 100%;
   height: auto;
   background-color: ${theme.palette.white};
   box-shadow: ${theme.elevation['02']};
   border-radius: ${rem(4)};
   z-index: 1;
   overflow: hidden;
+  min-width: 100%;
+  max-width: ${rem(620)};
 `;

--- a/src/components/Filter/__snapshots__/Filter.stories.storyshot
+++ b/src/components/Filter/__snapshots__/Filter.stories.storyshot
@@ -867,7 +867,64 @@ exports[`Storyshots Design System/Filter Filter with big text 1`] = `
                       <span
                         className="emotion-8"
                       >
-                        default item is a very long text that should be overflow ellipsis
+                        default item is a very long text that should not be overflow ellipsis
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    className="emotion-9"
+                    onClick={[Function]}
+                  >
+                    <span
+                      className="emotion-10"
+                    />
+                  </span>
+                </span>
+              </div>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style={
+        Object {
+          "margin": 5,
+        }
+      }
+    >
+      <div>
+        <div
+          role="button"
+        >
+          <div
+            className="emotion-2"
+          >
+            <button
+              className="emotion-3"
+              data-testid="filter"
+              disabled={false}
+              onClick={[Function]}
+            >
+              <div
+                className="emotion-4"
+              >
+                <span
+                  className="emotion-5"
+                >
+                  <span
+                    className="emotion-6"
+                  >
+                    <span
+                      className="emotion-7"
+                    >
+                      <div>
+                        Label :
+                      </div>
+                      <span
+                        className="emotion-8"
+                      >
+                        default item is a very long text that should be overflow ellipsis because the max width of the component is smaller than the width of the text
                       </span>
                     </span>
                   </span>


### PR DESCRIPTION
## Description
[DS-240](https://orfium.atlassian.net/browse/DS-240)
<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

+ If content's width is < = to filter's top, both top and menu have the same width
+ Menu's min width is 150 (same with min width of the top)
+ Menu's max width is 620 (same with min width of the top)

## Screenshot
<img width="1680" alt="Στιγμιότυπο 2021-08-12, 6 32 32 μμ" src="https://user-images.githubusercontent.com/3957883/129225129-80976ac7-63e8-463f-bcff-e3101549d747.png">


<img width="1680" alt="Στιγμιότυπο 2021-08-12, 6 32 27 μμ" src="https://user-images.githubusercontent.com/3957883/129225149-5578d312-0324-46f5-a67c-0349c09ee8c7.png">
<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
