### PR TITLE
fix: fix color calculations

### DIFF
--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -66,7 +66,6 @@ export const buttonWrapperStyle = ({
 
 export const buttonBaseStyle = ({
   calculatedColor,
-  activeCalculatedColor,
   disabled,
   open,
   styleType,
@@ -82,7 +81,6 @@ export const buttonBaseStyle = ({
     color: getTextColor({
       theme,
       open,
-      activeCalculatedColor,
       calculatedColor,
       hasSelectedValue,
     }),
@@ -91,14 +89,12 @@ export const buttonBaseStyle = ({
       open,
       styleType,
       hasSelectedValue,
-      activeCalculatedColor,
       calculatedColor,
     }),
     border: `${borderStyleParams} ${getBorder({
       styleType,
       theme,
       hasSelectedValue,
-      activeCalculatedColor,
       filterType,
       calculatedColor,
       open,
@@ -109,7 +105,6 @@ export const buttonBaseStyle = ({
         styleType,
         theme,
         hasSelectedValue,
-        activeCalculatedColor,
         filterType,
         calculatedColor,
         open,
@@ -120,14 +115,7 @@ export const buttonBaseStyle = ({
 };
 
 export const divider = (props: ButtonStyleProps) => (theme: Theme) => {
-  const {
-    open,
-    activeCalculatedColor,
-    calculatedColor,
-    styleType,
-    hasSelectedValue,
-    filterType,
-  } = props;
+  const { open, calculatedColor, styleType, hasSelectedValue, filterType } = props;
 
   return {
     height: '100%',
@@ -137,7 +125,6 @@ export const divider = (props: ButtonStyleProps) => (theme: Theme) => {
       styleType,
       theme,
       hasSelectedValue,
-      activeCalculatedColor,
       filterType,
       calculatedColor,
       open,
@@ -147,7 +134,6 @@ export const divider = (props: ButtonStyleProps) => (theme: Theme) => {
       styleType,
       theme,
       hasSelectedValue,
-      activeCalculatedColor,
       filterType,
       calculatedColor,
       open,
@@ -156,7 +142,6 @@ export const divider = (props: ButtonStyleProps) => (theme: Theme) => {
       styleType,
       theme,
       hasSelectedValue,
-      activeCalculatedColor,
       filterType,
       calculatedColor,
       open,

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -54,15 +54,9 @@ const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
     Boolean(selectedItem?.value) && selectedItem?.value !== defaultValue.value;
   const calculatedColor = calculateColorBetweenColorAndType('', buttonType);
 
-  // The active calculated color is the base of the defined color. So till today the base is defined as '500'.
-  const activeCalculatedColor = calculateColorBetweenColorAndType(
-    `${calculatedColor.color}-${BASE_SHADE}`,
-    buttonType
-  );
   const iconColor = getTextColor({
     open,
     theme,
-    activeCalculatedColor,
     calculatedColor,
     hasSelectedValue,
   });
@@ -112,7 +106,6 @@ const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
 
   const buttonStyleProps = {
     calculatedColor,
-    activeCalculatedColor,
     buttonType,
     disabled,
     open,

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -52,7 +52,6 @@ export type BaseColorProps = {
   open: boolean;
   theme: Theme;
   calculatedColor: ColorShapeFromComponent;
-  activeCalculatedColor: ColorShapeFromComponent;
   hasSelectedValue: boolean;
 };
 

--- a/src/components/Filter/utils.ts
+++ b/src/components/Filter/utils.ts
@@ -14,13 +14,12 @@ export const getBackgroundColor = ({
   theme,
   hasSelectedValue,
   calculatedColor,
-  activeCalculatedColor,
   styleType,
 }: BackgroundColorProps) => {
   if (open) {
-    return theme.utils.getColor(activeCalculatedColor.color, 500);
+    return theme.utils.getColor(calculatedColor.color, 500);
   } else if (hasSelectedValue) {
-    return theme.utils.getColor(activeCalculatedColor.color, 50);
+    return theme.utils.getColor(calculatedColor.color, 50);
   } else if (styleType === 'filled') {
     return theme.utils.getColor('neutralWhite', 100);
   } else if (styleType === 'transparent') {
@@ -34,12 +33,12 @@ export const getTextColor = ({
   open,
   theme,
   hasSelectedValue,
-  activeCalculatedColor,
+  calculatedColor,
 }: BaseColorProps) => {
   if (hasSelectedValue && !open) {
-    return pickTextColorFromSwatches(activeCalculatedColor.color, 50);
+    return pickTextColorFromSwatches(calculatedColor.color, 50);
   } else if (open) {
-    return pickTextColorFromSwatches(activeCalculatedColor.color, activeCalculatedColor.shade);
+    return pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade);
   }
 
   return theme.utils.getColor('darkGrey', 850);
@@ -63,9 +62,15 @@ export const getBorder = ({
   if (state === 'normal' && styleType === 'transparent' && !open && !hasSelectedValue) {
     return `transparent`;
   }
+
   if (isDivider && open) {
     return `transparent`;
   }
+
+  if (hasSelectedValue && open) {
+    return `transparent`;
+  }
+
   if (hasSelectedValue) {
     const shadeCalculated = addOrSubtract(calculatedColor.shade);
 
@@ -84,7 +89,6 @@ export const getHoverBorder = ({
   theme,
   open,
   calculatedColor,
-  activeCalculatedColor,
   hasSelectedValue,
   filterType,
 }: HoverBorderProps) => {
@@ -93,7 +97,7 @@ export const getHoverBorder = ({
   }
   if (hasSelectedValue) {
     if (open) {
-      return `${stateBackgroundColor(theme, 'hover', activeCalculatedColor, true)}`;
+      return `${stateBackgroundColor(theme, 'hover', calculatedColor, true)}`;
     }
 
     return `${stateBackgroundColor(theme, 'hover', calculatedColor, true)}`;


### PR DESCRIPTION
## Description

- Fix Filter color calculations by deprecating the `activeCalculatedColor` variable and only using the generated palette that is provided by the user through the `theme` prop (`calculatedColor`)

Before (secondary: `blue-600`): 
![image](https://user-images.githubusercontent.com/13350837/140730563-c1cc2e6d-f891-41a1-a902-2ad7fc510510.png)


After (secondary: `blue-600`): 
![image](https://user-images.githubusercontent.com/13350837/140730348-1749d5ab-0625-43f4-a0fa-27c2ac17ef0e.png)
