### PR TITLE
[DS-364]: fix: add isContentPadded prop in Modal

### DIFF
--- a/src/components/Modal/Modal.style.ts
+++ b/src/components/Modal/Modal.style.ts
@@ -3,6 +3,7 @@ import { transparentize } from 'polished';
 import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
+import { Props } from './Modal';
 
 export const backgroundContainer = (theme: Theme): SerializedStyles => css`
   position: fixed;
@@ -22,11 +23,16 @@ export const cardSizing = css`
   max-height: ${rem(684)};
 `;
 
-export const modalContainer = (theme: Theme): SerializedStyles => css`
+export const modalContainer = ({ isContentPadded }: Pick<Props, 'isContentPadded'>) => (
+  theme: Theme
+): SerializedStyles => css`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  padding: ${theme.spacing.lg} ${theme.spacing.xl} ${theme.spacing.xl} ${theme.spacing.xl};
+
+  padding: ${isContentPadded
+    ? `${theme.spacing.lg} ${theme.spacing.xl} ${theme.spacing.xl} ${theme.spacing.xl}`
+    : undefined};
 `;
 
 export const closeContainer = (theme: Theme) => css`

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -20,6 +20,8 @@ export type Props = {
   dataTestId?: TestId;
   /**  If true, the modal will close also with esc button. Defaults to true. */
   closeOnEsc?: boolean;
+  /** If false, the content won't have any padding */
+  isContentPadded?: boolean;
 };
 
 const Modal: React.FC<Props> = ({
@@ -29,6 +31,7 @@ const Modal: React.FC<Props> = ({
   children,
   contentProps,
   closeOnEsc = true,
+  isContentPadded = true,
 }) => {
   useEscape(() => {
     if (closeOnEsc) {
@@ -64,7 +67,7 @@ const Modal: React.FC<Props> = ({
                 dataTestId={'modal-close'}
               />
             </div>
-            <div css={modalContainer}>
+            <div css={modalContainer({ isContentPadded })}>
               {contentProps ? <ModalContent {...contentProps} /> : children}
             </div>
           </Card>


### PR DESCRIPTION
## Description

- Adds the `isContentPadded` flag (`true` by default) that removes the ModalContent padding when false. The issue that this addition addresses is that when the modal content needs to be scrollable, this padding pushes the scrollbar inside of the modal, which isn't wanted.


Also, by using these flags, no existing UIs will be affected.
