### PR TITLE
feat: fix dark mode switch and deprecate old isDark 2/3

### DIFF
--- a/docs/system/THEME.stories.mdx
+++ b/docs/system/THEME.stories.mdx
@@ -19,7 +19,7 @@ The theme configuration is the core of the whole app as we said. This consist of
 | typography | [Typography](/?path=/story/guide-typography--page)                                                                    |
 | spacing    | [Spacing](/?path=/story/system-theme--page#theme-spacing)                                                             |
 | elevation  | [Elevation](/?path=/docs/system-theme--page#theme-elevation)                                                          |
-| isDark     | boolean                                                                                                               |
+| colorScheme     | string ('light' or 'dark')                                                                                                                |
 | utils      | [Utility Functions](/story/system-utils--page)                                                                        |
 
 <br />

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,12 +1,13 @@
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
 import { css, Global } from '@emotion/react';
-import { useThemeSwitch } from 'hooks/useThemeSwitch';
+import { ThemeSwitchProvider, useThemeSwitch } from 'hooks/useThemeSwitch';
 import { keys, merge, pick } from 'lodash';
 import { normalize } from 'polished';
 import React from 'react';
 import theme, { Theme, ThemeConfig } from 'theme';
 
 import { TypeColorToColorMatchProvider } from '../../hooks/useTypeColorToColorMatch';
+import { ColorScheme } from '../../theme/types';
 import { enhancePaletteWithShades } from '../../theme/utils';
 import { DeepPartial } from '../../utils/types';
 import 'utils/initLocaleFormat';
@@ -41,16 +42,24 @@ export const globalStyles = (theme: Theme) => css`
 `;
 
 const ThemeProvider: React.FC<Props> = ({ theme = {}, children }) => {
+  return (
+    <ThemeSwitchProvider>
+      <ThemeProviderContents theme={theme}>{children}</ThemeProviderContents>
+    </ThemeSwitchProvider>
+  );
+};
+
+const ThemeProviderContents: React.FC<Props> = ({ theme = {}, children }) => {
   const themeSwitchState = useThemeSwitch();
+  const colorScheme = themeSwitchState.dark ? 'dark' : ('light' as ColorScheme);
   const newTheme = {
     ...theme,
+    colorScheme,
     palette: theme?.palette ? enhancePaletteWithShades(theme.palette) : {},
   };
 
   return (
-    <EmotionThemeProvider
-      theme={deepMergeTheme(newTheme, themeSwitchState.dark ? 'dark' : 'light')}
-    >
+    <EmotionThemeProvider theme={deepMergeTheme(newTheme, colorScheme)}>
       <TypeColorToColorMatchProvider>
         <Global styles={globalStyles} />
         {children}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -18,7 +18,7 @@ const defaultTheme = (theming: 'dark' | 'light'): Theme => {
     typography,
     spacing,
     elevation,
-    isDark: false,
+    colorScheme: theming,
     overrides,
     utils: {
       getColor: getColor(palette),

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -6,6 +6,8 @@ import { getColorErrors } from './utils';
 
 export const neutralColors = ['neutralWhite', 'neutralBlack'] as const;
 
+export const colorSchemes = ['light', 'dark'] as const;
+
 /**
  * Here are listed all the colors available for our project
  * Flat colors are the actual colors of the system

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -6,6 +6,7 @@ import { Spacing } from './spacing';
 import { Typography } from './typography';
 
 export type TextColorTypes = 'primary' | 'secondary' | 'light';
+export type ColorScheme = 'light' | 'dark';
 
 export type ThemeConfig = {
   palette: PaletteConfig;
@@ -13,7 +14,6 @@ export type ThemeConfig = {
   spacing: Spacing;
   elevation: Elevation;
   overrides: Overrides;
-  isDark: boolean;
 };
 
 export type Theme = {
@@ -21,7 +21,7 @@ export type Theme = {
   typography: Typography;
   spacing: Spacing;
   elevation: Elevation;
-  isDark: boolean;
+  colorScheme: ColorScheme;
   overrides: Overrides;
   utils: {
     getColor: GetColor;


### PR DESCRIPTION
## Description

depends on https://github.com/Orfium/orfium-ictinus/pull/479

*This PR will be a part of 3 that has a goal for a small fix that I made for dark mode first try. 2/3*

In this PR I am adding the switch dark mode functionality inside the `ThemeProvider` in order to switch from `light` to `dark`. 

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot

No screenshot applied 
<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
