### PR TITLE
[DS-266]: Fix/navigation parent item icon color

### DIFF
--- a/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
+++ b/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
@@ -45,7 +45,7 @@ const MenuItem: React.FC<Props> = memo(
             color={
               isCurrent
                 ? pickTextColorFromSwatches(color, shade)
-                : theme.utils.getColor('lightGrey', hasSubMenus ? 850 : 650)
+                : theme.utils.getColor('lightGrey', 850)
             }
             size={20}
             variant={isCurrent ? shade : BASE_SHADE}


### PR DESCRIPTION
## Description

Icon color on non expandable items should be the same as on expandable items.

Ticket: https://orfium.atlassian.net/browse/DS-266

## Screenshot

![image](https://user-images.githubusercontent.com/28539607/140040859-9c800474-0ed3-4237-92c7-5181d494b6d0.png)
