### PR TITLE
fix: adds toLowerCase in string equality

### DIFF
--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -1188,11 +1188,11 @@ exports[`Storyshots Design System/Button Button Types 1`] = `
 
 .emotion-17:hover,
 .emotion-17:focus {
-  background-color: transparent;
+  background-color: #528bea;
 }
 
 .emotion-17:active {
-  background-color: transparent;
+  background-color: #7fa9f0;
 }
 
 <div

--- a/src/components/Notification/__snapshots__/Notification.stories.storyshot
+++ b/src/components/Notification/__snapshots__/Notification.stories.storyshot
@@ -243,11 +243,11 @@ exports[`Storyshots Design System/Notification Inline Notification 1`] = `
 
 .emotion-14:hover,
 .emotion-14:focus {
-  background-color: transparent;
+  background-color: #528bea;
 }
 
 .emotion-14:active {
-  background-color: transparent;
+  background-color: #7fa9f0;
 }
 
 .emotion-15 {

--- a/src/hooks/useTypeColorToColorMatch.tsx
+++ b/src/hooks/useTypeColorToColorMatch.tsx
@@ -59,7 +59,7 @@ const calculateTypesShadeAndColors = (
     mainTypeAcc[mainType] = flatPaletteKeys.reduce((acc, paletteColor) => {
       const colorShadesKeys = keys(palette[paletteColor]); // the shades of the palette color currently in the iteration
       const foundShadeWithThatColor = colorShadesKeys.find(
-        shade => palette[paletteColor][shade] === typeColor
+        shade => palette[paletteColor][shade].toLowerCase() === typeColor.toLowerCase()
       );
 
       // return either the found color as e.g { shade: 500, color: 'orange'} or the object as it was


### PR DESCRIPTION
Remember all those times that the text returned black when it should have been white? All those times `primary` didn't work? Well, `#8c0d95 === #8C0D95` returns false :) *screams internally*