### PR TITLE
fix: make filters take up full width when min-width is triggered

### DIFF
--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -40,7 +40,7 @@ export const buttonWrapperStyle = ({
     alignItems: 'center',
     height: '100%',
     maxWidth: rem(270),
-    minWidth: rem(150),
+    minWidth: rem(110),
 
     ':hover > div, :active > div': {
       backgroundColor:

--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -100,6 +100,8 @@ export const buttonBaseStyle = ({
       open,
     })}`,
     display: 'flex',
+    justifyContent: 'center',
+    width: '100%',
     '&:hover': {
       border: `${borderStyleParams} ${getBorder({
         styleType,


### PR DESCRIPTION
## Description

- Fixes issue where filters would not take up the full min-width space when they were smaller than 150px

## Screenshot

Before: 
![image](https://user-images.githubusercontent.com/13350837/142471119-79038c7d-5a7b-4a95-812c-3b163c39e3cc.png)

After: 
![image](https://user-images.githubusercontent.com/13350837/142471176-97199c8c-2487-4a7a-9b3b-ff9f7b045652.png)



**PS: ~We can also completely remove the `min-width` rule. Please advise. This proposal accommodates the min-width rule.~ The designs show an updated `min-width` of `110px`.**