### PR TITLE
[DS-363]: fix: Select and Filter overlap issue 

### DIFF
--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -243,7 +243,7 @@ export const menuStyle = () => (theme: Theme) => css`
   border-radius: ${theme.spacing.xsm};
   background-color: ${theme.palette.white};
   box-shadow: ${theme.elevation['02']};
-  z-index: 1;
+  z-index: 500;
   overflow: hidden;
   min-width: 100%;
   max-width: ${rem(620)};


### PR DESCRIPTION
## Description

[DS-363](https://orfium.atlassian.net/browse/DS-363)

The issue was resolved by increasing the z-index value of the Filter Menu (value same as in Select Menu)

## Screenshots 

![Screenshot_23](https://user-images.githubusercontent.com/57801353/163382688-577c8ea2-cebb-4965-a3cd-6295050266c9.jpg)

