### PR TITLE
fix: [DS-237] change hover bg-color to filter

### DIFF
--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -3,7 +3,6 @@ import { rem } from 'polished';
 
 import { Theme } from '../../theme';
 import { pickTextColorFromSwatches } from '../../theme/palette';
-import { stateBackgroundColor } from '../Button/utils';
 import { ButtonStyleProps } from './types';
 import {
   getBackgroundColor,
@@ -11,6 +10,7 @@ import {
   getBorder,
   getHoverBorder,
   borderStyleParams,
+  getHoverBackgroundColor,
 } from './utils';
 
 export const wrapperStyle = ({ styleType, hasSelectedValue, open }: ButtonStyleProps) => (
@@ -60,7 +60,7 @@ export const buttonWrapperStyle = ({
     ':hover > div, :active > div': {
       backgroundColor:
         !disabled && !open
-          ? stateBackgroundColor(theme, 'hover', calculatedColor, true)
+          ? getHoverBackgroundColor(theme, calculatedColor)
           : undefined,
       border: `${borderStyleParams} ${getHoverBorder({
         styleType,
@@ -69,11 +69,11 @@ export const buttonWrapperStyle = ({
         calculatedColor,
         hasSelectedValue,
       })}`,
-      color: pickTextColorFromSwatches(calculatedColor.color, 400),
+      color: pickTextColorFromSwatches(calculatedColor.color, open ? 400 : 100),
     },
     // hack to change color to arrow and close icons
     ':hover > div > span > span > svg path, :hover > div > span > svg path': {
-      fill: pickTextColorFromSwatches(calculatedColor.color, 400),
+      fill: pickTextColorFromSwatches(calculatedColor.color, open ? 400 : 100),
     }
   };
 };

--- a/src/components/Filter/__snapshots__/Filter.stories.storyshot
+++ b/src/components/Filter/__snapshots__/Filter.stories.storyshot
@@ -38,14 +38,14 @@ exports[`Storyshots Design System/Filter Async Filter 1`] = `
 
 .emotion-2:hover>div,
 .emotion-2:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-2:hover>div>span>span>svg path,
 .emotion-2:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-3 {
@@ -253,14 +253,14 @@ exports[`Storyshots Design System/Filter Async Filter with min characters 1`] = 
 
 .emotion-2:hover>div,
 .emotion-2:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-2:hover>div>span>span>svg path,
 .emotion-2:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-3 {
@@ -468,14 +468,14 @@ exports[`Storyshots Design System/Filter Dynamic Filter Props 1`] = `
 
 .emotion-2:hover>div,
 .emotion-2:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-2:hover>div>span>span>svg path,
 .emotion-2:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-3 {
@@ -699,14 +699,14 @@ exports[`Storyshots Design System/Filter Filter with big text 1`] = `
 
 .emotion-3:hover>div,
 .emotion-3:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-3:hover>div>span>span>svg path,
 .emotion-3:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-4 {
@@ -999,14 +999,14 @@ exports[`Storyshots Design System/Filter Filter with colors 1`] = `
 
 .emotion-3:hover>div,
 .emotion-3:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-3:hover>div>span>span>svg path,
 .emotion-3:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-4 {
@@ -1126,14 +1126,14 @@ exports[`Storyshots Design System/Filter Filter with colors 1`] = `
 
 .emotion-12:hover>div,
 .emotion-12:active>div {
-  background-color: #181f55;
-  border: solid 1px #181f55;
-  color: #fff;
+  background-color: #a8abcb;
+  border: solid 1px #a8abcb;
+  color: #000;
 }
 
 .emotion-12:hover>div>span>span>svg path,
 .emotion-12:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-13 {
@@ -1204,7 +1204,7 @@ exports[`Storyshots Design System/Filter Filter with colors 1`] = `
 
 .emotion-40:hover>div,
 .emotion-40:active>div {
-  background-color: #cc9f00;
+  background-color: #ffe68c;
   border: solid 1px transparent;
   color: #000;
 }
@@ -1256,8 +1256,8 @@ exports[`Storyshots Design System/Filter Filter with colors 1`] = `
 
 .emotion-49:hover>div,
 .emotion-49:active>div {
-  background-color: #cc9f00;
-  border: solid 1px #cc9f00;
+  background-color: #ffe68c;
+  border: solid 1px #ffe68c;
   color: #000;
 }
 
@@ -1833,14 +1833,14 @@ exports[`Storyshots Design System/Filter Filter with style types 1`] = `
 
 .emotion-3:hover>div,
 .emotion-3:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-3:hover>div>span>span>svg path,
 .emotion-3:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-4 {
@@ -1960,14 +1960,14 @@ exports[`Storyshots Design System/Filter Filter with style types 1`] = `
 
 .emotion-12:hover>div,
 .emotion-12:active>div {
-  background-color: #181f55;
-  border: solid 1px #181f55;
-  color: #fff;
+  background-color: #a8abcb;
+  border: solid 1px #a8abcb;
+  color: #000;
 }
 
 .emotion-12:hover>div>span>span>svg path,
 .emotion-12:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-13 {
@@ -2039,14 +2039,14 @@ exports[`Storyshots Design System/Filter Filter with style types 1`] = `
 
 .emotion-40:hover>div,
 .emotion-40:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-40:hover>div>span>span>svg path,
 .emotion-40:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-41 {
@@ -2144,14 +2144,14 @@ exports[`Storyshots Design System/Filter Filter with style types 1`] = `
 
 .emotion-53:hover>div,
 .emotion-53:active>div {
-  background-color: #181f55;
-  border: solid 1px #181f55;
-  color: #fff;
+  background-color: #a8abcb;
+  border: solid 1px #a8abcb;
+  color: #000;
 }
 
 .emotion-53:hover>div>span>span>svg path,
 .emotion-53:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-54 {
@@ -2751,14 +2751,14 @@ exports[`Storyshots Design System/Filter Searchable Filter 1`] = `
 
 .emotion-3:hover>div,
 .emotion-3:active>div {
-  background-color: #181f55;
+  background-color: #a8abcb;
   border: solid 1px transparent;
-  color: #fff;
+  color: #000;
 }
 
 .emotion-3:hover>div>span>span>svg path,
 .emotion-3:hover>div>span>svg path {
-  fill: #fff;
+  fill: #000;
 }
 
 .emotion-4 {

--- a/src/components/Filter/utils.ts
+++ b/src/components/Filter/utils.ts
@@ -1,6 +1,11 @@
+import { darken, lighten, transparentize } from 'polished';
+
+import { Theme } from '../../theme';
 import { colorShades, pickTextColorFromSwatches } from '../../theme/palette';
+import { ColorShapeFromComponent } from '../../utils/themeFunctions';
 import { defineBackgroundColor, stateBackgroundColor } from '../Button/utils';
 import { BackgroundColorProps, BaseColorProps, BorderProps, HoverBorderProps } from './types';
+
 
 export const FILTER_OPTIONS_MAX_HEIGHT = 253;
 
@@ -70,8 +75,18 @@ export const getHoverBorder = ({
     return `transparent`;
   }
   if (styleType === 'outlined' || hasSelectedValue) {
-    return `${stateBackgroundColor(theme, 'hover', calculatedColor, true)}`;
+    return `${getHoverBackgroundColor(theme, calculatedColor)}`;
   }
 
   return 'transparent';
+};
+
+export const getHoverBackgroundColor = (
+  theme: Theme,
+  calculatedColor: ColorShapeFromComponent,
+) => {
+  const value = 0.1;
+  const color = theme.utils.getColor(calculatedColor.color, 100);
+
+  return calculatedColor.shade > 400 ? lighten(value, color) : darken(value, color);
 };


### PR DESCRIPTION
## Description
[DS-237](https://orfium.atlassian.net/browse/DS-237)

Changed for `hover` state so as background color  to be 10% darken (or lighten) of the `default` color

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot
<img width="959" alt="Στιγμιότυπο 2021-08-17, 4 54 40 μμ" src="https://user-images.githubusercontent.com/3957883/129738607-0e9b22a5-7ab7-406d-8f65-90c790110df0.png">
<img width="917" alt="Στιγμιότυπο 2021-08-17, 6 20 20 μμ" src="https://user-images.githubusercontent.com/3957883/129753956-a05d268c-0d29-4ace-b5a0-15d67d0080cf.png">


<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
