### PR TITLE
feat: stabilize dark mode and add new dark palette 3/3

### DIFF
--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.stories.storyshot
@@ -99,7 +99,7 @@ exports[`Storyshots Design System/Breadcrumb Active Breadcrumbs 1`] = `
   cursor: default;
   font-size: 0.9375rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
 }
 
 .emotion-24 {
@@ -382,7 +382,7 @@ exports[`Storyshots Design System/Breadcrumb Active Breadcrumbs with inactive la
   cursor: default;
   font-size: 0.9375rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
 }
 
 <div
@@ -651,7 +651,7 @@ exports[`Storyshots Design System/Breadcrumb Breadcrumb showcase 1`] = `
   cursor: default;
   font-size: 0.9375rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
 }
 
 .emotion-24 {
@@ -937,7 +937,7 @@ exports[`Storyshots Design System/Breadcrumb Simple Breadcrumbs 1`] = `
   cursor: default;
   font-size: 0.9375rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
 }
 
 <div

--- a/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -26,7 +26,7 @@ exports[`Storyshots Design System/Button Async Button 1`] = `
   font-size: 0.8125rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.25rem;
   border-radius: 0.25rem;
@@ -41,11 +41,11 @@ exports[`Storyshots Design System/Button Async Button 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -92,7 +92,7 @@ exports[`Storyshots Design System/Button Async Button 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: black;
-  background-color: #FDD835;
+  background-color: #1DE9B6;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -107,11 +107,11 @@ exports[`Storyshots Design System/Button Async Button 1`] = `
 }
 
 .emotion-9:hover:not(:disabled) {
-  background-color: #e3c22f;
+  background-color: #1ad1a3;
 }
 
 .emotion-9:active:not(:disabled) {
-  background-color: #caac2a;
+  background-color: #17ba91;
 }
 
 .emotion-9:disabled {
@@ -128,7 +128,7 @@ exports[`Storyshots Design System/Button Async Button 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -143,11 +143,11 @@ exports[`Storyshots Design System/Button Async Button 1`] = `
 }
 
 .emotion-13:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-13:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-13:disabled {
@@ -368,7 +368,7 @@ exports[`Storyshots Design System/Button Block Button 1`] = `
   font-weight: 500;
   color: white;
   width: 100%;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -383,11 +383,11 @@ exports[`Storyshots Design System/Button Block Button 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -439,13 +439,13 @@ exports[`Storyshots Design System/Button Block Button 1`] = `
 }
 
 .emotion-6 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1rem;
   height: 1rem;
 }
 
 .emotion-6 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-7 {
@@ -456,13 +456,13 @@ exports[`Storyshots Design System/Button Block Button 1`] = `
 .emotion-11 {
   font-size: 1rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
   width: 100%;
   background-color: transparent;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
-  border: solid 0.0625rem #4945EE;
+  border: solid 0.0625rem #175BF5;
   cursor: pointer;
   -webkit-transition: background-color,border 150ms linear;
   transition: background-color,border 150ms linear;
@@ -473,11 +473,11 @@ exports[`Storyshots Design System/Button Block Button 1`] = `
 }
 
 .emotion-11:hover:not(:disabled) {
-  background-color: #ececfd;
+  background-color: #e7eefe;
 }
 
 .emotion-11:active:not(:disabled) {
-  background-color: #dad9fb;
+  background-color: #d0defd;
 }
 
 .emotion-11:disabled {
@@ -972,7 +972,7 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -987,11 +987,11 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -1028,7 +1028,7 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -1043,11 +1043,11 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
 }
 
 .emotion-5:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-5:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-5:disabled {
@@ -1064,7 +1064,7 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
   font-size: 0.8125rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.25rem;
   border-radius: 0.25rem;
@@ -1079,11 +1079,11 @@ exports[`Storyshots Design System/Button Button Sizes 1`] = `
 }
 
 .emotion-8:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-8:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-8:disabled {
@@ -1659,7 +1659,7 @@ exports[`Storyshots Design System/Button Button with icon 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -1674,11 +1674,11 @@ exports[`Storyshots Design System/Button Button with icon 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -1730,13 +1730,13 @@ exports[`Storyshots Design System/Button Button with icon 1`] = `
 }
 
 .emotion-6 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1rem;
   height: 1rem;
 }
 
 .emotion-6 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-7 {
@@ -1755,13 +1755,13 @@ exports[`Storyshots Design System/Button Button with icon 1`] = `
 }
 
 .emotion-22 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1.125rem;
   height: 1.125rem;
 }
 
 .emotion-22 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 <div
@@ -1944,7 +1944,7 @@ exports[`Storyshots Design System/Button Dynamic Button Props 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: black;
-  background-color: #FDD835;
+  background-color: #1DE9B6;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -1959,11 +1959,11 @@ exports[`Storyshots Design System/Button Dynamic Button Props 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #e3c22f;
+  background-color: #1ad1a3;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #caac2a;
+  background-color: #17ba91;
 }
 
 .emotion-1:disabled {
@@ -2080,7 +2080,7 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -2095,11 +2095,11 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -2151,13 +2151,13 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
 }
 
 .emotion-6 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 0.875rem;
   height: 0.875rem;
 }
 
 .emotion-6 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-7 {
@@ -2169,7 +2169,7 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -2184,11 +2184,11 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
 }
 
 .emotion-8:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-8:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-8:disabled {
@@ -2205,7 +2205,7 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
   font-size: 0.8125rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.25rem;
   border-radius: 0.25rem;
@@ -2220,11 +2220,11 @@ exports[`Storyshots Design System/Button Icon Button Sizes 1`] = `
 }
 
 .emotion-14:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-14:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-14:disabled {
@@ -2404,12 +2404,12 @@ exports[`Storyshots Design System/Button Non Filled Button 1`] = `
 .emotion-1 {
   font-size: 1rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
   background-color: transparent;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
-  border: solid 0.0625rem #4945EE;
+  border: solid 0.0625rem #175BF5;
   cursor: pointer;
   -webkit-transition: background-color,border 150ms linear;
   transition: background-color,border 150ms linear;
@@ -2420,11 +2420,11 @@ exports[`Storyshots Design System/Button Non Filled Button 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #ececfd;
+  background-color: #e7eefe;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #dad9fb;
+  background-color: #d0defd;
 }
 
 .emotion-1:disabled {
@@ -2527,7 +2527,7 @@ exports[`Storyshots Design System/Button Regular Button 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 1rem;
   height: 3.5rem;
   border-radius: 0.25rem;
@@ -2542,11 +2542,11 @@ exports[`Storyshots Design System/Button Regular Button 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {
@@ -2648,7 +2648,7 @@ exports[`Storyshots Design System/Button Transparent Button 1`] = `
 .emotion-1 {
   font-size: 1rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
   background-color: transparent;
   padding: 1rem;
   height: 3.5rem;
@@ -2664,11 +2664,11 @@ exports[`Storyshots Design System/Button Transparent Button 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #ececfd;
+  background-color: #e7eefe;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #dad9fb;
+  background-color: #d0defd;
 }
 
 .emotion-1:disabled {

--- a/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
+++ b/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
@@ -163,7 +163,7 @@ exports[`Storyshots Design System/CheckBox CheckBox 1`] = `
   vertical-align: text-top;
   width: 1.5rem;
   height: 1.5rem;
-  background: #4945EE;
+  background: #175BF5;
   border-radius: 0.25rem;
 }
 
@@ -1039,7 +1039,7 @@ exports[`Storyshots Design System/CheckBox CheckBox with Label 1`] = `
   vertical-align: text-top;
   width: 1.5rem;
   height: 1.5rem;
-  background: #4945EE;
+  background: #175BF5;
   border-radius: 0.25rem;
 }
 

--- a/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
+++ b/src/components/DatePicker/__snapshots__/DatePicker.stories.storyshot
@@ -335,7 +335,7 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  background: #4945EE;
+  background: #175BF5;
 }
 
 .emotion-30:hover {
@@ -623,12 +623,12 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
 .emotion-429 {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
   background-color: transparent;
   padding: 0 1rem;
   height: 2.25rem;
   border-radius: 0.25rem;
-  border: solid 0.0625rem #4945EE;
+  border: solid 0.0625rem #175BF5;
   cursor: pointer;
   -webkit-transition: background-color,border 150ms linear;
   transition: background-color,border 150ms linear;
@@ -639,11 +639,11 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
 }
 
 .emotion-429:hover:not(:disabled) {
-  background-color: #ececfd;
+  background-color: #e7eefe;
 }
 
 .emotion-429:active:not(:disabled) {
-  background-color: #dad9fb;
+  background-color: #d0defd;
 }
 
 .emotion-429:disabled {
@@ -665,7 +665,7 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
   font-size: 0.8125rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.25rem;
   border-radius: 0.25rem;
@@ -680,11 +680,11 @@ exports[`Storyshots Design System/DatePicker Calendar 1`] = `
 }
 
 .emotion-432:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-432:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-432:disabled {
@@ -4614,11 +4614,11 @@ exports[`Storyshots Design System/DatePicker DatePicker with Filter 1`] = `
 }
 
 .emotion-5:hover>div {
-  background-color: #dad9fb;
+  background-color: #d0defd;
 }
 
 .emotion-5:active>div {
-  background-color: #c8c7f9;
+  background-color: #b9cdfc;
 }
 
 .emotion-5:focus-visible>div {
@@ -4638,8 +4638,8 @@ exports[`Storyshots Design System/DatePicker DatePicker with Filter 1`] = `
   -webkit-transition: all 150ms linear;
   transition: all 150ms linear;
   color: black;
-  background-color: #ececfd;
-  border: solid 0.0625rem #413ed6;
+  background-color: #e7eefe;
+  border: solid 0.0625rem #1451dc;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4654,7 +4654,7 @@ exports[`Storyshots Design System/DatePicker DatePicker with Filter 1`] = `
 }
 
 .emotion-6:hover {
-  border: solid 0.0625rem #413ed6;
+  border: solid 0.0625rem #1451dc;
 }
 
 .emotion-7 {

--- a/src/components/Icon/__snapshots__/Icon.stories.storyshot
+++ b/src/components/Icon/__snapshots__/Icon.stories.storyshot
@@ -39,23 +39,23 @@ exports[`Storyshots Design System/Icon Icon with color 1`] = `
 }
 
 .emotion-3 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1rem;
   height: 1rem;
 }
 
 .emotion-3 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-5 {
-  fill: #FDD835;
+  fill: #1DE9B6;
   width: 1rem;
   height: 1rem;
 }
 
 .emotion-5 path {
-  fill: #FDD835;
+  fill: #1DE9B6;
 }
 
 .emotion-7 {
@@ -534,33 +534,33 @@ exports[`Storyshots Design System/Icon Icon with size 1`] = `
 }
 
 .emotion-3 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1rem;
   height: 1rem;
 }
 
 .emotion-3 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-5 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1.25rem;
   height: 1.25rem;
 }
 
 .emotion-5 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-7 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 2.875rem;
   height: 2.875rem;
 }
 
 .emotion-7 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 <div

--- a/src/components/IconButton/__snapshots__/IconButton.stories.storyshot
+++ b/src/components/IconButton/__snapshots__/IconButton.stories.storyshot
@@ -25,13 +25,13 @@ exports[`Storyshots Design System/IconButton IconButton Playground 1`] = `
 .emotion-2 {
   font-size: 1rem;
   font-weight: 500;
-  color: #4945EE;
+  color: #175BF5;
   width: 2.875rem;
   background-color: transparent;
   padding: 0;
   height: 2.875rem;
   border-radius: 100%;
-  border: solid 0.0625rem #4945EE;
+  border: solid 0.0625rem #175BF5;
   cursor: pointer;
   -webkit-transition: background-color,border 150ms linear;
   transition: background-color,border 150ms linear;
@@ -54,11 +54,11 @@ exports[`Storyshots Design System/IconButton IconButton Playground 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #ececfd;
+  background-color: #e7eefe;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #dad9fb;
+  background-color: #d0defd;
 }
 
 .emotion-2:disabled {
@@ -88,13 +88,13 @@ exports[`Storyshots Design System/IconButton IconButton Playground 1`] = `
 }
 
 .emotion-4 {
-  fill: #4945EE;
+  fill: #175BF5;
   width: 1rem;
   height: 1rem;
 }
 
 .emotion-4 path {
-  fill: #4945EE;
+  fill: #175BF5;
 }
 
 <div
@@ -193,7 +193,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
   font-weight: 500;
   color: white;
   width: 2.25rem;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0;
   height: 2.25rem;
   border-radius: 100%;
@@ -220,11 +220,11 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -268,7 +268,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
   font-weight: 500;
   color: white;
   width: 2.875rem;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0;
   height: 2.875rem;
   border-radius: 100%;
@@ -295,11 +295,11 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
 }
 
 .emotion-5:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-5:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-5:disabled {
@@ -317,7 +317,7 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
   font-weight: 500;
   color: white;
   width: 3.5rem;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0;
   height: 3.5rem;
   border-radius: 100%;
@@ -344,11 +344,11 @@ exports[`Storyshots Design System/IconButton IconButton Sizes 1`] = `
 }
 
 .emotion-8:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-8:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-8:disabled {
@@ -505,7 +505,7 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
   font-weight: 500;
   color: white;
   width: 2.25rem;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0;
   height: 2.25rem;
   border-radius: 100%;
@@ -532,11 +532,11 @@ exports[`Storyshots Design System/IconButton IconButton Types 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {

--- a/src/components/Loader/__snapshots__/Loader.stories.storyshot
+++ b/src/components/Loader/__snapshots__/Loader.stories.storyshot
@@ -87,7 +87,7 @@ exports[`Storyshots Design System/Loader Loader Types 1`] = `
 
 .emotion-7 {
   position: absolute;
-  background: #4945EE;
+  background: #175BF5;
   height: 0.5rem;
   -webkit-animation: decrease 2.3s 0.8s infinite;
   animation: decrease 2.3s 0.8s infinite;
@@ -95,7 +95,7 @@ exports[`Storyshots Design System/Loader Loader Types 1`] = `
 
 .emotion-8 {
   position: absolute;
-  background: #4945EE;
+  background: #175BF5;
   height: 0.5rem;
   -webkit-animation: increase 2.3s infinite;
   animation: increase 2.3s infinite;
@@ -106,9 +106,9 @@ exports[`Storyshots Design System/Loader Loader Types 1`] = `
   height: 1.5rem;
   margin: auto;
   box-sizing: border-box;
-  border-top: 0.125rem solid #4945EE;
-  border-right: 0.125rem solid #4945EE;
-  border-bottom: 0.125rem solid #4945EE;
+  border-top: 0.125rem solid #175BF5;
+  border-right: 0.125rem solid #175BF5;
+  border-bottom: 0.125rem solid #175BF5;
   border-left: 0.125rem solid transparent;
   border-radius: 50%;
   -webkit-animation: spin 1.1s infinite linear;

--- a/src/components/Menu/__snapshots__/Menu.stories.storyshot
+++ b/src/components/Menu/__snapshots__/Menu.stories.storyshot
@@ -1327,7 +1327,7 @@ exports[`Storyshots Design System/Menu Menu with selection handler 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -1342,11 +1342,11 @@ exports[`Storyshots Design System/Menu Menu with selection handler 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {

--- a/src/components/Modal/__snapshots__/Modal.stories.storyshot
+++ b/src/components/Modal/__snapshots__/Modal.stories.storyshot
@@ -26,7 +26,7 @@ exports[`Storyshots Design System/Modal Modal 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -41,11 +41,11 @@ exports[`Storyshots Design System/Modal Modal 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -212,7 +212,7 @@ exports[`Storyshots Design System/Modal Modal Content 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -227,11 +227,11 @@ exports[`Storyshots Design System/Modal Modal Content 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {

--- a/src/components/Notification/__snapshots__/Notification.stories.storyshot
+++ b/src/components/Notification/__snapshots__/Notification.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Design System/Notification Banner Notification 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -27,11 +27,11 @@ exports[`Storyshots Design System/Notification Banner Notification 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {
@@ -682,7 +682,7 @@ exports[`Storyshots Design System/Notification Playground 1 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -697,11 +697,11 @@ exports[`Storyshots Design System/Notification Playground 1 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {
@@ -835,7 +835,7 @@ exports[`Storyshots Design System/Notification Playground 2 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -850,11 +850,11 @@ exports[`Storyshots Design System/Notification Playground 2 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {
@@ -988,7 +988,7 @@ exports[`Storyshots Design System/Notification Snackbar Notification 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -1003,11 +1003,11 @@ exports[`Storyshots Design System/Notification Snackbar Notification 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {
@@ -1141,7 +1141,7 @@ exports[`Storyshots Design System/Notification Toast Notification 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -1156,11 +1156,11 @@ exports[`Storyshots Design System/Notification Toast Notification 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {

--- a/src/components/Overlay/__snapshots__/Overlay.stories.storyshot
+++ b/src/components/Overlay/__snapshots__/Overlay.stories.storyshot
@@ -26,7 +26,7 @@ exports[`Storyshots Design System/Overlay Overlay 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -41,11 +41,11 @@ exports[`Storyshots Design System/Overlay Overlay 1`] = `
 }
 
 .emotion-2:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-2:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-2:disabled {
@@ -783,7 +783,7 @@ exports[`Storyshots Design System/Overlay Overlay Playground 1`] = `
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #175BF5;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -798,11 +798,11 @@ exports[`Storyshots Design System/Overlay Overlay Playground 1`] = `
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #1451dc;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #1248c4;
 }
 
 .emotion-1:disabled {

--- a/src/components/Radio/Radio.style.ts
+++ b/src/components/Radio/Radio.style.ts
@@ -9,13 +9,7 @@ import { Props } from './Radio';
 const lightHoverColor = 'rgba(14, 14, 23, 0.07)';
 const darkHoverColor = 'rgba(255, 255, 255, 0.1)';
 
-const boxShadow = ({
-  inset = false,
-  colorScheme,
-}: {
-  inset?: boolean;
-  colorScheme: ColorScheme;
-}) => css`
+const boxShadow = ({ colorScheme }: { colorScheme: ColorScheme }) => css`
   box-shadow: 0 0 0 ${rem('6px')} ${colorScheme === 'dark' ? darkHoverColor : lightHoverColor},
     inset 0 0 0 ${rem('6px')} ${colorScheme === 'dark' ? darkHoverColor : lightHoverColor};
 `;
@@ -45,7 +39,7 @@ export const customRadioInnerHover = (focused: boolean, disabled: boolean) => (
   width: ${rem('24px')};
   height: ${rem('24px')};
   transition: all 0.2s ease;
-  // ${focused && !disabled && boxShadow({ inset: true, colorScheme: theme.colorScheme })};
+  ${focused && !disabled && boxShadow({ colorScheme: theme.colorScheme })};
 `;
 
 export const customRadioWrapperStyles = (focused: boolean, disabled: boolean) => (
@@ -87,7 +81,6 @@ export const customRadioStyles = (props: Pick<Props, 'checked' | 'disabled' | 'f
     height: 100%;
     box-sizing: border-box;
     position: absolute;
-    // background-color: ${determineColorBasedOnState(props)(theme)};
     &:before {
       content: '';
       display: inline-block;

--- a/src/components/Radio/Radio.style.ts
+++ b/src/components/Radio/Radio.style.ts
@@ -1,14 +1,23 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { Theme } from 'theme';
 import { BASE_SHADE } from 'theme/palette';
+import { ColorScheme } from 'theme/types';
 import { rem } from 'theme/utils';
 
 import { Props } from './Radio';
 
-const hoverColor = 'rgba(0, 0, 0, 0.05)';
+const lightHoverColor = 'rgba(14, 14, 23, 0.07)';
+const darkHoverColor = 'rgba(255, 255, 255, 0.1)';
 
-const focusedRadio = css`
-  box-shadow: 0 0 0 ${rem('12px')} ${hoverColor};
+const boxShadow = ({
+  inset = false,
+  colorScheme,
+}: {
+  inset?: boolean;
+  colorScheme: ColorScheme;
+}) => css`
+  box-shadow: 0 0 0 ${rem('6px')} ${colorScheme === 'dark' ? darkHoverColor : lightHoverColor},
+    inset 0 0 0 ${rem('6px')} ${colorScheme === 'dark' ? darkHoverColor : lightHoverColor};
 `;
 
 export const inputStyles: SerializedStyles = css`
@@ -28,47 +37,44 @@ export const inputStyles: SerializedStyles = css`
   }
 `;
 
-export const customRadioInnerHover = (focused: boolean, disabled: boolean): SerializedStyles => css`
+export const customRadioInnerHover = (focused: boolean, disabled: boolean) => (
+  theme: Theme
+): SerializedStyles => css`
   position: absolute;
   border-radius: 50%;
   width: ${rem('24px')};
   height: ${rem('24px')};
   transition: all 0.2s ease;
-  ${focused && !disabled && `box-shadow: inset 0 0 0 ${rem('12px')} ${hoverColor};`};
+  // ${focused && !disabled && boxShadow({ inset: true, colorScheme: theme.colorScheme })};
 `;
 
-export const customRadioWrapperStyles = (
-  focused: boolean,
-  disabled: boolean
+export const customRadioWrapperStyles = (focused: boolean, disabled: boolean) => (
+  theme: Theme
 ): SerializedStyles => css`
   position: relative;
   border-radius: 50%;
   width: ${rem('24px')};
   height: ${rem('24px')};
   transition: box-shadow 0.3s ease;
-  ${focused && !disabled && focusedRadio};
+  ${focused && !disabled && boxShadow({ colorScheme: theme.colorScheme })};
 `;
 
-const boxShadowSpread = (spread: string | number) => `inset 0px 0px 0px ${rem(spread)}`;
-
-const determineBoxShadow = ({
+const determineColorBasedOnState = ({
   checked,
   disabled,
   filled,
 }: Pick<Props, 'checked' | 'disabled' | 'filled'>) => (theme: Theme) => {
   if (checked) {
-    return `${boxShadowSpread('2px')} currentColor, ${boxShadowSpread(
-      '4px'
-    )} ${theme.utils.getColor('neutralWhite', 50)}, ${boxShadowSpread('12px')} currentColor`;
+    return `currentColor`;
   }
   if (disabled) {
-    return `${boxShadowSpread(filled ? '12px' : '2px')} ${theme.utils.getColor('lightGrey', 250)}`;
+    return `${theme.utils.getColor('lightGrey', 250)}`;
   }
   if (filled) {
-    return `${boxShadowSpread('12px')} ${theme.utils.getColor('lightGrey', 300)}`;
+    return `${theme.utils.getColor('lightGrey', 300)}`;
   }
 
-  return `${boxShadowSpread('2px')} ${theme.utils.getColor('lightGrey', 300)}`;
+  return `${theme.utils.getColor('lightGrey', 300)}`;
 };
 
 export const customRadioStyles = (props: Pick<Props, 'checked' | 'disabled' | 'filled'>) => (
@@ -80,8 +86,33 @@ export const customRadioStyles = (props: Pick<Props, 'checked' | 'disabled' | 'f
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    box-shadow: ${determineBoxShadow(props)(theme)};
     position: absolute;
+    // background-color: ${determineColorBasedOnState(props)(theme)};
+    &:before {
+      content: '';
+      display: inline-block;
+      box-sizing: border-box;
+      margin: ${rem('2px')} ${rem('12px')} ${rem('2px')} ${rem('2px')};
+      border: solid 2px ${determineColorBasedOnState(props)(theme)};
+      border-radius: 50%;
+      width: ${rem('20px')};
+      height: ${rem('20px')};
+      vertical-align: top;
+      transition: border-color 0.2s;
+    }
+    &:after {
+      content: '';
+      display: block;
+      position: absolute;
+      top: ${rem('1px')};
+      left: ${rem('1px')};
+      border-radius: 50%;
+      width: ${rem('12px')};
+      height: ${rem('12px')};
+      background-color: ${determineColorBasedOnState(props)(theme)};
+      transform: translate(5px, 5px) scale(${props.checked ? '1' : '0'});
+      transition: transform 0.2s;
+    }
   `;
 };
 
@@ -90,8 +121,8 @@ export const wrapperStyles = (disabled: boolean) => (theme: Theme): SerializedSt
 
   border-radius: 50%;
 
-  width: ${rem('48px')};
-  height: ${rem('48px')};
+  width: ${rem('36px')};
+  height: ${rem('36px')};
 
   color: ${theme.utils.getColor('primary', BASE_SHADE, 'normal')};
   border: 0;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -113,7 +113,7 @@ const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
         checked={checkedValue}
         ref={ref}
       />
-      <span css={customRadioWrapperStyles(focused, disabled)}>
+      <span css={customRadioWrapperStyles(focused, disabled)(theme)}>
         <span
           css={customRadioStyles({
             checked: checkedValue,
@@ -121,7 +121,7 @@ const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             filled,
           })(theme)}
         />
-        <span css={customRadioInnerHover(focused, disabled)} />
+        <span css={customRadioInnerHover(focused, disabled)(theme)} />
       </span>
     </span>
   );

--- a/src/components/Radio/__snapshots__/Radio.stories.storyshot
+++ b/src/components/Radio/__snapshots__/Radio.stories.storyshot
@@ -25,9 +25,9 @@ exports[`Storyshots Design System/Radio Disabled not selected Radio 1`] = `
 .emotion-2 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 0.5;
   cursor: pointer;
@@ -90,8 +90,39 @@ exports[`Storyshots Design System/Radio Disabled not selected Radio 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #c3cddf;
   position: absolute;
+}
+
+.emotion-5:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #c3cddf;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-5:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #c3cddf;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-6 {
@@ -101,17 +132,6 @@ exports[`Storyshots Design System/Radio Disabled not selected Radio 1`] = `
   height: 1.5rem;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
-}
-
-.emotion-10 {
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  border-radius: 50%;
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem #c3cddf;
-  position: absolute;
 }
 
 <div
@@ -218,7 +238,7 @@ exports[`Storyshots Design System/Radio Disabled not selected Radio 1`] = `
             className="emotion-4"
           >
             <span
-              className="emotion-10"
+              className="emotion-5"
             />
             <span
               className="emotion-6"
@@ -242,9 +262,9 @@ exports[`Storyshots Design System/Radio Disabled selected Radio 1`] = `
 .emotion-1 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 0.5;
   cursor: pointer;
@@ -307,8 +327,39 @@ exports[`Storyshots Design System/Radio Disabled selected Radio 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem currentColor,inset 0px 0px 0px 0.25rem #fefefe,inset 0px 0px 0px 0.75rem currentColor;
   position: absolute;
+}
+
+.emotion-4:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px currentColor;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-4:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-transform: translate(5px, 5px) scale(1);
+  -moz-transform: translate(5px, 5px) scale(1);
+  -ms-transform: translate(5px, 5px) scale(1);
+  transform: translate(5px, 5px) scale(1);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-5 {
@@ -414,9 +465,9 @@ exports[`Storyshots Design System/Radio Not selected Radio  (\`checked === undef
 .emotion-2 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -479,8 +530,39 @@ exports[`Storyshots Design System/Radio Not selected Radio  (\`checked === undef
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-5:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-5:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-6 {
@@ -490,17 +572,6 @@ exports[`Storyshots Design System/Radio Not selected Radio  (\`checked === undef
   height: 1.5rem;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
-}
-
-.emotion-10 {
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  border-radius: 50%;
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem #b7c3d8;
-  position: absolute;
 }
 
 <div
@@ -607,7 +678,7 @@ exports[`Storyshots Design System/Radio Not selected Radio  (\`checked === undef
             className="emotion-4"
           >
             <span
-              className="emotion-10"
+              className="emotion-5"
             />
             <span
               className="emotion-6"
@@ -645,9 +716,9 @@ exports[`Storyshots Design System/Radio Not selected Radio (\`checked === false\
 .emotion-2 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -710,8 +781,39 @@ exports[`Storyshots Design System/Radio Not selected Radio (\`checked === false\
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-5:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-5:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-6 {
@@ -721,17 +823,6 @@ exports[`Storyshots Design System/Radio Not selected Radio (\`checked === false\
   height: 1.5rem;
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
-}
-
-.emotion-10 {
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  border-radius: 50%;
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem #b7c3d8;
-  position: absolute;
 }
 
 <div
@@ -838,7 +929,7 @@ exports[`Storyshots Design System/Radio Not selected Radio (\`checked === false\
             className="emotion-4"
           >
             <span
-              className="emotion-10"
+              className="emotion-5"
             />
             <span
               className="emotion-6"
@@ -862,9 +953,9 @@ exports[`Storyshots Design System/Radio Radio Playground 1`] = `
 .emotion-1 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -927,8 +1018,39 @@ exports[`Storyshots Design System/Radio Radio Playground 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem currentColor,inset 0px 0px 0px 0.25rem #fefefe,inset 0px 0px 0px 0.75rem currentColor;
   position: absolute;
+}
+
+.emotion-4:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px currentColor;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-4:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-transform: translate(5px, 5px) scale(1);
+  -moz-transform: translate(5px, 5px) scale(1);
+  -ms-transform: translate(5px, 5px) scale(1);
+  transform: translate(5px, 5px) scale(1);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-5 {
@@ -1020,9 +1142,9 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
 .emotion-1 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -1085,8 +1207,39 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-4:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-4:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-5 {
@@ -1098,17 +1251,6 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
   transition: all 0.2s ease;
 }
 
-.emotion-9 {
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  border-radius: 50%;
-  width: 100%;
-  height: 100%;
-  box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem #b7c3d8;
-  position: absolute;
-}
-
 .emotion-14 {
   -webkit-transition: all 0.2s ease;
   transition: all 0.2s ease;
@@ -1116,16 +1258,47 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem currentColor,inset 0px 0px 0px 0.25rem #fefefe,inset 0px 0px 0px 0.75rem currentColor;
   position: absolute;
+}
+
+.emotion-14:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px currentColor;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-14:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-transform: translate(5px, 5px) scale(1);
+  -moz-transform: translate(5px, 5px) scale(1);
+  -ms-transform: translate(5px, 5px) scale(1);
+  transform: translate(5px, 5px) scale(1);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-16 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 0.5;
   cursor: pointer;
@@ -1162,19 +1335,39 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #c3cddf;
   position: absolute;
 }
 
-.emotion-24 {
-  -webkit-transition: all 0.2s ease;
-  transition: all 0.2s ease;
-  border-radius: 50%;
-  width: 100%;
-  height: 100%;
+.emotion-19:before {
+  content: '';
+  display: inline-block;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem #c3cddf;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #c3cddf;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-19:after {
+  content: '';
+  display: block;
   position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #c3cddf;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 <div
@@ -1264,7 +1457,7 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
           className="emotion-3"
         >
           <span
-            className="emotion-9"
+            className="emotion-4"
           />
           <span
             className="emotion-5"
@@ -1348,7 +1541,7 @@ exports[`Storyshots Design System/Radio Radio showcase 1`] = `
           className="emotion-3"
         >
           <span
-            className="emotion-24"
+            className="emotion-19"
           />
           <span
             className="emotion-5"
@@ -1399,9 +1592,9 @@ exports[`Storyshots Design System/Radio Selected Radio 1`] = `
 .emotion-1 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -1464,8 +1657,39 @@ exports[`Storyshots Design System/Radio Selected Radio 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem currentColor,inset 0px 0px 0px 0.25rem #fefefe,inset 0px 0px 0px 0.75rem currentColor;
   position: absolute;
+}
+
+.emotion-4:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px currentColor;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-4:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-transform: translate(5px, 5px) scale(1);
+  -moz-transform: translate(5px, 5px) scale(1);
+  -ms-transform: translate(5px, 5px) scale(1);
+  transform: translate(5px, 5px) scale(1);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-5 {

--- a/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -4,8 +4,8 @@ exports[`Radio should render correctly 1`] = `
 .emotion-0 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
+  width: 2.25rem;
+  height: 2.25rem;
   color: #175BF5;
   border: 0;
   opacity: 1;
@@ -69,8 +69,39 @@ exports[`Radio should render correctly 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-3:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-3:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-4 {
@@ -85,8 +116,8 @@ exports[`Radio should render correctly 1`] = `
 .emotion-0 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
+  width: 2.25rem;
+  height: 2.25rem;
   color: #175BF5;
   border: 0;
   opacity: 1;
@@ -150,8 +181,39 @@ exports[`Radio should render correctly 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-3:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-3:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-4 {

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.stories.storyshot
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.stories.storyshot
@@ -11,9 +11,9 @@ exports[`Storyshots Design System/RadioGroup Radio with options 1`] = `
 .emotion-1 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -76,8 +76,39 @@ exports[`Storyshots Design System/RadioGroup Radio with options 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-4:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-4:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-5 {
@@ -96,8 +127,39 @@ exports[`Storyshots Design System/RadioGroup Radio with options 1`] = `
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem currentColor,inset 0px 0px 0px 0.25rem #fefefe,inset 0px 0px 0px 0.75rem currentColor;
   position: absolute;
+}
+
+.emotion-9:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px currentColor;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-9:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-transform: translate(5px, 5px) scale(1);
+  -moz-transform: translate(5px, 5px) scale(1);
+  -ms-transform: translate(5px, 5px) scale(1);
+  transform: translate(5px, 5px) scale(1);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 <div
@@ -247,9 +309,9 @@ exports[`Storyshots Design System/RadioGroup Radio with options with onChange ha
 .emotion-1 {
   position: relative;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
-  color: #4945EE;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: #175BF5;
   border: 0;
   opacity: 1;
   cursor: pointer;
@@ -312,8 +374,39 @@ exports[`Storyshots Design System/RadioGroup Radio with options with onChange ha
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.75rem #b7c3d8;
   position: absolute;
+}
+
+.emotion-4:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px #b7c3d8;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-4:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: #b7c3d8;
+  -webkit-transform: translate(5px, 5px) scale(0);
+  -moz-transform: translate(5px, 5px) scale(0);
+  -ms-transform: translate(5px, 5px) scale(0);
+  transform: translate(5px, 5px) scale(0);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 .emotion-5 {
@@ -332,8 +425,39 @@ exports[`Storyshots Design System/RadioGroup Radio with options with onChange ha
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  box-shadow: inset 0px 0px 0px 0.125rem currentColor,inset 0px 0px 0px 0.25rem #fefefe,inset 0px 0px 0px 0.75rem currentColor;
   position: absolute;
+}
+
+.emotion-9:before {
+  content: '';
+  display: inline-block;
+  box-sizing: border-box;
+  margin: 0.125rem 0.75rem 0.125rem 0.125rem;
+  border: solid 2px currentColor;
+  border-radius: 50%;
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: top;
+  -webkit-transition: border-color 0.2s;
+  transition: border-color 0.2s;
+}
+
+.emotion-9:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0.0625rem;
+  left: 0.0625rem;
+  border-radius: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  background-color: currentColor;
+  -webkit-transform: translate(5px, 5px) scale(1);
+  -moz-transform: translate(5px, 5px) scale(1);
+  -ms-transform: translate(5px, 5px) scale(1);
+  transform: translate(5px, 5px) scale(1);
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
 }
 
 <div

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -4,15 +4,14 @@ import { rem } from 'theme/utils';
 import { DEFAULT_SIZE, getTextFieldPadding, getTextFieldSize } from 'utils/size-utils';
 
 import { getDisabled, getHover, getPressed } from '../../theme/states';
+import { ColorScheme } from '../../theme/types';
 import { MIN_WIDTH, textInputConfig } from './config';
 import { Props } from './TextInputBase';
 import { LABEL_TRANSFORM_LEFT_SPACING } from 'components/Label/Label.style';
 
-const borderConfig = textInputConfig.types.outlined.border;
-
 const wrapperStyleSwitch = (
   theme: Theme,
-  dark?: boolean,
+  colorScheme: ColorScheme = 'light',
   lean?: boolean,
   error?: boolean,
   disabled?: boolean
@@ -22,8 +21,10 @@ const wrapperStyleSwitch = (
       backgroundColor: 'transparent',
     };
   }
+  const borderConfig = textInputConfig.types[colorScheme].outlined.border;
 
-  const backgroundColor = dark ? theme.utils.getColor('darkGrey', 750) : theme.palette.white;
+  const backgroundColor =
+    colorScheme === 'dark' ? theme.utils.getColor('darkGrey', 700) : theme.palette.white;
   const borderColorName = !error ? borderConfig.color.pressed.name : borderConfig.color.error.name;
   const borderColorShade = !error
     ? borderConfig.color.pressed.shade
@@ -68,8 +69,10 @@ export const wrapperStyle = ({
   isTextArea,
   size,
 }: Props) => (theme: Theme): SerializedStyles => {
+  const colorScheme = dark ? 'dark' : theme.colorScheme;
   const error = status === 'error';
   const textFieldSize = !(lean || isTextArea) ? getTextFieldSize(size) : getTextFieldSize();
+  const borderConfig = textInputConfig.types[colorScheme].outlined.border;
 
   return css({
     display: 'flex',
@@ -86,7 +89,7 @@ export const wrapperStyle = ({
     opacity: disabled ? getDisabled().opacity : 1,
     cursor: disabled || locked ? getDisabled().cursor : 'auto',
     ...textFieldSize,
-    ...wrapperStyleSwitch(theme, dark, lean, error, Boolean(disabled || locked)),
+    ...wrapperStyleSwitch(theme, colorScheme, lean, error, Boolean(disabled || locked)),
   });
 };
 
@@ -115,7 +118,7 @@ export const inputStyle = ({
 }: Props) => (theme: Theme): SerializedStyles => css`
   background: transparent;
   border: none;
-  color: ${dark ? theme.palette.white : theme.utils.getColor('darkGrey', 850)};
+  color: ${theme.colorScheme === 'dark' || dark ? theme.palette.white : theme.utils.getColor('darkGrey', 850)};
   display: block;
   position: relative;
   top: ${label && rem(7)};

--- a/src/components/TextInputBase/config.ts
+++ b/src/components/TextInputBase/config.ts
@@ -11,42 +11,70 @@ export const MIN_WIDTH = 150;
 export const textInputSizes = [MD, SM] as const;
 export const textInputStates = ['default', 'pressed', 'error'] as const;
 
-type TextInputConfig = {
-  types: {
-    outlined: {
-      border: {
-        width: number;
-        color: {
-          [key in typeof textInputStates[number]]: {
-            name: typeof flatColors[number];
-            shade: typeof colorShades[number];
-          };
+type TextInputType = {
+  outlined: {
+    border: {
+      width: number;
+      color: {
+        [key in typeof textInputStates[number]]: {
+          name: typeof flatColors[number];
+          shade: typeof colorShades[number];
         };
       };
     };
   };
+}
+type TextInputConfig = {
+  types: {
+    light: TextInputType;
+    dark: TextInputType;
+  }
+
 };
 
 export const textInputConfig: TextInputConfig = {
   types: {
-    outlined: {
-      border: {
-        width: 1,
-        color: {
-          default: {
-            name: 'lightGrey',
-            shade: 200,
-          },
-          pressed: {
-            name: 'blue',
-            shade: 550,
-          },
-          error: {
-            name: 'red',
-            shade: 550,
+    light: {
+      outlined: {
+        border: {
+          width: 1,
+          color: {
+            default: {
+              name: 'lightGrey',
+              shade: 200,
+            },
+            pressed: {
+              name: 'blue',
+              shade: 550,
+            },
+            error: {
+              name: 'red',
+              shade: 550,
+            },
           },
         },
       },
     },
+    dark: {
+      outlined: {
+        border: {
+          width: 1,
+          color: {
+            default: {
+              name: 'darkGrey',
+              shade: 500,
+            },
+            pressed: {
+              name: 'blue',
+              shade: 350,
+            },
+            error: {
+              name: 'red',
+              shade: 200,
+            },
+          },
+        },
+      },
+    }
   },
 };

--- a/src/components/ThemeProvider/ThemeProvider.stories.mdx
+++ b/src/components/ThemeProvider/ThemeProvider.stories.mdx
@@ -14,7 +14,7 @@ A component that will hold all components as childs. These component is the firs
 ```js
 import { ThemeProvider } from '@orfium/ictinus';
 
-<ThemeProvider theme={{ colors: { primary: 'red' } }}>
+<ThemeProvider theme={{ palette: { primary: '#2D2D46' } }}>
   ...
 </ThemeProvider>
 ```
@@ -24,10 +24,14 @@ import { ThemeProvider } from '@orfium/ictinus';
 <Props of={ThemeProvider} />
 
 # Theme with button
+
+This is a demo of how you wrap a component on this provider. Because preview is also automatically wrapped in the provider
+some things like dark mode switcher will not work as intended.
+
 <Preview>
   <Story name="Setting up a button example">
-    <ThemeProvider theme={{ colors: { primary: 'red' } }}>
-        <Button bg={'green'}>Hello world</Button>
+    <ThemeProvider theme={{ palette: { primary: '#2D2D46' } }}>
+        <Button>Hello world</Button>
       </ThemeProvider>
   </Story>
 </Preview>

--- a/src/components/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { useThemeSwitch } from '../../hooks/useThemeSwitch';
+import ThemeProvider from './ThemeProvider';
+
+const ThemeSwitcher = () => {
+  const themeSwitchState = useThemeSwitch();
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <button
+        onClick={themeSwitchState.toggle}
+        css={{
+          backgroundColor: themeSwitchState.dark ? '#fff' : 'transparent',
+          color: '#000',
+          outline: 'none',
+          borderRadius: 4,
+        }}
+      >
+        turn {themeSwitchState.dark ? 'light' : 'dark'} on
+      </button>
+    </div>
+  );
+};
+
+test('ThemeProvider has default dark mode', () => {
+  render(
+    <ThemeProvider theme={{}}>
+      <ThemeSwitcher />
+    </ThemeProvider>
+  );
+  expect(screen.getByText(/turn dark on/i)).toBeInTheDocument();
+});
+
+test('ThemeProvider changes default dark mode to light', () => {
+  render(
+    <ThemeProvider theme={{}}>
+      <ThemeSwitcher />
+    </ThemeProvider>
+  );
+  userEvent.click(screen.getByText(/turn dark on/i));
+
+  expect(screen.getByText(/turn light on/i)).toBeInTheDocument();
+});

--- a/src/components/ThemeProvider/__snapshots__/ThemeProvider.stories.storyshot
+++ b/src/components/ThemeProvider/__snapshots__/ThemeProvider.stories.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots Design System/ThemeProvider Setting up a button example 1`] 
   font-size: 1rem;
   font-weight: 500;
   color: white;
-  background-color: #4945EE;
+  background-color: #2d2d46;
   padding: 0 1rem;
   height: 2.875rem;
   border-radius: 0.25rem;
@@ -27,11 +27,11 @@ exports[`Storyshots Design System/ThemeProvider Setting up a button example 1`] 
 }
 
 .emotion-1:hover:not(:disabled) {
-  background-color: #413ed6;
+  background-color: #28283e;
 }
 
 .emotion-1:active:not(:disabled) {
-  background-color: #3a37be;
+  background-color: #232336;
 }
 
 .emotion-1:disabled {

--- a/src/components/Toast/__snapshots__/Toast.stories.storyshot
+++ b/src/components/Toast/__snapshots__/Toast.stories.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots Design System/Toast Generic Toast 1`] = `
   justify-content: space-between;
   overflow: hidden;
   height: 3.625rem;
-  background: #FDD835;
+  background: #1DE9B6;
 }
 
 .emotion-4 {
@@ -154,7 +154,7 @@ exports[`Storyshots Design System/Toast Generic Toast 1`] = `
   justify-content: space-between;
   overflow: hidden;
   height: 3.625rem;
-  background: #4945EE;
+  background: #175BF5;
 }
 
 <div

--- a/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
+++ b/src/components/TopAppBar/__snapshots__/TopAppBar.stories.storyshot
@@ -96,13 +96,13 @@ exports[`Storyshots Design System/TopAppBar playground 1`] = `
 }
 
 .emotion-5 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1.5rem;
   height: 1.5rem;
 }
 
 .emotion-5 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-6 {
@@ -571,13 +571,13 @@ exports[`Storyshots Design System/TopAppBar with Additional Tools 1`] = `
 }
 
 .emotion-5 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1.5rem;
   height: 1.5rem;
 }
 
 .emotion-5 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-6 {
@@ -1214,13 +1214,13 @@ exports[`Storyshots Design System/TopAppBar with Dark theme enabled 1`] = `
 }
 
 .emotion-5 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1.5rem;
   height: 1.5rem;
 }
 
 .emotion-5 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-6 {
@@ -1689,13 +1689,13 @@ exports[`Storyshots Design System/TopAppBar with Logo Placeholder 1`] = `
 }
 
 .emotion-5 {
-  fill: #ececfd;
+  fill: #e7eefe;
   width: 1.5rem;
   height: 1.5rem;
 }
 
 .emotion-5 path {
-  fill: #ececfd;
+  fill: #e7eefe;
 }
 
 .emotion-6 {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,11 +3,11 @@ import overrides from './overrides';
 import { getAAColor, getAAColorFromSwatches, getColor } from './palette';
 import { darkPaletteConfig, lightPaletteConfig } from './palette.config';
 import spacing from './spacing';
-import { TextColorTypes, Theme, ThemeConfig } from './types';
+import { ColorScheme, TextColorTypes, Theme, ThemeConfig } from './types';
 import typography from './typography';
 import { enhancePaletteWithShades } from './utils';
 
-const defaultTheme = (theming: 'dark' | 'light'): Theme => {
+const defaultTheme = (theming: ColorScheme): Theme => {
   const palette =
     theming === 'light'
       ? enhancePaletteWithShades(lightPaletteConfig)

--- a/src/theme/palette.config.ts
+++ b/src/theme/palette.config.ts
@@ -37,8 +37,8 @@ export const palePaletteConfig: Record<typeof paleColors[number], string> = {
 
 export const lightPaletteConfig: PaletteConfig = {
   // Primary Palette
-  primary: flatPaletteConfig.darkBlue,
-  secondary: flatPaletteConfig.yellow,
+  primary: flatPaletteConfig.blue,
+  secondary: flatPaletteConfig.teal,
 
   //rest
   success: flatPaletteConfig.green, //550 shade
@@ -68,15 +68,16 @@ export const lightPaletteConfig: PaletteConfig = {
 
 export const darkPaletteConfig: PaletteConfig = {
   // Primary Palette
-  primary: flatPaletteConfig.darkGrey,
-  secondary: flatPaletteConfig.lightGrey,
+  primary: flatPaletteConfig.teal,
+  secondary: flatPaletteConfig.blue,
 
   //rest
-  success: flatPaletteConfig.green,
+  success: flatPaletteConfig.green, //550 shade
   error: flatPaletteConfig.red,
   warning: flatPaletteConfig.orange,
   info: flatPaletteConfig.darkBlue,
-  light: flatPaletteConfig.lightGrey,
+  light: flatPaletteConfig.greyScale,
+  link: '#246CE5',
 
   flat: {
     ...flatPaletteConfig,
@@ -88,8 +89,8 @@ export const darkPaletteConfig: PaletteConfig = {
 
   text: {
     primary: flatPaletteConfig.darkGrey,
-    secondary: flatPaletteConfig.greyScale,
-    light: flatPaletteConfig.lightGrey,
+    secondary: flatPaletteConfig.lightGrey,
+    light: flatPaletteConfig.greyScale,
   },
 
   white: 'white',

--- a/src/theme/states/disabled.ts
+++ b/src/theme/states/disabled.ts
@@ -9,8 +9,8 @@ export type GetDisabled = {
   cursor: string;
 };
 
-const opacityAmount = statesConfig.disabled.opacity.amount;
-const cursor = statesConfig.disabled.cursor.name;
+const opacityAmount = statesConfig['light'].disabled.opacity.amount;
+const cursor = statesConfig['light'].disabled.cursor.name;
 
 /**
  * On disabled opacity is dropped in half and cursor is 'not-allowed'

--- a/src/theme/states/focus.ts
+++ b/src/theme/states/focus.ts
@@ -14,8 +14,8 @@ export type GetFocus = {
   styleOutline: string;
 };
 
-const borderWidthStep = statesConfig.focus.border.width.step;
-const borderColor = statesConfig.focus.border.color;
+const borderWidthStep = statesConfig['light'].focus.border.width.step;
+const borderColor = statesConfig['light'].focus.border.color;
 
 /**
  * On focus border is darken by one step in shade.

--- a/src/theme/states/hover.ts
+++ b/src/theme/states/hover.ts
@@ -13,14 +13,20 @@ export type GetHover = {
   backgroundColor: string;
 };
 
-const backgroundColorStep = statesConfig.hover.backgroundColor.step;
-
 /**
  * On hover background is darken by one step in shade.
  * If we exceed the maximum value then we lighten it.
  * This will be reviewed when dark theme is implemented. **/
-export const getHover = ({ theme, color = 'lightGrey', shade = 0 }: Props): GetHover => {
-  const calculatedShade = getShadeWithStep({ shade, step: backgroundColorStep });
+export const getHover = ({ theme, color, shade }: Props): GetHover => {
+  const backgroundColorStep = statesConfig[theme.colorScheme].hover.backgroundColor.step;
+  const endColor = color || (theme.colorScheme === 'dark' ? 'darkGrey' : 'lightGrey');
+  const endShade = shade || (theme.colorScheme === 'dark' ? 700 : 0);
 
-  return { backgroundColor: theme.utils.getColor(color, calculatedShade) };
+  const calculatedShade = getShadeWithStep({
+    shade: endShade,
+    step: backgroundColorStep,
+    colorScheme: theme.colorScheme,
+  });
+
+  return { backgroundColor: theme.utils.getColor(endColor, calculatedShade) };
 };

--- a/src/theme/states/pressed.ts
+++ b/src/theme/states/pressed.ts
@@ -13,14 +13,20 @@ export type GetPressed = {
   backgroundColor: string;
 };
 
-const backgroundColorStep = statesConfig.pressed.backgroundColor.step;
-
 /**
  * On pressed background is darken by two steps in shade.
  * If we exceed the maximum value then we lighten it by two steps.
  * This will be reviewed when dark theme is implemented. **/
-export const getPressed = ({ theme, color = 'lightGrey', shade = 0 }: Props): GetPressed => {
-  const calculatedShade = getShadeWithStep({ shade, step: backgroundColorStep });
+export const getPressed = ({ theme, color, shade }: Props): GetPressed => {
+  const backgroundColorStep = statesConfig[theme.colorScheme].pressed.backgroundColor.step;
+  const endColor = color || (theme.colorScheme === 'dark' ? 'darkGrey' : 'lightGrey');
+  const endShade = shade || (theme.colorScheme === 'dark' ? 700 : 0);
 
-  return { backgroundColor: theme.utils.getColor(color, calculatedShade) };
+  const calculatedShade = getShadeWithStep({
+    shade: endShade,
+    step: backgroundColorStep,
+    colorScheme: theme.colorScheme,
+  });
+
+  return { backgroundColor: theme.utils.getColor(endColor, calculatedShade) };
 };

--- a/src/theme/states/statesConfig.ts
+++ b/src/theme/states/statesConfig.ts
@@ -1,6 +1,6 @@
-import { colorShades, flatColors } from '../palette';
+import { colorSchemes, colorShades, flatColors } from '../palette';
 
-type StatesConfig = {
+type StateConfig = {
   hover: {
     backgroundColor: {
       step: number;
@@ -32,7 +32,7 @@ type StatesConfig = {
   };
 };
 
-export const statesConfig: StatesConfig = {
+export const lightStatesConfig: StateConfig = {
   hover: {
     backgroundColor: {
       step: 50,
@@ -62,4 +62,41 @@ export const statesConfig: StatesConfig = {
       name: 'not-allowed',
     },
   },
+};
+
+export const darkStatesConfig: StateConfig = {
+  hover: {
+    backgroundColor: {
+      step: 50,
+    },
+  },
+  focus: {
+    border: {
+      width: {
+        step: 1,
+      },
+      color: {
+        name: 'magenta',
+        shade: 500,
+      },
+    },
+  },
+  pressed: {
+    backgroundColor: {
+      step: 100,
+    },
+  },
+  disabled: {
+    opacity: {
+      amount: 0.5,
+    },
+    cursor: {
+      name: 'not-allowed',
+    },
+  },
+};
+
+export const statesConfig: Record<typeof colorSchemes[number], StateConfig> = {
+  light: lightStatesConfig,
+  dark: darkStatesConfig,
 };

--- a/src/theme/states/tests/states.test.ts
+++ b/src/theme/states/tests/states.test.ts
@@ -6,6 +6,8 @@ import { getDisabled, getFocus, getHover, getPressed } from '../index';
 import { statesConfig } from '../statesConfig';
 import { getShadeWithStep } from '../utils';
 
+const themeMode = 'light';
+
 describe('Global states - getHover ', () => {
   const testTheme = theme('light');
 
@@ -29,40 +31,42 @@ describe('Global states - getHover ', () => {
 });
 
 describe('Global states - getFocus ', () => {
-  const testTheme = theme('light');
+  const testTheme = theme(themeMode);
 
   const expected = (focusResponse: GetFocus, expectedResultBorder: string) => {
     expect(focusResponse.borderWidth).toBe(expectedResultBorder);
     expect(focusResponse.styleBorder).toBe(
       `${expectedResultBorder} solid ${testTheme.utils.getColor(
-        statesConfig.focus.border.color.name,
-        statesConfig.focus.border.color.shade
+        statesConfig[themeMode].focus.border.color.name,
+        statesConfig[themeMode].focus.border.color.shade
       )}`
     );
     expect(focusResponse.focusColor).toBe(
       testTheme.utils.getColor(
-        statesConfig.focus.border.color.name,
-        statesConfig.focus.border.color.shade
+        statesConfig[themeMode].focus.border.color.name,
+        statesConfig[themeMode].focus.border.color.shade
       )
     );
     expect(focusResponse.styleOutline).toBe(
       `${testTheme.utils.getColor(
-        statesConfig.focus.border.color.name,
-        statesConfig.focus.border.color.shade
+        statesConfig[themeMode].focus.border.color.name,
+        statesConfig[themeMode].focus.border.color.shade
       )} auto ${expectedResultBorder}`
     );
   };
 
   test('with theme only as prop', () => {
     const focusResponse = getFocus({ theme: testTheme });
-    const expectedResultBorder = rem(statesConfig.focus.border.width.step);
+    const expectedResultBorder = rem(statesConfig[themeMode].focus.border.width.step);
 
     expected(focusResponse, expectedResultBorder);
   });
   test('with borderWidth as prop', () => {
     const testBorderWidth = 1;
     const focusResponse = getFocus({ theme: testTheme, borderWidth: testBorderWidth });
-    const expectedResultBorder = rem(testBorderWidth + statesConfig.focus.border.width.step);
+    const expectedResultBorder = rem(
+      testBorderWidth + statesConfig[themeMode].focus.border.width.step
+    );
 
     expected(focusResponse, expectedResultBorder);
   });
@@ -96,24 +100,24 @@ describe('Global states - getDisabled ', () => {
 
     expect(disabledResponse).toStrictEqual({
       style: {
-        opacity: statesConfig.disabled.opacity.amount,
-        cursor: statesConfig.disabled.cursor.name,
+        opacity: statesConfig[themeMode].disabled.opacity.amount,
+        cursor: statesConfig[themeMode].disabled.cursor.name,
       },
-      opacity: statesConfig.disabled.opacity.amount,
-      cursor: statesConfig.disabled.cursor.name,
+      opacity: statesConfig[themeMode].disabled.opacity.amount,
+      cursor: statesConfig[themeMode].disabled.cursor.name,
     });
   });
 });
 
 describe('Global states - utils ', () => {
   test('getShadeWithStep in bounds', () => {
-    const shade = getShadeWithStep({ shade: 50, step: 50 });
+    const shade = getShadeWithStep({ colorScheme: themeMode, shade: 50, step: 50 });
 
     expect(shade).toBe(100);
   });
 
   test('getShadeWithStep out of bounds', () => {
-    const shade = getShadeWithStep({ shade: MAX_SHADE, step: 50 });
+    const shade = getShadeWithStep({ colorScheme: themeMode, shade: MAX_SHADE, step: 50 });
 
     expect(shade).toBe(900);
   });

--- a/src/theme/states/utils.ts
+++ b/src/theme/states/utils.ts
@@ -1,14 +1,21 @@
-import { colorShades, MAX_SHADE } from '../palette';
+import { colorShades, MAX_SHADE, MIN_SHADE } from '../palette';
+import { ColorScheme } from '../types';
 
 type Props = {
   shade: typeof colorShades[number] | 0;
   step: number;
+  colorScheme: ColorScheme;
 };
 
-export const getShadeWithStep = ({ shade = 0, step = 50 }: Props): typeof colorShades[number] => {
+export const getShadeWithStep = ({
+  shade = 0,
+  step = 50,
+  colorScheme,
+}: Props): typeof colorShades[number] => {
+  const calculation = colorScheme === 'light' ? shade + step > MAX_SHADE : shade - step > MIN_SHADE;
   let calculatedShade = shade;
 
-  if (shade + step > MAX_SHADE) {
+  if (calculation) {
     calculatedShade -= step;
   } else {
     calculatedShade += step;

--- a/src/utils/tests/themeFunctions.test.ts
+++ b/src/utils/tests/themeFunctions.test.ts
@@ -52,7 +52,7 @@ describe('The usability of getColorFromType to be correct', () => {
     const testColor = 'primary';
     const color = getColorFromType(testColor, theme('light'));
 
-    expect(color).toBe('#ececfd');
+    expect(color).toBe('#e7eefe');
   });
   test('getColorFromType to get a color from the palette and return the correct color', () => {
     const testColor = 'lightBlue';


### PR DESCRIPTION
## Description

depends on https://github.com/Orfium/orfium-ictinus/pull/480

*This PR will be a part of 3 that has a goal for a small fix that I made for dark mode first try. 3/3*

This PR introduces a new dark mode config based on Figma and extends the current functions to apply a basic dark mode functionality to the app.

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->

### TextField
![Screen Recording 2022-03-30 at 10 59 06 AM](https://user-images.githubusercontent.com/6433679/160782041-57de044d-f908-4a56-96af-21925da2539c.gif)

### Button
![Screen Recording 2022-03-30 at 10 58 44 AM](https://user-images.githubusercontent.com/6433679/160782046-3d5e6d69-eec1-49df-b124-1f445b6cc516.gif)

### Checkbox
![Screen Recording 2022-03-30 at 10 58 26 AM](https://user-images.githubusercontent.com/6433679/160782051-70ba6b86-6c4b-4b50-8fe1-d32dd687c620.gif)


## Test Plan

<!-- Explain what you tested and why -->

* Update state test because I changed the `darkBlue` to `blue`
* introduce `ThemeProvider.test.tsx` to test the dark mode switching

<!--
  Have any questions? Check out the contributing doc for more
-->
