### PR TITLE
[NO-JIRA] Refactor / palette functions

### DIFF
--- a/src/components/Avatar/Avatar.style.ts
+++ b/src/components/Avatar/Avatar.style.ts
@@ -3,7 +3,7 @@ import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
 import { flex } from '../../theme/functions';
-import { colorShades, flatColors, pickTextColorFromSwatches } from '../../theme/palette';
+import { colorShades, flatColors } from '../../theme/palette';
 import { AvatarSizes } from './Avatar';
 
 export const sizeBasedOnProp = (size: AvatarSizes): number => {
@@ -57,7 +57,7 @@ export const avatarStyle = ({
   line-height: 1;
   user-select: none;
   justify-content: center;
-  color: ${pickTextColorFromSwatches(fill, fillShade)};
+  color: ${theme.utils.getAAColorFromSwatches(fill, fillShade)};
 
   img {
     border-radius: 100%;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { pickTextColorFromSwatches } from '../../theme/palette';
+import { useTheme } from '../../index';
 import { DivProps } from '../../utils/common';
 import { calculateActualColorFromComponentProp } from '../../utils/themeFunctions';
 import Icon from '../Icon';
@@ -26,7 +26,7 @@ export type Props = {
   className?: string;
 };
 
-export type AvatarSizes =   'xs' | 'sm' | 'md' | 'lg';
+export type AvatarSizes = 'xs' | 'sm' | 'md' | 'lg';
 
 const iconSizeBasedOnAvatar = (size: AvatarSizes) => {
   switch (size) {
@@ -46,6 +46,7 @@ const Avatar = React.forwardRef<HTMLDivElement, Props & DivProps>(
     { src = '', iconName = 'user', size = 'md', color = 'lightGrey-600', children, className },
     ref
   ) => {
+    const theme = useTheme();
     const calculatedColor = calculateActualColorFromComponentProp(color);
 
     return (
@@ -61,7 +62,7 @@ const Avatar = React.forwardRef<HTMLDivElement, Props & DivProps>(
         {src && <img src={src} />}
         {!src && !children && iconName && (
           <Icon
-            color={pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)}
+            color={theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade)}
             name={iconName}
             size={iconSizeBasedOnAvatar(size)}
           />

--- a/src/components/ButtonBase/ButtonBase.style.ts
+++ b/src/components/ButtonBase/ButtonBase.style.ts
@@ -2,7 +2,6 @@ import { transparentize } from 'polished';
 import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
-import { pickTextColorFromSwatches } from '../../theme/palette';
 import { RequiredProperties } from '../../utils/common';
 import { ColorShapeFromComponent } from '../../utils/themeFunctions';
 import { Props } from './ButtonBase';
@@ -66,7 +65,7 @@ export const buttonBaseStyle = ({
       );
     }
 
-    return pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade);
+    return theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade);
   };
   const baseButtonStyles = {
     fontSize: fontSizeBasedOnSize(theme, size),

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,7 +1,6 @@
 import { useTypeColorToColorMatch } from 'hooks/useTypeColorToColorMatch';
 import * as React from 'react';
 import { ChangeEvent, useEffect } from 'react';
-import { pickTextColorFromSwatches } from 'theme/palette';
 
 import { generateTestDataId, generateUniqueID } from '../../utils/helpers';
 import { TestId } from '../../utils/types';
@@ -13,6 +12,7 @@ import {
   markerStyle,
 } from './CheckBox.style';
 import Icon from 'components/Icon';
+import { useTheme } from '../../index';
 
 export type Props = {
   /** The label of the checkbox. */
@@ -53,6 +53,7 @@ const CheckBox = React.forwardRef<HTMLSpanElement, Props>(
     const [isChecked, setIsChecked] = React.useState(Boolean(checked));
     const inputRef = React.useRef<HTMLInputElement>(null);
 
+    const theme = useTheme();
     const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
     const { color, shade } = calculateColorBetweenColorAndType('', 'primary');
 
@@ -76,7 +77,7 @@ const CheckBox = React.forwardRef<HTMLSpanElement, Props>(
     return (
       <span ref={ref} css={wrapperStyle({ disabled })}>
         <span
-          css={checkboxWrapperStyle({disabled})}
+          css={checkboxWrapperStyle({ disabled })}
           onClick={e => {
             e.stopPropagation();
             if (e.currentTarget === e.target) {
@@ -99,7 +100,7 @@ const CheckBox = React.forwardRef<HTMLSpanElement, Props>(
             <Icon
               name={intermediate ? 'minus' : 'checkmark'}
               size={24}
-              color={pickTextColorFromSwatches(color, shade)}
+              color={theme.utils.getAAColorFromSwatches(color, shade)}
             />
           </label>
         </span>

--- a/src/components/Chip/components/Badge/Badge.style.ts
+++ b/src/components/Chip/components/Badge/Badge.style.ts
@@ -1,7 +1,6 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { Theme } from 'theme';
 import { flex } from 'theme/functions';
-import { pickTextColorFromSwatches } from 'theme/palette';
 
 import { Props } from '../../Chip';
 
@@ -22,6 +21,6 @@ export const badgeStyle = ({ fill = 'greyScale', isSelected }: Props) => (
   line-height: normal;
   justify-content: center;
   color: ${isSelected
-    ? pickTextColorFromSwatches(fill, 550)
-    : pickTextColorFromSwatches('lightGrey', 200)};
+    ? theme.utils.getAAColorFromSwatches(fill, 550)
+    : theme.utils.getAAColorFromSwatches('lightGrey', 200)};
 `;

--- a/src/components/DatePicker/Day/Day.style.ts
+++ b/src/components/DatePicker/Day/Day.style.ts
@@ -2,7 +2,6 @@ import { css, SerializedStyles } from '@emotion/react';
 import { Theme } from 'theme';
 import { rem } from 'theme/utils';
 
-import { pickTextColorFromSwatches } from '../../../theme/palette';
 import { ColorShapeFromComponent } from '../../../utils/themeFunctions';
 
 type Props = {
@@ -32,7 +31,7 @@ export const dayWrapperStyle = ({
   cursor: pointer;
   position: relative;
   color: ${isSelected
-    ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
+    ? theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade)
     : theme.utils.getColor('darkGrey', 850)};
   width: ${rem(40)};
   padding: 0 ${rem(4)};

--- a/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
+++ b/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
@@ -1,7 +1,7 @@
 import { useTypeColorToColorMatch } from 'hooks/useTypeColorToColorMatch';
 import React, { memo, useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
-import { BASE_SHADE, pickTextColorFromSwatches } from 'theme/palette';
+import { BASE_SHADE } from 'theme/palette';
 
 import useTheme from '../../../../hooks/useTheme';
 import {
@@ -44,7 +44,7 @@ const MenuItem: React.FC<Props> = memo(
             name={iconName}
             color={
               isCurrent
-                ? pickTextColorFromSwatches(color, shade)
+                ? theme.utils.getAAColorFromSwatches(color, shade)
                 : theme.utils.getColor('lightGrey', 850)
             }
             size={20}

--- a/src/components/Filter/utils.ts
+++ b/src/components/Filter/utils.ts
@@ -1,6 +1,6 @@
 import { rem } from 'theme/utils';
 
-import { colorShades, pickTextColorFromSwatches } from '../../theme/palette';
+import { colorShades } from '../../theme/palette';
 import { defineBackgroundColor, stateBackgroundColor } from '../Button/utils';
 import { BackgroundColorProps, BaseColorProps, BorderProps, HoverBorderProps } from './types';
 
@@ -36,9 +36,9 @@ export const getTextColor = ({
   calculatedColor,
 }: BaseColorProps) => {
   if (hasSelectedValue && !open) {
-    return pickTextColorFromSwatches(calculatedColor.color, 50);
+    return theme.utils.getAAColorFromSwatches(calculatedColor.color, 50);
   } else if (open) {
-    return pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade);
+    return theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade);
   }
 
   return theme.utils.getColor('darkGrey', 850);

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { useTypeColorToColorMatch } from '../../hooks/useTypeColorToColorMatch';
 import { useTheme } from '../../index';
-import { pickTextColorFromSwatches } from '../../theme/palette';
 import { EventProps } from '../../utils/common';
 import { TestProps } from '../../utils/types';
 import { defineBackgroundColor } from '../Button/utils';
@@ -25,7 +24,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, Props & TestProps & Event
     const calculatedColor = calculateColorBetweenColorAndType(color, type);
     const iconColor =
       filled && !transparent
-        ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
+        ? theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade)
         : defineBackgroundColor(theme, calculatedColor, type, true, true);
 
     return (

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -2,7 +2,6 @@ import useTheme from 'hooks/useTheme';
 import { useTypeColorToColorMatch } from 'hooks/useTypeColorToColorMatch';
 import isEmpty from 'lodash/isEmpty';
 import * as React from 'react';
-import { pickTextColorFromSwatches } from 'theme/palette';
 import { EventProps } from 'utils/common';
 import { AcceptedColorComponentTypes } from 'utils/themeFunctions';
 
@@ -77,7 +76,7 @@ const Menu: React.FC<Props & TestProps & EventProps> = props => {
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const calculatedColor = calculateColorBetweenColorAndType(color, buttonType);
   const iconColor = filled
-    ? pickTextColorFromSwatches(calculatedColor.color, calculatedColor.shade)
+    ? theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade)
     : defineBackgroundColor(theme, calculatedColor, buttonType, true, true);
 
   return (

--- a/src/components/Tooltip/Tooltip.style.ts
+++ b/src/components/Tooltip/Tooltip.style.ts
@@ -2,7 +2,6 @@ import { css, SerializedStyles } from '@emotion/react';
 import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
-import { pickTextColorFromSwatches } from '../../theme/palette';
 import { TooltipSize } from './Tooltip';
 import 'tippy.js/dist/tippy.css';
 
@@ -30,7 +29,7 @@ export const tooltipStyle = ({
   return css`
     background: transparent;
     .tippy-content {
-      color: ${pickTextColorFromSwatches(color, shade)};
+      color: ${theme.utils.getAAColorFromSwatches(color, shade)};
       background-color: ${backgroundColor};
       max-width: ${rem(256)};
       padding: ${theme.spacing.sm};

--- a/src/components/storyUtils/ColorUtility/ColorUtility.tsx
+++ b/src/components/storyUtils/ColorUtility/ColorUtility.tsx
@@ -1,7 +1,7 @@
 import { toPairs } from 'lodash';
 import React from 'react';
 
-import { TextField } from '../../../index';
+import { TextField, useTheme } from '../../../index';
 import { colorShadesCreator } from '../../../theme/utils';
 import { colorBox, colorBoxWrapper } from '../PaletteShowcase/PaletteShowcase.style';
 import ColorBox from './ColorBox';
@@ -11,6 +11,8 @@ import { useColors } from './useColors';
 const DEFAULT_COLOR = 'white';
 
 const ColorUtility = ({ defaultColor }: { defaultColor?: string }) => {
+  const theme = useTheme();
+
   const { color, updateColor, setDarkenValue, setLightenValue, utilityValues } = useColors(
     defaultColor
   );
@@ -18,6 +20,7 @@ const ColorUtility = ({ defaultColor }: { defaultColor?: string }) => {
   const palette = colorShadesCreator(color.normal);
   const colors = toPairs(palette);
 
+  // @ts-ignore
   return (
     <div style={{ flex: 1 }}>
       <h1> Color Utility </h1>
@@ -49,10 +52,15 @@ const ColorUtility = ({ defaultColor }: { defaultColor?: string }) => {
         </div>
         <div css={colorBoxWrapper}>
           {colors.map(([shade, color]) => (
-            // @ts-ignore
             <div
               key={`${shade}-${color}`}
-              css={colorBox({ color, isSelectedColor: false, isHoverable: false })}
+              css={colorBox({
+                // @ts-ignore
+                theme,
+                color,
+                isSelectedColor: false,
+                isHoverable: false,
+              })}
             >
               <div>{shade}</div>
               <div css={{ textTransform: 'capitalize' }}>{color}</div>

--- a/src/components/storyUtils/PaletteShowcase/PaletteShowcase.style.tsx
+++ b/src/components/storyUtils/PaletteShowcase/PaletteShowcase.style.tsx
@@ -1,12 +1,8 @@
 import { css, SerializedStyles } from '@emotion/react';
 
+import { Theme } from '../../../theme';
 import { transition } from '../../../theme/functions';
-import {
-  colorShades,
-  flatColors,
-  getAATextColor,
-  pickTextColorFromSwatches,
-} from '../../../theme/palette';
+import { colorShades, flatColors } from '../../../theme/palette';
 
 export const paletteWrapper = css`
   display: grid;
@@ -22,6 +18,7 @@ export const paletteColorWrapper = css`
 `;
 
 export const colorNameBox = (
+  theme: Theme,
   color: string,
   colorName?: typeof flatColors[number],
   shade?: typeof colorShades[number]
@@ -33,8 +30,10 @@ export const colorNameBox = (
   display: flex;
   flex-direction: column;
   color: ${shade && colorName
-    ? pickTextColorFromSwatches(colorName, shade)
-    : getAATextColor(color)};
+    ? //@ts-ignore
+      theme.utils.getAAColorFromSwatches(colorName, shade)
+    : //@ts-ignore
+      theme.utils.getAAColor(color)};
 `;
 
 export const colorBoxWrapper = css`
@@ -45,6 +44,7 @@ export const colorBoxWrapper = css`
 `;
 
 type Props = {
+  theme: Theme;
   color: string;
   colorName?: typeof flatColors[number];
   shade?: typeof colorShades[number];
@@ -53,6 +53,7 @@ type Props = {
 };
 
 export const colorBox = ({
+  theme,
   color,
   colorName,
   shade,
@@ -63,8 +64,10 @@ export const colorBox = ({
   width: calc(100% - 20px);
   background: ${color};
   color: ${shade && colorName
-    ? pickTextColorFromSwatches(colorName, shade)
-    : getAATextColor(color)};
+    ? //@ts-ignore
+      theme.utils.getAAColorFromSwatches(colorName, shade)
+    : //@ts-ignore
+      theme.utils.getAAColor(color)};
   justify-content: space-between;
   align-items: center;
   display: flex;

--- a/src/components/storyUtils/PaletteShowcase/PaletteShowcase.tsx
+++ b/src/components/storyUtils/PaletteShowcase/PaletteShowcase.tsx
@@ -51,7 +51,15 @@ const PaletteShowcase = () => {
           // .filter(([colorName]) => !neutralColors.find(neutralColor => neutralColor === colorName))
           .map(([colorName, colors]) => (
             <div key={colorName} css={paletteColorWrapper}>
-              <div css={colorNameBox(colors[Math.floor(colors.length / 2)], colorName, BASE_SHADE)}>
+              <div
+                css={colorNameBox(
+                  // @ts-ignore
+                  theme,
+                  colors[Math.floor(colors.length / 2)],
+                  colorName,
+                  BASE_SHADE
+                )}
+              >
                 <div
                   css={css`
                     flex: 1;
@@ -79,6 +87,8 @@ const PaletteShowcase = () => {
                       setPaletteColor(color);
                     }}
                     css={colorBox({
+                      // @ts-ignore
+                      theme,
                       color,
                       colorName,
                       shade: ((index + 1) * 50) as typeof colorShades[number],
@@ -97,7 +107,13 @@ const PaletteShowcase = () => {
         <h3>PALE PALETTE</h3>
         <p>Another palette is the pale where is not having shades.</p>
         <div css={paletteColorWrapper}>
-          <div css={colorNameBox('white')}>
+          <div
+            css={colorNameBox(
+              // @ts-ignore
+              theme,
+              'white'
+            )}
+          >
             <div
               css={css`
                 flex: 1;
@@ -117,7 +133,14 @@ const PaletteShowcase = () => {
             {palePalette.map(([colorName, color]) => (
               <div
                 key={uniqueId(`${color}-${colorName}`)}
-                css={colorBox({ color, colorName, isSelectedColor: false, isHoverable: false })}
+                css={colorBox({
+                  //@ts-ignore
+                  theme,
+                  color,
+                  colorName,
+                  isSelectedColor: false,
+                  isHoverable: false,
+                })}
               >
                 <div>{colorName}</div>
                 <div css={{ textTransform: 'capitalize' }}>{color}</div>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,7 +3,7 @@ import overrides from './overrides';
 import { getAAColor, getAAColorFromSwatches, getColor } from './palette';
 import { darkPaletteConfig, lightPaletteConfig } from './palette.config';
 import spacing from './spacing';
-import { TextColorTypes, Theme } from './types';
+import { TextColorTypes, Theme, ThemeConfig } from './types';
 import typography from './typography';
 import { enhancePaletteWithShades } from './utils';
 
@@ -28,5 +28,5 @@ const defaultTheme = (theming: 'dark' | 'light'): Theme => {
   };
 };
 
-export { TextColorTypes, Theme };
+export { TextColorTypes, Theme, ThemeConfig };
 export default defaultTheme;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,66 +1,11 @@
-import elevation, { Elevation } from './elevation';
-import overrides, { Overrides } from './overrides';
-import { colorShades, flatColors, mainTypes, paleColors, Palette } from './palette';
-import { darkPaletteConfig, lightPaletteConfig, PaletteConfig } from './palette.config';
-import spacing, { Spacing } from './spacing';
-import typography, { Typography } from './typography';
+import elevation from './elevation';
+import overrides from './overrides';
+import { getAAColor, getAAColorFromSwatches, getColor } from './palette';
+import { darkPaletteConfig, lightPaletteConfig } from './palette.config';
+import spacing from './spacing';
+import { TextColorTypes, Theme } from './types';
+import typography from './typography';
 import { enhancePaletteWithShades } from './utils';
-
-type TextColorTypes = 'primary' | 'secondary' | 'light';
-
-export type ThemeConfig = {
-  palette: PaletteConfig;
-  typography: Typography;
-  spacing: Spacing;
-  elevation: Elevation;
-  overrides: Overrides;
-  isDark: boolean;
-};
-
-type Names = typeof paleColors[number];
-
-type GetColor = {
-  (color: typeof flatColors[number], variant: typeof colorShades[number]): string;
-  (color: typeof flatColors[number], variant: typeof colorShades[number], scope: 'flat'): string;
-  (color: TextColorTypes, variant: typeof colorShades[number], scope: 'text'): string;
-  (color: typeof mainTypes[number], variant: typeof colorShades[number], scope: 'normal'): string;
-  (color: typeof paleColors[number], variant: null, scope: 'pale'): string;
-};
-
-export type Theme = {
-  palette: Palette;
-  typography: Typography;
-  spacing: Spacing;
-  elevation: Elevation;
-  isDark: boolean;
-  overrides: Overrides;
-  utils: {
-    getColor: GetColor;
-  };
-};
-
-export const getColor = (palette: Palette): GetColor => (
-  color:
-    | typeof flatColors[number]
-    | TextColorTypes
-    | typeof mainTypes[number]
-    | typeof paleColors[number],
-  variant: typeof colorShades[number] | null,
-  scope: 'flat' | 'text' | 'normal' | 'pale' = 'flat'
-) => {
-  const endColor =
-    variant === null
-      ? palette?.[scope]?.[color]
-      : scope === 'normal'
-      ? palette[color][variant]
-      : palette?.[scope]?.[color]?.[variant];
-
-  if (!endColor) {
-    throw new Error('No color found with that name');
-  }
-
-  return endColor;
-};
 
 const defaultTheme = (theming: 'dark' | 'light'): Theme => {
   const palette =
@@ -77,9 +22,11 @@ const defaultTheme = (theming: 'dark' | 'light'): Theme => {
     overrides,
     utils: {
       getColor: getColor(palette),
+      getAAColorFromSwatches: getAAColorFromSwatches(palette),
+      getAAColor: getAAColor(palette),
     },
   };
 };
 
-/* Declare any static variables here e.g. $gray: #888; */
+export { TextColorTypes, Theme };
 export default defaultTheme;

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -1,8 +1,6 @@
 import { getContrast } from 'polished';
 
-import { getColor } from './index';
-import { lightPaletteConfig } from './palette.config';
-import { enhancePaletteWithShades } from './utils';
+import { TextColorTypes } from './index';
 
 export const neutralColors = ['neutralWhite', 'neutralBlack'] as const;
 
@@ -117,22 +115,59 @@ export type Palette = {
 
 export type formFieldStyles = 'filled' | 'outlined' | 'elevated';
 
+export type GetColor = {
+  (color: typeof flatColors[number], variant: typeof colorShades[number]): string;
+  (color: typeof flatColors[number], variant: typeof colorShades[number], scope: 'flat'): string;
+  (color: TextColorTypes, variant: typeof colorShades[number], scope: 'text'): string;
+  (color: typeof mainTypes[number], variant: typeof colorShades[number], scope: 'normal'): string;
+  (color: typeof paleColors[number], variant: null, scope: 'pale'): string;
+};
+
+export const getColor = (palette: Palette): GetColor => (
+  color:
+    | typeof flatColors[number]
+    | TextColorTypes
+    | typeof mainTypes[number]
+    | typeof paleColors[number],
+  variant: typeof colorShades[number] | null,
+  scope: 'flat' | 'text' | 'normal' | 'pale' = 'flat'
+) => {
+  const endColor =
+    variant === null
+      ? palette?.[scope]?.[color]
+      : scope === 'normal'
+      ? palette[color][variant]
+      : palette?.[scope]?.[color]?.[variant];
+
+  if (!endColor) {
+    throw new Error('No color found with that name');
+  }
+
+  return endColor;
+};
+
 /**
  * this function picks either white or black color based on the background that is passed
- * swatches are calculated based on accessibility by getAATextColor function and splited to those two colors
+ * swatches are calculated based on accessibility by getAAColor function and splited to those two colors
  **/
-export const pickTextColorFromSwatches = (
+export type GetAAColorFromSwatches = {
+  (color: typeof flatColors[number], variant: typeof colorShades[number]): string;
+};
+
+export const getAAColorFromSwatches = (palette: Palette): GetAAColorFromSwatches => (
   color: typeof flatColors[number],
   shade: typeof colorShades[number]
 ): string => {
-  const palette = enhancePaletteWithShades(lightPaletteConfig);
   const hexColorCode = getColor(palette)(color, shade);
 
-  return getAATextColor(hexColorCode);
+  return getAAColor(palette)(hexColorCode);
 };
 
-export const getAATextColor = (color: string): string => {
-  const palette = enhancePaletteWithShades(lightPaletteConfig);
+export type GetAAColor = {
+  (color: string): string;
+};
+
+export const getAAColor = (palette: Palette): GetAAColor => (color: string): string => {
   const white = palette.white;
   const black = palette.black;
 

--- a/src/theme/tests/utils.test.ts
+++ b/src/theme/tests/utils.test.ts
@@ -1,5 +1,4 @@
-import { getColor } from '../index';
-import { BASE_SHADE, pickTextColorFromSwatches } from '../palette';
+import { BASE_SHADE, getAAColor, getAAColorFromSwatches, getColor } from '../palette';
 import { flatPaletteConfig, lightPaletteConfig } from '../palette.config';
 import { colorShadesCreator, enhancePaletteWithShades } from '../utils';
 import { magentaShades } from './const';
@@ -18,15 +17,34 @@ describe('GetColor functionalities', () => {
   });
 });
 
-describe('pickTextColorFromSwatches functionalities', () => {
-  test('pickTextColorFromSwatches works with the given colors and to return the correct color', () => {
+describe('getAAColorFromSwatches functionalities', () => {
+  const palette = enhancePaletteWithShades(lightPaletteConfig);
+
+  test('getAAColorFromSwatches works with the given colors and to return the correct color', () => {
     const black = 'black';
     const white = 'white';
+    const getAAColorFromSwatchesFun = getAAColorFromSwatches(palette);
+    expect(getAAColorFromSwatchesFun('darkGrey', 300)).toBe(black);
+    expect(getAAColorFromSwatchesFun('darkBlue', 650)).toBe(white);
+    expect(getAAColorFromSwatchesFun('magenta', 650)).toBe(white);
+    expect(getAAColorFromSwatchesFun('green', 600)).toBe(black);
+    expect(getAAColorFromSwatchesFun('green', 850)).toBe(white);
+  });
+});
 
-    expect(pickTextColorFromSwatches('darkGrey', 300)).toBe(black);
-    expect(pickTextColorFromSwatches('darkBlue', 650)).toBe(white);
-    expect(pickTextColorFromSwatches('magenta', 650)).toBe(white);
-    expect(pickTextColorFromSwatches('green', 600)).toBe(black);
-    expect(pickTextColorFromSwatches('green', 850)).toBe(white);
+describe('getAAColor functionalities', () => {
+  const palette = enhancePaletteWithShades(lightPaletteConfig);
+
+  test('getAAColor works with the given colors and to return the correct color', () => {
+    const black = 'black';
+    const white = 'white';
+    const getColorFun = getColor(palette);
+    const getAAColorFun = getAAColor(palette);
+
+    expect(getAAColorFun(getColorFun('darkGrey', 300))).toBe(black);
+    expect(getAAColorFun(getColorFun('darkBlue', 650))).toBe(white);
+    expect(getAAColorFun(getColorFun('magenta', 650))).toBe(white);
+    expect(getAAColorFun(getColorFun('green', 600))).toBe(black);
+    expect(getAAColorFun(getColorFun('green', 850))).toBe(white);
   });
 });

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,0 +1,31 @@
+import { Elevation } from './elevation';
+import { Overrides } from './overrides';
+import { GetAAColor, GetAAColorFromSwatches, GetColor, Palette } from './palette';
+import { PaletteConfig } from './palette.config';
+import { Spacing } from './spacing';
+import { Typography } from './typography';
+
+export type TextColorTypes = 'primary' | 'secondary' | 'light';
+
+export type ThemeConfig = {
+  palette: PaletteConfig;
+  typography: Typography;
+  spacing: Spacing;
+  elevation: Elevation;
+  overrides: Overrides;
+  isDark: boolean;
+};
+
+export type Theme = {
+  palette: Palette;
+  typography: Typography;
+  spacing: Spacing;
+  elevation: Elevation;
+  isDark: boolean;
+  overrides: Overrides;
+  utils: {
+    getColor: GetColor;
+    getAAColorFromSwatches: GetAAColorFromSwatches;
+    getAAColor: GetAAColor;
+  };
+};


### PR DESCRIPTION
## Description

I started this an an investigation to check out if it's  doable. It turns out that it's feasible so I made it a PR.

I wanted to remove the `enhancePaletteWithShades` from the `pickTextColorFromSwatches` function since it's a recursive function and it's not something we have to run each and every time we need to have a AA text.

I also moved the getColor function to the palette since it's a palette function.

Finally, I renamed the `pickTextColorFromSwatches` to `getAAColorFromSwatches` and the `getAATextColor` to `getAAColor` and added them to theme.utils.

## Test Plan

Tested the getAAColor individually. No futher tests needed as it was more of a performance gain and no visual changes where made. 