### PR TITLE
[ds-360]: fix: removes testid prop from tippy to fix warning

### DIFF
--- a/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -3518,7 +3518,6 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
                 >
                   <div
                     className="emotion-8"
-                    data-testid="title"
                     interactive={false}
                     interactiveDebounce={100}
                     placement="bottom"
@@ -3586,7 +3585,6 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
                 >
                   <div
                     className="emotion-8"
-                    data-testid="surname"
                     interactive={false}
                     interactiveDebounce={100}
                     placement="top"
@@ -3643,7 +3641,6 @@ exports[`Storyshots Design System/Table Regular Table with sorting and tooltips 
                 >
                   <div
                     className="emotion-8"
-                    data-testid="age"
                     interactive={false}
                     interactiveDebounce={100}
                     placement="right"
@@ -14188,7 +14185,6 @@ exports[`Storyshots Design System/Table Table with expandable rows and sortDir 1
                 >
                   <div
                     className="emotion-20"
-                    data-testid="title"
                     interactive={false}
                     interactiveDebounce={100}
                     placement="bottom"
@@ -14256,7 +14252,6 @@ exports[`Storyshots Design System/Table Table with expandable rows and sortDir 1
                 >
                   <div
                     className="emotion-20"
-                    data-testid="surname"
                     interactive={false}
                     interactiveDebounce={100}
                     placement="top"
@@ -14313,7 +14308,6 @@ exports[`Storyshots Design System/Table Table with expandable rows and sortDir 1
                 >
                   <div
                     className="emotion-20"
-                    data-testid="age"
                     interactive={false}
                     interactiveDebounce={100}
                     placement="right"

--- a/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
+++ b/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
@@ -75,11 +75,7 @@ const ExtendedColumnItem: React.FC<Props> = ({ item, sorting, isNumerical }) => 
         }}
         key={`table_icon_tooltip_${itemContentLowerCase}`}
       >
-        <Tooltip
-          content={item?.tooltip?.content}
-          id={itemContentLowerCase}
-          placement={item?.tooltip.placement}
-        >
+        <Tooltip content={item?.tooltip?.content} placement={item?.tooltip.placement}>
           <Icon
             name={'info'}
             dataTestId={`table_icon_tooltip_${itemContentLowerCase}`}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -36,7 +36,6 @@ type Props = {
 };
 
 const Tooltip: React.FC<Props> = ({
-  id,
   size = 'medium',
   children,
   content,
@@ -47,7 +46,6 @@ const Tooltip: React.FC<Props> = ({
 }) => {
   return (
     <Tippy
-      data-testid={id}
       css={tooltipStyle({ size, isTransparent })}
       content={content}
       placement={placement}

--- a/src/components/storyUtils/TooltipShowcase/TooltipShowcase.tsx
+++ b/src/components/storyUtils/TooltipShowcase/TooltipShowcase.tsx
@@ -39,7 +39,6 @@ const TooltipShowcase = ({ content }: { content: string }) => {
       <h2>Tooltip with text-only content</h2>
       <div css={tooltipRowStyle()}>
         <Tooltip
-          id={'left'}
           content={content}
           placement={'left'}
           interactive={boolean('interactive', false)}
@@ -50,7 +49,6 @@ const TooltipShowcase = ({ content }: { content: string }) => {
           </Button>
         </Tooltip>
         <Tooltip
-          id={'right'}
           content={content}
           placement={'right'}
           interactive={boolean('interactive', false)}
@@ -64,7 +62,6 @@ const TooltipShowcase = ({ content }: { content: string }) => {
 
       <div css={tooltipRowStyle()}>
         <Tooltip
-          id={'top'}
           content={content}
           placement={'top'}
           interactive={boolean('interactive', false)}
@@ -75,7 +72,6 @@ const TooltipShowcase = ({ content }: { content: string }) => {
           </Button>
         </Tooltip>
         <Tooltip
-          id={'bottom'}
           content={content}
           placement={'bottom'}
           interactive={boolean('interactive', false)}
@@ -88,7 +84,6 @@ const TooltipShowcase = ({ content }: { content: string }) => {
       </div>
       <h2>Tooltip with component content</h2>
       <Tooltip
-        id={'right'}
         isTransparent
         content={CustomContent()}
         placement={'right'}


### PR DESCRIPTION
## Description

- Removes testid prop from tippy as it is not used.

PS. Running `yarn test . -u` updated the Table storyshots. While it looks like the data-testid prop was removed, I confirmed that the prop was never in the DOM to begin with.