### PR TITLE
Hotfix/truncation tooltip

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -14,15 +14,26 @@ import { ExtendedColumn, Sort, SortingOrder } from './types';
 import { isItemString } from './utils';
 
 export type ContentComponent<T> = (data: Cell<T>) => React.Component | JSX.Element;
-export type Cell<T> = {
-  content: number | string | ContentComponent<T>;
-  tooltipContent?: string;
+
+type CellBase = {
   hasTruncatedTooltip?: boolean;
   colSpan?: number;
   type?: 'financial' | 'normal';
   align?: 'left' | 'right';
   widthPercentage?: number;
 };
+
+type JSXCell<T> = CellBase & {
+  content: ContentComponent<T>;
+  tooltipContent: string;
+};
+
+type NormalCell = CellBase & {
+  content: number | string;
+  tooltipContent?: string;
+};
+
+export type Cell<T> = NormalCell | JSXCell<T>;
 
 export type Row<T> = {
   id: string | number;

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
@@ -57,13 +57,9 @@ const ContentCell: React.FC<Props> = ({
         </div>
       )}
 
-      <TruncatedContent
-        placement={'bottom'}
-        shouldAlwaysShow={isComponentFunctionType(content) && !!tooltipContent}
-        tooltipContent={tooltipContent}
-      >
+      <TruncatedContent placement={'bottom'} tooltipContent={tooltipContent}>
         {isComponentFunctionType(content) ? (
-          content({ content, colSpan })
+          content({ content, colSpan, tooltipContent: tooltipContent ?? '' })
         ) : (
           <span data-column={columns[cellCounter]}>{content}</span>
         )}

--- a/src/components/TruncatedContent/TruncatedContent.stories.mdx
+++ b/src/components/TruncatedContent/TruncatedContent.stories.mdx
@@ -30,7 +30,8 @@ Regular Text with truncation and tooltip
 <Preview>
   <Story name="Regular Text with truncation and tooltip">
     <div style={{ width: 150 }}>
-      <TruncatedContent tooltipContent="This is a long text that will overflow">This is a long text that will overflow</TruncatedContent>
+      <TruncatedContent tooltipContent="This is a long text that will overflow">This is a long text that will
+        overflow</TruncatedContent>
     </div>
   </Story>
 </Preview>
@@ -60,7 +61,7 @@ Regular Table with cell tooltips
             { content: 'No tooltip', hasTruncatedTooltip: false },
             { content: () => <span>JSX Content without tooltip</span> },
             {
-              content: () => <span>JSX Content with forced tooltip</span>,
+              content: () => <span>JSX Content with long long long text and a forced tooltip</span>,
               tooltipContent: 'This is a kinda long (that could be longer) tooltip from a prop',
             },
           ],

--- a/src/components/TruncatedContent/TruncatedContent.tsx
+++ b/src/components/TruncatedContent/TruncatedContent.tsx
@@ -6,18 +6,11 @@ import Tooltip from 'components/Tooltip';
 type Props = {
   /** The content of the tooltip */
   tooltipContent: string | undefined;
-  /** Flag for overriding other settings to always show the tooltip */
-  shouldAlwaysShow?: boolean;
   /** The placement of the tooltip */
   placement?: 'top' | 'bottom' | 'right' | 'left';
 };
 
-const TruncatedContent: React.FC<Props> = ({
-  children,
-  shouldAlwaysShow = false,
-  tooltipContent,
-  placement = 'bottom',
-}) => {
+const TruncatedContent: React.FC<Props> = ({ children, tooltipContent, placement = 'bottom' }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   const targetRef = useRef<HTMLDivElement>(null);
@@ -33,21 +26,12 @@ const TruncatedContent: React.FC<Props> = ({
 
   const isTruncated = useMemo(() => {
     return !!target && target.scrollWidth > target.offsetWidth;
-  }, [target]);
+  }, [target, target?.offsetWidth]);
 
   const showTooltip = useCallback(
-    (
-      tooltipContent: string | undefined,
-      isHovered: boolean,
-      isTruncated: boolean,
-      shouldAlwaysShow: boolean
-    ) => {
+    (tooltipContent: string | undefined, isHovered: boolean, isTruncated: boolean) => {
       if (tooltipContent === undefined) {
         return false;
-      }
-
-      if (shouldAlwaysShow) {
-        return true;
       }
 
       return isHovered && isTruncated;
@@ -55,7 +39,7 @@ const TruncatedContent: React.FC<Props> = ({
     []
   );
 
-  return showTooltip(tooltipContent, isHovered, isTruncated, shouldAlwaysShow) ? (
+  return showTooltip(tooltipContent, isHovered, isTruncated) ? (
     <Tooltip placement={placement} content={tooltipContent}>
       <TruncationDiv
         ref={targetRef}

--- a/src/components/TruncatedContent/__snapshots__/TruncatedContent.stories.storyshot
+++ b/src/components/TruncatedContent/__snapshots__/TruncatedContent.stories.storyshot
@@ -75,25 +75,6 @@ exports[`Storyshots System/Truncated Text with Tooltip Regular Table with cell t
   white-space: nowrap;
 }
 
-.emotion-19 {
-  background: transparent;
-}
-
-.emotion-19 .tippy-content {
-  color: #fff;
-  background-color: #0f0f17;
-  max-width: 16rem;
-  padding: 0.5rem;
-  font-size: 0.875rem;
-  line-height: 110%;
-  border-radius: 0.5rem;
-  text-align: justify;
-}
-
-.emotion-19 .tippy-arrow {
-  color: #0f0f17;
-}
-
 <div
   style={
     Object {
@@ -228,23 +209,13 @@ exports[`Storyshots System/Truncated Text with Tooltip Regular Table with cell t
           data-testid="ictinus_table_row_1_cell_4"
         >
           <div
-            className="emotion-19"
-            interactive={false}
-            interactiveDebounce={100}
-            placement="bottom"
+            className="emotion-13"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
-            <div
-              className="emotion-13"
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-            >
-              <span>
-                JSX Content with forced tooltip
-              </span>
-            </div>
-          </div>
-          <div>
-            This is a kinda long (that could be longer) tooltip from a prop
+            <span>
+              JSX Content with long long long text and a forced tooltip
+            </span>
           </div>
         </td>
       </tr>


### PR DESCRIPTION
## Description

- Extend Table types to include `tooltipContent` as a required prop, when content is JSX
- Added `offsetWidth` to dependency array, so that the tooltip calculation updates on zoom/res change
- Removed `shouldAlwaysShow` prop as it was unnecessary