### PR TITLE
fix: fix textfield testid prop

### DIFF
--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -285,7 +285,6 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
               >
                 <input
                   className="emotion-6"
-                  dataTestId="select-input"
                   disabled={false}
                   onChange={[Function]}
                   onInput={[Function]}
@@ -614,7 +613,6 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
               >
                 <input
                   className="emotion-6"
-                  dataTestId="select-input"
                   disabled={false}
                   onChange={[Function]}
                   onInput={[Function]}
@@ -982,7 +980,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={true}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1046,7 +1043,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={true}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1110,7 +1106,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={true}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1178,7 +1173,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={true}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1237,7 +1231,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={true}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1296,7 +1289,6 @@ exports[`Storyshots Design System/Select Disabled/Locked Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={true}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1640,7 +1632,6 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1705,7 +1696,6 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -1770,7 +1760,6 @@ exports[`Storyshots Design System/Select Not Searchable Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -2204,7 +2193,6 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -2269,7 +2257,6 @@ exports[`Storyshots Design System/Select Select Sizes 1`] = `
                 >
                   <input
                     className="emotion-16"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -2614,7 +2601,6 @@ exports[`Storyshots Design System/Select Select with Highlight 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -2942,7 +2928,6 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
               >
                 <input
                   className="emotion-5"
-                  dataTestId="select-input"
                   disabled={false}
                   onChange={[Function]}
                   onInput={[Function]}
@@ -3000,7 +2985,6 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
             >
               <input
                 className="emotion-5"
-                dataTestId="select-input"
                 disabled={false}
                 onChange={[Function]}
                 onInput={[Function]}
@@ -3064,7 +3048,6 @@ exports[`Storyshots Design System/Select Select with edge case 1`] = `
               >
                 <input
                   className="emotion-5"
-                  dataTestId="select-input"
                   disabled={false}
                   onChange={[Function]}
                   onInput={[Function]}
@@ -3438,7 +3421,6 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                 >
                   <input
                     className="emotion-7"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -3503,7 +3485,6 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                 >
                   <input
                     className="emotion-7"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -3579,7 +3560,6 @@ exports[`Storyshots Design System/Select Select with icon and size 1`] = `
                 >
                   <input
                     className="emotion-7"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -4062,7 +4042,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                     >
                       <input
                         className="emotion-7"
-                        dataTestId="select-input"
                         disabled={false}
                         onChange={[Function]}
                         onInput={[Function]}
@@ -4141,7 +4120,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                     >
                       <input
                         className="emotion-7"
-                        dataTestId="select-input"
                         disabled={false}
                         onChange={[Function]}
                         onInput={[Function]}
@@ -4220,7 +4198,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                     >
                       <input
                         className="emotion-7"
-                        dataTestId="select-input"
                         disabled={false}
                         onChange={[Function]}
                         onInput={[Function]}
@@ -4311,7 +4288,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                     >
                       <input
                         className="emotion-7"
-                        dataTestId="select-input"
                         disabled={false}
                         onChange={[Function]}
                         onInput={[Function]}
@@ -4390,7 +4366,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                     >
                       <input
                         className="emotion-7"
-                        dataTestId="select-input"
                         disabled={false}
                         onChange={[Function]}
                         onInput={[Function]}
@@ -4469,7 +4444,6 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                     >
                       <input
                         className="emotion-7"
-                        dataTestId="select-input"
                         disabled={false}
                         onChange={[Function]}
                         onInput={[Function]}
@@ -4830,7 +4804,6 @@ exports[`Storyshots Design System/Select Simple Group Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -5175,7 +5148,6 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -5240,7 +5212,6 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}
@@ -5305,7 +5276,6 @@ exports[`Storyshots Design System/Select Simple Select 1`] = `
                 >
                   <input
                     className="emotion-6"
-                    dataTestId="select-input"
                     disabled={false}
                     onChange={[Function]}
                     onInput={[Function]}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,4 +1,5 @@
 import useTheme from 'hooks/useTheme';
+import { omit } from 'lodash';
 import React, { InputHTMLAttributes } from 'react';
 import { DEFAULT_SIZE } from 'utils/size-utils';
 
@@ -74,7 +75,7 @@ const TextField = React.forwardRef<HTMLInputElement, Props & InputProps & TestPr
               required={required}
               id={id}
               disabled={disabled || locked}
-              {...rest}
+              {...omit(rest, 'dataTestId')}
               ref={ref}
             />
             {label && (

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,5 +1,5 @@
 import useTheme from 'hooks/useTheme';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import React, { InputHTMLAttributes } from 'react';
 import { DEFAULT_SIZE } from 'utils/size-utils';
 


### PR DESCRIPTION
## Description

Inside `TextField` we take the props we need from the `props` object, which contains the `dataTestId` prop, and then spread that object both inside the `TextInputBase` component and the `input` element inside `TextField`.

That means we end up with a correct data-testid through `TextInputBase` and a `dataTestId` prop being passed to the `input` html element, which of course isn't recognized and produces this error: 

<img width="2041" alt="image" src="https://user-images.githubusercontent.com/13350837/168798138-60e74297-abc2-4532-904e-f5bc5f42460f.png">

This PR omits said prop from the `input` element.