### PR TITLE
fix: remove css rule that broke text components when in a flex container

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -4155,9 +4155,6 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -4317,9 +4314,6 @@ exports[`Storyshots Design System/DatePicker DatePicker Range 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -4916,9 +4910,6 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5078,9 +5069,6 @@ exports[`Storyshots Design System/DatePicker DayPicker Input props 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #e5143d;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5571,9 +5559,6 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5733,9 +5718,6 @@ exports[`Storyshots Design System/DatePicker DayPicker Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -6001,9 +5983,6 @@ exports[`Storyshots Design System/DatePicker DayPicker with disabled dates 1`] =
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -6271,9 +6250,6 @@ exports[`Storyshots Design System/DatePicker DayPicker with predefined values 1`
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -6529,9 +6505,6 @@ exports[`Storyshots Design System/DatePicker Dynamic disableDates with all optio
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
+++ b/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
@@ -36,9 +36,6 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 6.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -193,9 +190,6 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 6.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -411,9 +405,6 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 6.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -573,9 +564,6 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 6.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -794,9 +782,6 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 6.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -956,9 +941,6 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 6.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -33,9 +33,6 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -353,9 +350,6 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -682,9 +676,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -889,9 +880,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1357,9 +1345,6 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1823,9 +1808,6 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2035,9 +2017,6 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2317,9 +2296,6 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2639,9 +2615,6 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -3093,9 +3066,6 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -3597,9 +3567,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #e5143d;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -3842,9 +3809,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -4500,9 +4464,6 @@ exports[`Storyshots Design System/Select Simple Group Select 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -4836,9 +4797,6 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
+++ b/src/components/TextArea/__snapshots__/TextArea.stories.storyshot
@@ -36,9 +36,6 @@ exports[`Storyshots Design System/TextArea Text Area Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -264,9 +261,6 @@ exports[`Storyshots Design System/TextArea Text Area Types 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -513,9 +507,6 @@ exports[`Storyshots Design System/TextArea Text Area with KNOBS 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -714,9 +705,6 @@ exports[`Storyshots Design System/TextArea TextArea disabled with label 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -961,9 +949,6 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #e5143d;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1131,9 +1116,6 @@ exports[`Storyshots Design System/TextArea TextArea with label and statuses 1`] 
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/TextField/__snapshots__/TextField.stories.storyshot
+++ b/src/components/TextField/__snapshots__/TextField.stories.storyshot
@@ -36,9 +36,6 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -188,9 +185,6 @@ exports[`Storyshots Design System/TextField Text Field Sizes 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -398,9 +392,6 @@ exports[`Storyshots Design System/TextField Text Field Types 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -699,9 +690,6 @@ exports[`Storyshots Design System/TextField Text Field with Icons 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1197,9 +1185,6 @@ exports[`Storyshots Design System/TextField Text Field with KNOBS 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1582,9 +1567,6 @@ exports[`Storyshots Design System/TextField Text Field with and without Label 1`
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1980,9 +1962,6 @@ exports[`Storyshots Design System/TextField TextField disabled with label 1`] = 
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2276,9 +2255,6 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2465,9 +2441,6 @@ exports[`Storyshots Design System/TextField TextField locked with label 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -2918,9 +2891,6 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #e5143d;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -3119,9 +3089,6 @@ exports[`Storyshots Design System/TextField TextField with label and statuses 1`
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -82,7 +82,6 @@ export const wrapperStyle = ({
         : theme.utils.getColor(borderConfig.color.default.name, borderConfig.color.default.shade)
     }`,
     borderRadius: isSearch ? rem(100) : theme.spacing.xsm,
-    flex: '1 1 100%',
     userSelect: 'none',
     opacity: disabled ? getDisabled().opacity : 1,
     cursor: disabled || locked ? getDisabled().cursor : 'auto',

--- a/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
+++ b/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
@@ -653,9 +653,6 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
+++ b/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
@@ -13355,9 +13355,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -27319,9 +27316,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
   transition: background-color 0.25s,box-shadow 0.25s,border-color 0.25s;
   box-shadow: 0 0 0 0.0625rem #cfd7e5;
   border-radius: 0.25rem;
-  -webkit-flex: 1 1 100%;
-  -ms-flex: 1 1 100%;
-  flex: 1 1 100%;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;


### PR DESCRIPTION
## Description

- Removes a `flex: 1 1 100%` rule that caused the text components to break their width/height constraints when in a flex container
