### PR TITLE
fix: add color swatch and resize icons in filter

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -4545,11 +4545,6 @@ exports[`Storyshots Design System/DatePicker DatePicker with Filter 1`] = `
   background-color: #d0defd;
 }
 
-.emotion-5:focus>span {
-  border-top: solid 0.125rem #1451dc;
-  border-bottom: solid 0.125rem #1451dc;
-}
-
 .emotion-6 {
   font-size: 0.8125rem;
   cursor: pointer;

--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -58,10 +58,11 @@ export const buttonWrapperStyle = ({
         backgroundColor: theme.utils.getColor('blue', 50),
       },
     // target the divider on focus
-    ':focus > span': !open && {
-      borderTop: `${focusBorderStyleParams} ${theme.utils.getColor('blue', 550)}`,
-      borderBottom: `${focusBorderStyleParams} ${theme.utils.getColor('blue', 550)}`,
-    },
+    ':focus > span': !open &&
+      !hasSelectedValue && {
+        borderTop: `${focusBorderStyleParams} ${theme.utils.getColor('blue', 550)}`,
+        borderBottom: `${focusBorderStyleParams} ${theme.utils.getColor('blue', 550)}`,
+      },
   };
 };
 

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -1,5 +1,3 @@
-import useTheme from 'hooks/useTheme';
-import { useTypeColorToColorMatch } from 'hooks/useTypeColorToColorMatch';
 import { debounce } from 'lodash';
 import React, { useMemo } from 'react';
 import { ChangeEvent } from 'utils/common';
@@ -11,7 +9,6 @@ import Options from './components/Options/Options';
 import SearchInput from './components/SearchInput/SearchInput';
 import { menuStyle } from './Filter.style';
 import { FilterOption, Props } from './types';
-import { getTextColor } from './utils';
 import handleSearch from 'components/utils/handleSearch';
 
 const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
@@ -36,18 +33,9 @@ const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [searchValue, setSearchValue] = React.useState('');
 
-  const theme = useTheme();
-  const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const hasSelectedValue =
     Boolean(selectedItem?.value) && selectedItem?.value !== defaultValue.value;
-  const calculatedColor = calculateColorBetweenColorAndType('', buttonType);
 
-  const iconColor = getTextColor({
-    open: isOpen,
-    theme,
-    calculatedColor,
-    hasSelectedValue,
-  });
   const iconName = isOpen ? 'triangleUp' : 'triangleDown';
 
   const handleSelect = (option: FilterOption) => {
@@ -143,5 +131,5 @@ const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
     </ClickAwayListener>
   );
 });
-
+Filter.displayName = 'Filter';
 export default Filter;

--- a/src/components/Filter/components/FilterBase/FilterBase.tsx
+++ b/src/components/Filter/components/FilterBase/FilterBase.tsx
@@ -17,6 +17,7 @@ import {
   wrapperStyle,
 } from '../../Filter.style';
 import { Props } from '../../types';
+import { getTextColor } from '../../utils';
 
 type FilterBaseProps = {
   children?: ReactNode;
@@ -55,20 +56,15 @@ export const FilterBase = forwardRef<
   const calculatedColor = calculateColorBetweenColorAndType('', buttonType);
   const theme = useTheme();
 
-  const buttonStyleProps = {
-    calculatedColor,
-    buttonType,
-    disabled,
-    open,
-    styleType,
-    hasSelectedValue,
-    filterType,
-  };
-
   const pickIconColor = useCallback(
     (isCloseButton = false) => {
       if (open) {
-        return theme.utils.getColor('neutralWhite', 100);
+        return getTextColor({
+          theme,
+          open,
+          calculatedColor,
+          hasSelectedValue,
+        });
       }
       if (isCloseButton) {
         if (hasSelectedValue) {
@@ -80,8 +76,18 @@ export const FilterBase = forwardRef<
 
       return theme.utils.getColor('darkGrey', 850);
     },
-    [calculatedColor.color, hasSelectedValue, open, theme.utils]
+    [calculatedColor.color, hasSelectedValue, open, theme.utils, theme.palette]
   );
+
+  const buttonStyleProps = {
+    calculatedColor,
+    buttonType,
+    disabled,
+    open,
+    styleType,
+    hasSelectedValue,
+    filterType,
+  };
 
   return (
     <div css={wrapperStyle()} data-testid={dataTestId}>
@@ -98,14 +104,14 @@ export const FilterBase = forwardRef<
               <span css={labelSpanStyle(open, hasSelectedValue)}>
                 {label && (
                   <div>
-                    {label} {!isDatePicker ? ':' : ''}
+                    {label} {!isDatePicker ? <>:&nbsp;</> : ''}
                   </div>
                 )}
                 {selectedItemLabel && <span css={valueSpanStyle()}>{selectedItemLabel}</span>}
               </span>
             </div>
 
-            <Icon name={iconName} size={14} color={pickIconColor()} />
+            <Icon name={iconName} size={isDatePicker ? 14 : 7} color={pickIconColor()} />
           </div>
         </div>
 


### PR DESCRIPTION
## Description
[DS-317]

- Resizes icons inside filter between types (arrowUp, calendar)
- Adds color swatch functionality to icons
- Adds whitespace after ':' in label

## Screenshot
After:
![image](https://user-images.githubusercontent.com/13350837/146945336-6ba706df-d265-4efe-bfa0-8d32323ec642.png)


[DS-317]: https://orfium.atlassian.net/browse/DS-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ