### PR TITLE
fix: add 100% width in input styles

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -4215,6 +4215,9 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-7+label {
@@ -4346,6 +4349,9 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-16+label {
@@ -4970,6 +4976,9 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-8+label {
@@ -5622,6 +5631,9 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-7+label {
@@ -5753,6 +5765,9 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-16+label {
@@ -6046,6 +6061,9 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-7+label {
@@ -6313,6 +6331,9 @@ exports[`Storyshots Design System/DatePicker DayPicker with predefined values 1`
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -6568,6 +6589,9 @@ exports[`Storyshots Design System/DatePicker Dynamic disableDates with all optio
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {

--- a/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
+++ b/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
@@ -133,6 +133,9 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-8+label {
@@ -217,6 +220,9 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-15+label {
@@ -507,6 +513,9 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-8+label {
@@ -596,6 +605,9 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-15+label {
@@ -884,6 +896,9 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-8+label {
@@ -973,6 +988,9 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-15+label {

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -94,6 +94,9 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -411,6 +414,9 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -732,6 +738,9 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -1409,6 +1418,9 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -1872,6 +1884,9 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -2053,6 +2068,9 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-16+label {
@@ -2360,6 +2378,9 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -2679,6 +2700,9 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -3146,6 +3170,9 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-7+label {
@@ -3631,6 +3658,9 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-7+label {
@@ -4531,6 +4561,9 @@ exports[`Storyshots Design System/Select Simple Group Select 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -4864,6 +4897,9 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {

--- a/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
+++ b/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
@@ -97,6 +97,9 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -322,6 +325,9 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -568,6 +574,9 @@ exports[`Storyshots Design System/TextArea Text Area with KNOBS 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -761,6 +770,9 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -1010,6 +1022,9 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -97,6 +97,9 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -218,6 +221,9 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-10+label {
@@ -453,6 +459,9 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -767,6 +776,9 @@ exports[`Storyshots Design System/TextField Text Field with Icons 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -1288,6 +1300,9 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-8+label {
@@ -1628,6 +1643,9 @@ exports[`Storyshots Design System/TextField Text Field with and without Label 1`
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -1711,6 +1729,9 @@ exports[`Storyshots Design System/TextField Text Field with and without Label 1`
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-10+label {
@@ -1763,6 +1784,9 @@ exports[`Storyshots Design System/TextField Text Field with and without Label 1`
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-14+label {
@@ -2012,6 +2036,9 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-5+label {
@@ -2305,6 +2332,9 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {
@@ -2463,6 +2493,9 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
   z-index: 1;
   font-size: 0.8125rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-31+label {
@@ -2946,6 +2979,9 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-6+label {

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -119,6 +119,7 @@ export const inputStyle = ({ label, placeholder, size = DEFAULT_SIZE, dark }: Pr
   z-index: 1;
   font-size: ${theme.typography.fontSizes[size === 'md' ? '15' : '13']};
   text-overflow: ellipsis;
+  width: fill-available;
 
   & + label {
     font-size: ${theme.typography.fontSizes[size === 'md' ? '15' : '13']};

--- a/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
+++ b/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
@@ -713,6 +713,9 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-12+label {

--- a/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
+++ b/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
@@ -13415,6 +13415,9 @@ exports[`PaletteShowcase should render correctly 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-731+label {
@@ -27376,6 +27379,9 @@ exports[`PaletteShowcase should render correctly 1`] = `
   z-index: 1;
   font-size: 0.9375rem;
   text-overflow: ellipsis;
+  width: -webkit-fill-available;
+  width: -moz-available;
+  width: fill-available;
 }
 
 .emotion-731+label {


### PR DESCRIPTION
## Description

- Re-adding the `width: 100%` property since it was removed in a previous version and all components that used TextInputBase are probably broken.
![image](https://user-images.githubusercontent.com/13350837/158460950-126f200a-d709-46ea-a153-76a8480f6bcd.png)
