### PR TITLE
chore: update ci for style to create patch release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,6 +5,7 @@
         "preset": "angular",
         "releaseRules": [
           {"type": "docs", "scope":"DOCUMENTATION", "release": "patch"},
+          {"type": "style", "release": "patch"}
         ]
       }],
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Description

This PR adds `style` word to the semantic release to trigger patch release. Now it skips it like `chore`