### PR TITLE
[NDS-338] Feat/Props Standardization (Booleans pt3)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,14 @@
+node_modules
+build
+dist
+scripts
+typeDocs
+server
+**/storyUtils
+**/__snapshots__
+**/*.stories.tsx
+**/*.stories.mdx
+**/*.test.ts
+**/*.test.tsx
+__mocks__
+./jest.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -88,6 +88,12 @@
       }
     ],
     /* Typescript rules */
+    "@typescript-eslint/naming-convention": [
+      "error",
+      { "selector": "variable", "types": ["boolean"],
+        "format": ["camelCase"],
+        "prefix": ["is", "has"] }
+    ],
     "@typescript-eslint/no-unused-expressions": "warn",
     "@typescript-eslint/no-unused-vars": [
       "warn",
@@ -118,6 +124,7 @@
       "jsx": true
     },
     "ecmaVersion": 2018,
-    "sourceType": "module"
+    "sourceType": "module",
+    "project": ["./tsconfig.json"] // Specify it only for TypeScript files
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,7 +91,7 @@
     "@typescript-eslint/naming-convention": [
       "error",
       { "selector": "variable", "types": ["boolean"],
-        "format": ["camelCase"],
+        "format": ["PascalCase"],// As per documentation, prefix is trimmed before checking for format , so we need pascal case for values like `isBoolean`  https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md#format-options
         "prefix": ["is", "has"] }
     ],
     "@typescript-eslint/no-unused-expressions": "warn",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/recharts": "^1.8.16",
     "@types/styled-components": "^5.1.7",
     "@types/uuid": "^8.3.0",
-    "@typescript-eslint/eslint-plugin": "^5.30.5",
+    "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.30.5",
     "babel-loader": "^8.0.6",
     "babel-plugin-inline-import-data-uri": "^1.0.1",

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -108,7 +108,7 @@ Button types based on the system approved literals for `success, error, info, wa
 <Preview>
   <Story name="Button Types">
     <Stack>
-        <Button size={'sm'} disabled type='success'>Success</Button>
+        <Button size={'sm'} isDisabled type='success'>Success</Button>
         <Button size={'sm'} type='success'>Success</Button>
         <Button size={'sm'} type='error'>Error</Button>
         <Button size={'sm'} type='info'>Info</Button>
@@ -124,7 +124,7 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 <Preview>
   <Story name="Button Colors">
     <Stack>
-        <Button size={'sm'} disabled color={'red-500'}>Disabled</Button>
+        <Button size={'sm'} isDisabled color={'red-500'}>Disabled</Button>
         <Button size={'sm'} color={'red-600'}>Red 600</Button>
         <Button size={'sm'} color={'magenta-200'}>Magenta 200</Button>
     </Stack>
@@ -134,7 +134,7 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 # Regular Button
 <Preview>
   <Story name="Regular Button">
-    <Button filled={true} size={'lg'}>Hello world</Button>
+    <Button isFilled={true} size={'lg'}>Hello world</Button>
   </Story>
 </Preview>
 
@@ -142,9 +142,9 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 <Preview>
   <Story name="Button with icon">
     <Stack>
-      <Button filled={true} size={'lg'} iconLeft={<Icon name={'dashboard'} color={'primary'} size={16} />}>Hello world</Button>
-      <Button filled={true} size={'lg'} iconRight={<Icon name={'dashboard'} color={'primary'} size={16} />}>Hello world</Button>
-      <Button filled={true} size={'lg'} iconLeft={<Icon name={'dashboard'} color={'primary'} size={16} />} iconRight={<Icon name={'dotsVertical'} color={'primary'} size={18} />}>Hello world</Button>
+      <Button isFilled={true} size={'lg'} iconLeft={<Icon name={'dashboard'} color={'primary'} size={16} />}>Hello world</Button>
+      <Button isFilled={true} size={'lg'} iconRight={<Icon name={'dashboard'} color={'primary'} size={16} />}>Hello world</Button>
+      <Button isFilled={true} size={'lg'} iconLeft={<Icon name={'dashboard'} color={'primary'} size={16} />} iconRight={<Icon name={'dotsVertical'} color={'primary'} size={18} />}>Hello world</Button>
     </Stack>
   </Story>
 </Preview>
@@ -152,14 +152,14 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 # Non Filled Button
 <Preview>
   <Story name="Non Filled Button">
-    <Button filled={false} size={'lg'}>Hello world</Button>
+    <Button isFilled={false} size={'lg'}>Hello world</Button>
   </Story>
 </Preview>
 
 # Transparent Button
 <Preview>
   <Story name="Transparent Button">
-    <Button type='primary' size={'lg'} transparent>Hello world</Button>
+    <Button type='primary' size={'lg'} isTransparent>Hello world</Button>
   </Story>
 </Preview>
 
@@ -167,9 +167,9 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 <Preview>
   <Story name="Block Button">
     <Stack isVertical>
-      <Button filled={true} size={'lg'} block iconLeft={<Icon name={'dashboard'} color={'primary'} size={16} />} iconRight={<Icon name={'dashboard'} color={'primary'} size={16} />}>Hello world</Button>
-      <Button filled={false} size={'lg'} block>Hello world</Button>
-      <Button type='success' size={'lg'} transparent block>Hello world</Button>
+      <Button isFilled={true} size={'lg'} isBlock iconLeft={<Icon name={'dashboard'} color={'primary'} size={16} />} iconRight={<Icon name={'dashboard'} color={'primary'} size={16} />}>Hello world</Button>
+      <Button isFilled={false} size={'lg'} isBlock>Hello world</Button>
+      <Button type='success' size={'lg'} isTransparent isBlock>Hello world</Button>
     </Stack>
   </Story>
 </Preview>
@@ -177,7 +177,7 @@ Button colors based on the system palette. Check <a href="/?path=/story/guide-co
 # Dynamic Button Props - Knobs
 <Preview>
   <Story name="Dynamic Button Props" parameters={{ decorators: [withKnobs] }}>
-    <Button type={select('type', ['primary', 'secondary', 'success', 'error', 'info', 'warning', 'primary', 'secondary'], 'secondary')} filled={boolean('filled', true)} size={select('size', ['sm', 'md', 'lg'], 'lg')} block={boolean('block', false)}>{text('text', 'change me!')}</Button>
+    <Button type={select('type', ['primary', 'secondary', 'success', 'error', 'info', 'warning', 'primary', 'secondary'], 'secondary')} isFilled={boolean('isFilled', true)} size={select('size', ['sm', 'md', 'lg'], 'lg')} isBlock={boolean('isBlock', false)}>{text('text', 'change me!')}</Button>
   </Story>
 </Preview>
 

--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -14,18 +14,20 @@ export const iconStyle = () => () => ({
   display: 'inline-flex',
 });
 
-export const childrenWrapperStyle = ({
-  iconLeft,
-  iconRight,
-  hasChildren,
-}: Omit<Props, 'block' | 'isIconButton' | 'buttonType' | 'dataTestId' | 'onClick'> & {
-  hasChildren: boolean;
-}) => (theme: Theme) => {
-  const rightIconExists = hasChildren && iconRight;
-  const leftIconExists = hasChildren && iconLeft;
+export const childrenWrapperStyle =
+  ({
+    iconLeft,
+    iconRight,
+    hasChildren,
+  }: Omit<Props, 'block' | 'isIconButton' | 'buttonType' | 'dataTestId' | 'onClick' | 'ref'> & {
+    hasChildren: boolean;
+  }) =>
+  (theme: Theme) => {
+    const rightIconExists = hasChildren && iconRight;
+    const leftIconExists = hasChildren && iconLeft;
 
-  return {
-    marginLeft: leftIconExists ? theme.spacing.sm : 0,
-    marginRight: rightIconExists ? theme.spacing.sm : 0,
+    return {
+      marginLeft: leftIconExists ? theme.spacing.sm : 0,
+      marginRight: rightIconExists ? theme.spacing.sm : 0,
+    };
   };
-};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,46 +7,47 @@ import ButtonBase, { Props as ButtonBaseProps } from '../ButtonBase/ButtonBase';
 import { buttonSpanStyle, childrenWrapperStyle, iconStyle } from './Button.style';
 import ButtonLoader from './ButtonLoader';
 
-export type Props = ButtonBaseProps & TestProps & onClickProp;
 type onClickProp = { onClick: ClickHandler };
+export type Props = Omit<ButtonBaseProps, 'onClick'> & TestProps & onClickProp & ButtonProps;
 
-const Button = React.forwardRef<HTMLButtonElement, Props & ButtonProps>((props, ref) => {
+const Button: React.FC<Props> = (props) => {
   const {
     size = 'md',
     type = 'primary',
     color = '',
-    filled = true,
-    transparent = false,
+    isFilled = true,
+    isTransparent = false,
     iconLeft = null,
     iconRight = null,
-    disabled = false,
+    isDisabled = false,
     children,
     onClick,
+    ref,
   } = props;
-  const { loading, handleAsyncOperation } = useLoading(onClick);
+  const { isLoading, handleAsyncOperation } = useLoading(onClick);
   const childrenWrapperRef = useRef<HTMLSpanElement>(null);
   const innerButtonWidth = childrenWrapperRef?.current?.clientWidth;
 
   return (
-    <ButtonBase {...props} ref={ref} loading={loading} onClick={handleAsyncOperation}>
+    <ButtonBase {...props} ref={ref} isLoading={isLoading} onClick={handleAsyncOperation}>
       <span css={buttonSpanStyle()}>
         {iconLeft && <span css={iconStyle()}>{iconLeft}</span>}
         <span
           ref={childrenWrapperRef}
           css={childrenWrapperStyle({
             type,
-            loading,
-            filled,
+            isLoading,
+            isFilled,
             size,
             color,
-            transparent,
+            isTransparent,
             iconLeft,
             iconRight,
-            disabled,
+            isDisabled,
             hasChildren: Boolean(React.Children.count(children)),
           })}
         >
-          {loading ? (
+          {isLoading ? (
             <ButtonLoader innerButtonWidth={innerButtonWidth} color={color} type={type} />
           ) : (
             children
@@ -57,7 +58,10 @@ const Button = React.forwardRef<HTMLButtonElement, Props & ButtonProps>((props, 
       </span>
     </ButtonBase>
   );
-});
+};
+
 Button.displayName = 'Button';
 
-export default Button;
+export default React.forwardRef<HTMLButtonElement, Props>((props, ref) => (
+  <Button {...props} ref={ref} />
+));

--- a/src/components/ButtonBase/ButtonBase.style.ts
+++ b/src/components/ButtonBase/ButtonBase.style.ts
@@ -16,65 +16,67 @@ export const heightBasedOnSize = (size: typeof buttonSizes[number] | 'default') 
 const fontSizeBasedOnSize = (theme: Theme, size: typeof buttonSizes[number] | 'default') =>
   theme.typography.fontSizes[buttonConfig.fontSize[size] ?? buttonConfig.fontSize.default];
 
-export const buttonBaseStyle = ({
-  type,
-  filled,
-  calculatedColor,
-  size,
-  block,
-  transparent,
-  childrenCount,
-  sx,
-}: Omit<Props, 'buttonType'> & {
-  calculatedColor: ColorShapeFromComponent;
-  childrenCount: number;
-}) => (theme: Theme): SerializedStyles => {
-  const backGroundColor = defineBackgroundColor(theme, calculatedColor, type, childrenCount > 0);
-  const isOutlined = !filled && !transparent;
-  const isBackgroundTransparent = isOutlined || transparent;
+export const buttonBaseStyle =
+  ({
+    type,
+    isFilled,
+    calculatedColor,
+    size,
+    isBlock,
+    isTransparent,
+    childrenCount,
+    sx,
+  }: Omit<Props, 'buttonType' | 'ref'> & {
+    calculatedColor: ColorShapeFromComponent;
+    childrenCount: number;
+  }) =>
+  (theme: Theme): SerializedStyles => {
+    const backGroundColor = defineBackgroundColor(theme, calculatedColor, type, childrenCount > 0);
+    const isOutlined = !isFilled && !isTransparent;
+    const isBackgroundTransparent = isOutlined || isTransparent;
 
-  const borderWidth = isOutlined ? buttonConfig.types.outlined.border.width : 0;
+    const borderWidth = isOutlined ? buttonConfig.types.outlined.border.width : 0;
 
-  const baseButtonStyles = {
-    fontSize: fontSizeBasedOnSize(theme, size || 'default'),
-    fontWeight: theme.typography.weights.medium,
-    color: calculateButtonColor({
-      type,
-      isBackgroundTransparent: Boolean(isBackgroundTransparent),
-      backGroundColor,
-      calculatedColor,
-      theme,
-    }),
-    width: block ? '100%' : undefined,
-    backgroundColor: isBackgroundTransparent ? 'transparent' : backGroundColor,
-    padding: size === 'lg' ? theme.spacing.md : `0 ${theme.spacing.md}`,
-    height: heightBasedOnSize(size || 'default'),
-    borderRadius: theme.spacing.xsm,
-    border: isOutlined ? `solid ${rem(borderWidth)} ${backGroundColor}` : 'none',
-    cursor: 'pointer',
-    transition: 'background-color,border 150ms linear',
-    ':focus-visible:not(:disabled)': {
-      outline: getFocus({ theme, borderWidth: borderWidth }).styleOutline,
-    },
-    ':hover:not(:disabled)': {
-      backgroundColor: getHover({
+    const baseButtonStyles = {
+      fontSize: fontSizeBasedOnSize(theme, size || 'default'),
+      fontWeight: theme.typography.weights.medium,
+      color: calculateButtonColor({
+        type,
+        isBackgroundTransparent: Boolean(isBackgroundTransparent),
+        backGroundColor,
+        calculatedColor,
         theme,
-        color: calculatedColor.color,
-        shade: isBackgroundTransparent ? 0 : calculatedColor.shade,
-      }).backgroundColor,
-    },
-    ':active:not(:disabled)': {
-      backgroundColor: getPressed({
-        theme,
-        color: calculatedColor.color,
-        shade: isBackgroundTransparent ? 0 : calculatedColor.shade,
-      }).backgroundColor,
-    },
-    ':disabled': getDisabled(),
+      }),
+      width: isBlock ? '100%' : undefined,
+      backgroundColor: isBackgroundTransparent ? 'transparent' : backGroundColor,
+      padding: size === 'lg' ? theme.spacing.md : `0 ${theme.spacing.md}`,
+      height: heightBasedOnSize(size || 'default'),
+      borderRadius: theme.spacing.xsm,
+      border: isOutlined ? `solid ${rem(borderWidth)} ${backGroundColor}` : 'none',
+      cursor: 'pointer',
+      transition: 'background-color,border 150ms linear',
+      ':focus-visible:not(:disabled)': {
+        outline: getFocus({ theme, borderWidth: borderWidth }).styleOutline,
+      },
+      ':hover:not(:disabled)': {
+        backgroundColor: getHover({
+          theme,
+          color: calculatedColor.color,
+          shade: isBackgroundTransparent ? 0 : calculatedColor.shade,
+        }).backgroundColor,
+      },
+      ':active:not(:disabled)': {
+        backgroundColor: getPressed({
+          theme,
+          color: calculatedColor.color,
+          shade: isBackgroundTransparent ? 0 : calculatedColor.shade,
+        }).backgroundColor,
+      },
+      ':disabled': getDisabled(),
+    };
+
+    return css({ ...baseButtonStyles, ...sx?.container });
   };
-
-  return css({ ...baseButtonStyles, ...sx?.container });
-};
 
 export const buttonSpanStyle = () => () => {
   return {

--- a/src/components/ButtonBase/ButtonBase.tsx
+++ b/src/components/ButtonBase/ButtonBase.tsx
@@ -23,13 +23,13 @@ export type Props = {
   /** This property define the size of the button. Defaults to 'md' */
   size?: typeof buttonSizes[number];
   /** This property will make the button fit to its parent width. Defaults to false */
-  block?: boolean;
+  isBlock?: boolean;
   /** Property indicating if the component is filled with a color based on the type */
-  filled?: boolean;
+  isFilled?: boolean;
   /** Property indicating if the component is async and loading */
-  loading?: boolean;
+  isLoading?: boolean;
   /** Property indicating if the component is transparent with a color based on the type */
-  transparent?: boolean;
+  isTransparent?: boolean;
   /** An optional boolean to show if the button is icon */
   isIconButton?: boolean;
   /** An optional icon to put on the right of the button */
@@ -37,31 +37,31 @@ export type Props = {
   /** An optional icon to put on the left of the button */
   iconLeft?: React.Component | JSX.Element | null;
   /** Define if the button is in disabled state */
-  disabled?: boolean;
+  isDisabled?: boolean;
   /** Defines the button type */
   buttonType?: 'submit' | 'reset' | 'button';
   /** Sx prop to override specific properties */
   sx?: {
     container?: CSSObject;
   };
-};
+  ref: React.ForwardedRef<HTMLButtonElement>;
+} & TestProps &
+  EventButtonProps &
+  ButtonProps;
 
 //@TODO fix props to not overwrite button props
-const ButtonBase = React.forwardRef<
-  HTMLButtonElement,
-  ButtonProps & Props & TestProps & EventButtonProps
->((props, ref) => {
+const ButtonBase: React.FC<Props> = (props) => {
   const {
     size = 'md',
     type = 'primary',
     color = '',
-    block = false,
-    filled = true,
-    transparent = false,
+    isBlock = false,
+    isFilled = true,
+    isTransparent = false,
     iconLeft = null,
     iconRight = null,
-    disabled = false,
-    loading = false,
+    isDisabled = false,
+    isLoading = false,
     children,
     dataTestId = '',
     dataTestPrefixId = '',
@@ -69,6 +69,7 @@ const ButtonBase = React.forwardRef<
     onClick,
     onBlur,
     sx,
+    ref,
   } = props;
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const calculatedColor = calculateColorBetweenColorAndType(color, type);
@@ -81,31 +82,34 @@ const ButtonBase = React.forwardRef<
       data-testid={generateTestDataId(testIdName, dataTestId)}
       css={buttonBaseStyle({
         type,
-        loading,
-        filled,
+        isLoading,
+        isFilled,
         size,
-        block,
+        isBlock,
         color,
-        transparent,
+        isTransparent,
         calculatedColor,
-        disabled,
+        isDisabled,
         iconLeft,
         iconRight,
         sx,
         childrenCount: React.Children.count(children),
       })}
-      onClick={event => {
+      onClick={(event) => {
         if (onClick) {
           onClick(event);
         }
       }}
       onBlur={onBlur}
-      disabled={disabled || loading}
+      disabled={isDisabled || isLoading}
     >
       {children}
     </button>
   );
-});
+};
+
 ButtonBase.displayName = 'ButtonBase';
 
-export default ButtonBase;
+export default React.forwardRef<HTMLButtonElement, Props>((props, ref) => (
+  <ButtonBase {...props} ref={ref} />
+));

--- a/src/components/Label/Label.style.ts
+++ b/src/components/Label/Label.style.ts
@@ -3,33 +3,31 @@ import { Theme } from 'theme';
 import { BASE_SHADE } from 'theme/palette';
 import { rem } from 'theme/utils';
 
+import { Props } from './Label';
+
 export const LABEL_TRANSFORM_LEFT_SPACING = rem(3);
 
-export const labelStyle = ({
-  animateToTop,
-  error,
-}: {
-  size: string;
-  animateToTop: boolean;
-  error: boolean;
-}) => (theme: Theme): SerializedStyles => css`
-  transition: transform 0.25s, opacity 0.25s ease-in-out;
-  transform-origin: 0 0;
-  width: 100%;
-  position: absolute;
-  user-select: none;
-  transform: ${!animateToTop
-    ? `translate(${LABEL_TRANSFORM_LEFT_SPACING}, 0)`
-    : `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -95%) scale(0.8);`};
-  font-size: ${theme.typography.fontSizes['16']};
-  font-weight: ${theme.typography.weights.regular};
-  color: ${error
-    ? theme.utils.getColor('error', BASE_SHADE, 'normal')
-    : theme.utils.getColor('lightGrey', 650)};
-  align-items: center;
-  display: flex;
-  top: 0;
-  bottom: 0;
-  margin: auto;
-  white-space: nowrap;
-`;
+export const labelStyle =
+  ({ isAnimated, hasError }: Pick<Props, 'isAnimated' | 'hasError'>) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      transition: transform 0.25s, opacity 0.25s ease-in-out;
+      transform-origin: 0 0;
+      width: 100%;
+      position: absolute;
+      user-select: none;
+      transform: ${!isAnimated
+        ? `translate(${LABEL_TRANSFORM_LEFT_SPACING}, 0)`
+        : `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -95%) scale(0.8);`};
+      font-size: ${theme.typography.fontSizes['16']};
+      font-weight: ${theme.typography.weights.regular};
+      color: ${hasError
+        ? theme.utils.getColor('error', BASE_SHADE, 'normal')
+        : theme.utils.getColor('lightGrey', 650)};
+      align-items: center;
+      display: flex;
+      top: 0;
+      bottom: 0;
+      margin: auto;
+      white-space: nowrap;
+    `;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,32 +1,29 @@
 import * as React from 'react';
 
-import { DEFAULT_SIZE } from '../../utils/size-utils';
 import { labelStyle } from './Label.style';
 
 export type Props = {
   /** If the label has error */
-  error?: boolean;
+  hasError?: boolean;
   /** The label that is going to be displayed */
   label: string;
   /** If the label value is required */
-  required: boolean;
+  isRequired: boolean;
   /** If the label must be moved to the top */
-  animateToTop?: boolean;
+  isAnimated?: boolean;
   htmlFor?: string;
-  size?: string;
 };
 
 const Label: React.FC<Props> = ({
-  error = false,
+  hasError = false,
   htmlFor,
   label,
-  required = false,
-  animateToTop = false,
-  size = DEFAULT_SIZE,
+  isRequired = false,
+  isAnimated = false,
 }) => {
   return (
-    <label htmlFor={htmlFor} css={labelStyle({ size, animateToTop, error })}>
-      {label} {required && '*'}
+    <label htmlFor={htmlFor} css={labelStyle({ isAnimated, hasError })}>
+      {label} {isRequired && '*'}
     </label>
   );
 };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { EventProps } from 'utils/common';
 import { AcceptedColorComponentTypes } from 'utils/themeFunctions';
 
+import { TestProps } from '../../utils/types';
 import Avatar from '../Avatar';
 import Button from '../Button';
 import { defineBackgroundColor } from '../Button/utils';
@@ -23,7 +24,7 @@ export type Props = {
   /** This property define the size of the button. Defaults to 'md' */
   size?: 'lg' | 'md' | 'sm';
   /** Property indicating if the component is filled with a color based on the type */
-  filled?: boolean;
+  isFilled?: boolean;
   /** Returns the items selected on the menu */
   selectedItem?: string | null;
   /** A callback that is being triggered when an items has been clicked */
@@ -31,7 +32,7 @@ export type Props = {
   /** The text of the button to show - defaults to "More" */
   buttonText: React.ReactNode;
   /** Define if the button is in disabled state */
-  disabled?: boolean;
+  isDisabled?: boolean;
   /** Menu position when open */
   menuPosition?: MenuPositionAllowed;
   /** The type of the button - defaults to "primary" */
@@ -48,13 +49,10 @@ export type Props = {
     letter: string;
     color?: string;
   };
-};
+} & TestProps &
+  EventProps;
 
-export type TestProps = {
-  dataTestId?: string;
-};
-
-const Menu: React.FC<Props & TestProps & EventProps> = props => {
+const Menu: React.FC<Props> = (props) => {
   const {
     items,
     onSelect,
@@ -64,31 +62,31 @@ const Menu: React.FC<Props & TestProps & EventProps> = props => {
     menuPosition = 'left',
     buttonType = 'primary',
     rightIconName,
-    filled = true,
-    disabled = false,
+    isFilled = true,
+    isDisabled = false,
     leftIconName,
     iconSize = 16,
     avatar,
     dataTestId,
   } = props;
-  const [open, setOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(false);
   const theme = useTheme();
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const calculatedColor = calculateColorBetweenColorAndType(color, buttonType);
-  const iconColor = filled
+  const iconColor = isFilled
     ? theme.utils.getAAColorFromSwatches(calculatedColor.color, calculatedColor.shade)
     : defineBackgroundColor(theme, calculatedColor, buttonType, true, true);
 
   return (
-    <ClickAwayListener onClick={() => setOpen(false)}>
+    <ClickAwayListener onClick={() => setIsOpen(false)}>
       <div css={wrapperStyle()} data-testid={dataTestId}>
         <Button
           size={size}
-          onClick={() => setOpen(!open)}
+          onClick={() => setIsOpen(!open)}
           type={buttonType}
           color={color}
-          disabled={disabled}
-          filled={filled}
+          isDisabled={isDisabled}
+          isFilled={isFilled}
           iconRight={
             rightIconName ? <Icon name={rightIconName} color={iconColor} size={iconSize} /> : null
           }
@@ -104,14 +102,14 @@ const Menu: React.FC<Props & TestProps & EventProps> = props => {
         >
           <span>{buttonText}</span>
         </Button>
-        {open && (
+        {isOpen && (
           <div css={optionsStyle({ menuPosition })(theme)}>
             {items && (
               <List
                 data={items}
                 rowSize={'small'}
                 handleOptionClick={(option: string) => {
-                  setOpen(false);
+                  setIsOpen(false);
                   onSelect(option);
                 }}
               />

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -45,8 +45,8 @@ const Overlay = React.forwardRef<HTMLDivElement, Props & DivProps>(
             <div css={closeIconContainer()}>
               <IconButton
                 name={'close'}
-                filled={false}
-                transparent
+                isFilled={false}
+                isTransparent
                 color={'lightGrey-650'}
                 size={'sm'}
                 onClick={onClose}

--- a/src/components/Radio/Radio.style.ts
+++ b/src/components/Radio/Radio.style.ts
@@ -31,105 +31,108 @@ export const inputStyles: SerializedStyles = css`
   }
 `;
 
-export const customRadioInnerHover = (focused: boolean, disabled: boolean) => (
-  theme: Theme
-): SerializedStyles => css`
-  position: absolute;
-  border-radius: 50%;
-  width: ${rem('24px')};
-  height: ${rem('24px')};
-  transition: all 0.2s ease;
-  ${focused && !disabled && boxShadow({ colorScheme: theme.colorScheme })};
-`;
-
-export const customRadioWrapperStyles = (focused: boolean, disabled: boolean) => (
-  theme: Theme
-): SerializedStyles => css`
-  position: relative;
-  border-radius: 50%;
-  width: ${rem('24px')};
-  height: ${rem('24px')};
-  transition: box-shadow 0.3s ease;
-  ${focused && !disabled && boxShadow({ colorScheme: theme.colorScheme })};
-`;
-
-const determineColorBasedOnState = ({
-  checked,
-  disabled,
-  filled,
-}: Pick<Props, 'checked' | 'disabled' | 'filled'>) => (theme: Theme) => {
-  if (checked) {
-    return `currentColor`;
-  }
-  if (disabled) {
-    return `${theme.utils.getColor('lightGrey', 250)}`;
-  }
-  if (filled) {
-    return `${theme.utils.getColor('lightGrey', 300)}`;
-  }
-
-  return `${theme.utils.getColor('lightGrey', 300)}`;
-};
-
-export const customRadioStyles = (props: Pick<Props, 'checked' | 'disabled' | 'filled'>) => (
-  theme: Theme
-): SerializedStyles => {
-  return css`
-    transition: all 0.2s ease;
-    border-radius: 50%;
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    position: absolute;
-    &:before {
-      content: '';
-      display: inline-block;
-      box-sizing: border-box;
-      margin: ${rem('2px')} ${rem('12px')} ${rem('2px')} ${rem('2px')};
-      border: solid 2px ${determineColorBasedOnState(props)(theme)};
-      border-radius: 50%;
-      width: ${rem('20px')};
-      height: ${rem('20px')};
-      vertical-align: top;
-      transition: border-color 0.2s;
-    }
-    &:after {
-      content: '';
-      display: block;
+export const customRadioInnerHover =
+  (focused: boolean, disabled: boolean) =>
+  (theme: Theme): SerializedStyles =>
+    css`
       position: absolute;
-      top: ${rem('1px')};
-      left: ${rem('1px')};
       border-radius: 50%;
-      width: ${rem('12px')};
-      height: ${rem('12px')};
-      background-color: ${determineColorBasedOnState(props)(theme)};
-      transform: translate(5px, 5px) scale(${props.checked ? '1' : '0'});
-      transition: transform 0.2s;
+      width: ${rem('24px')};
+      height: ${rem('24px')};
+      transition: all 0.2s ease;
+      ${focused && !disabled && boxShadow({ colorScheme: theme.colorScheme })};
+    `;
+
+export const customRadioWrapperStyles =
+  (focused: boolean, disabled: boolean) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      position: relative;
+      border-radius: 50%;
+      width: ${rem('24px')};
+      height: ${rem('24px')};
+      transition: box-shadow 0.3s ease;
+      ${focused && !disabled && boxShadow({ colorScheme: theme.colorScheme })};
+    `;
+
+const determineColorBasedOnState =
+  ({ isChecked, isDisabled, isFilled }: Pick<Props, 'isChecked' | 'isDisabled' | 'isFilled'>) =>
+  (theme: Theme) => {
+    if (isChecked) {
+      return `currentColor`;
     }
-  `;
-};
+    if (isDisabled) {
+      return `${theme.utils.getColor('lightGrey', 250)}`;
+    }
+    if (isFilled) {
+      return `${theme.utils.getColor('lightGrey', 300)}`;
+    }
 
-export const wrapperStyles = (disabled: boolean) => (theme: Theme): SerializedStyles => css`
-  position: relative;
+    return `${theme.utils.getColor('lightGrey', 300)}`;
+  };
 
-  border-radius: 50%;
+export const customRadioStyles =
+  (props: Pick<Props, 'isChecked' | 'isDisabled' | 'isFilled'>) =>
+  (theme: Theme): SerializedStyles => {
+    return css`
+      transition: all 0.2s ease;
+      border-radius: 50%;
+      width: 100%;
+      height: 100%;
+      box-sizing: border-box;
+      position: absolute;
+      &:before {
+        content: '';
+        display: inline-block;
+        box-sizing: border-box;
+        margin: ${rem('2px')} ${rem('12px')} ${rem('2px')} ${rem('2px')};
+        border: solid 2px ${determineColorBasedOnState(props)(theme)};
+        border-radius: 50%;
+        width: ${rem('20px')};
+        height: ${rem('20px')};
+        vertical-align: top;
+        transition: border-color 0.2s;
+      }
+      &:after {
+        content: '';
+        display: block;
+        position: absolute;
+        top: ${rem('1px')};
+        left: ${rem('1px')};
+        border-radius: 50%;
+        width: ${rem('12px')};
+        height: ${rem('12px')};
+        background-color: ${determineColorBasedOnState(props)(theme)};
+        transform: translate(5px, 5px) scale(${props.isChecked ? '1' : '0'});
+        transition: transform 0.2s;
+      }
+    `;
+  };
 
-  width: ${rem('36px')};
-  height: ${rem('36px')};
+export const wrapperStyles =
+  (disabled: boolean) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      position: relative;
 
-  color: ${theme.utils.getColor('primary', BASE_SHADE, 'normal')};
-  border: 0;
-  opacity: ${disabled ? 0.5 : 1};
-  cursor: pointer;
-  margin: 0;
-  display: inline-flex;
-  outline: 0;
-  align-items: center;
-  user-select: none;
-  vertical-align: middle;
-  -moz-appearance: none;
-  justify-content: center;
-  text-decoration: none;
-  -webkit-appearance: none;
-  -webkit-tap-highlight-color: transparent;
-`;
+      border-radius: 50%;
+
+      width: ${rem('36px')};
+      height: ${rem('36px')};
+
+      color: ${theme.utils.getColor('primary', BASE_SHADE, 'normal')};
+      border: 0;
+      opacity: ${disabled ? 0.5 : 1};
+      cursor: pointer;
+      margin: 0;
+      display: inline-flex;
+      outline: 0;
+      align-items: center;
+      user-select: none;
+      vertical-align: middle;
+      -moz-appearance: none;
+      justify-content: center;
+      text-decoration: none;
+      -webkit-appearance: none;
+      -webkit-tap-highlight-color: transparent;
+    `;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -20,7 +20,7 @@ export type Props = {
    * */
   value?: string | number;
   /** Whether the radio input is selected or not. Defining this prop means the radio input is controlled */
-  checked?: boolean;
+  isChecked?: boolean;
   /** The onChange event handler for the radio input */
   onChange?: React.ReactEventHandler;
   /** The name of the radio input, in case you want to manually form a radio group */
@@ -29,53 +29,54 @@ export type Props = {
    *
    *  @default false
    * */
-  disabled?: boolean;
+  isDisabled?: boolean;
   /** ID property of the radio input */
   id?: string;
   /** Whether the radio input is required to be selected in the context of a form
    *
    * @default false
    * */
-  required?: boolean;
+  isRequired?: boolean;
   /** Whether the radio input is filled or outlined
    *
    * @default true
    * */
-  filled?: boolean;
+  isFilled?: boolean;
   dataTestId?: TestId;
+  ref: React.ForwardedRef<HTMLInputElement>;
 };
 
-const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+const Radio: React.FC<Props> = (props, ref) => {
   const {
-    checked: externallyControlledChecked,
+    isChecked: isExternallyControlledChecked,
     onChange,
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#value
     value = 'on',
     name,
-    disabled = false,
+    isDisabled = false,
     id,
-    required = false,
-    filled = true,
+    isRequired = false,
+    isFilled = true,
     dataTestId,
   } = props;
-  const [focused, setFocused] = React.useState(false);
-  const [internallyControlledChecked, setInternallyControlledChecked] = React.useState(false);
+  const [isFocused, setIsFocused] = React.useState(false);
+  const [isInternallyControlledChecked, setIsInternallyControlledChecked] = React.useState(false);
   const radioGroup = useRadioGroup();
   const theme = useTheme();
 
   const handleFocus = () => {
-    setFocused(true);
+    setIsFocused(true);
   };
 
   const handleBlur = () => {
-    setFocused(false);
+    setIsFocused(false);
   };
 
   const handleChange = (e: React.SyntheticEvent) => {
-    if (disabled) return;
+    if (isDisabled) return;
 
-    if (externallyControlledChecked === undefined) {
-      setInternallyControlledChecked((e.target as HTMLInputElement).checked);
+    if (isExternallyControlledChecked === undefined) {
+      setIsInternallyControlledChecked((e.target as HTMLInputElement).checked);
     }
 
     if (onChange) {
@@ -90,13 +91,16 @@ const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   // Checked value is either the externally controlled value,
   // or based on the radioGroup provided values,
   // or the internally controlled value
-  const checkedValue =
-    externallyControlledChecked ??
-    (radioGroup ? (radioGroup && radioGroup.value) === value : internallyControlledChecked);
+  const isCheckedValue =
+    isExternallyControlledChecked ??
+    (radioGroup ? (radioGroup && radioGroup.value) === value : isInternallyControlledChecked);
   const nameValue = name ?? (radioGroup && radioGroup.name);
 
   return (
-    <span css={wrapperStyles(disabled)} data-testid={generateTestDataId('radio-input', dataTestId)}>
+    <span
+      css={wrapperStyles(isDisabled)}
+      data-testid={generateTestDataId('radio-input', dataTestId)}
+    >
       <input
         css={inputStyles}
         onFocus={handleFocus}
@@ -107,26 +111,28 @@ const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
         onChange={handleChange}
         name={nameValue}
         value={value}
-        disabled={disabled}
+        disabled={isDisabled}
         id={id}
-        required={required}
-        checked={checkedValue}
+        required={isRequired}
+        checked={isCheckedValue}
         ref={ref}
       />
-      <span css={customRadioWrapperStyles(focused, disabled)(theme)}>
+      <span css={customRadioWrapperStyles(isFocused, isDisabled)(theme)}>
         <span
           css={customRadioStyles({
-            checked: checkedValue,
-            disabled,
-            filled,
+            isChecked: isCheckedValue,
+            isDisabled,
+            isFilled,
           })(theme)}
         />
-        <span css={customRadioInnerHover(focused, disabled)(theme)} />
+        <span css={customRadioInnerHover(isFocused, isDisabled)(theme)} />
       </span>
     </span>
   );
-});
+};
 
 Radio.displayName = 'Radio';
 
-export default Radio;
+export default React.forwardRef<HTMLInputElement, Props>((props, ref) => (
+  <Radio {...props} ref={ref} />
+));

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -13,67 +13,68 @@ import { inputStyle } from 'components/TextInputBase/TextInputBase.style';
 export type Props = {
   /** A callback that's called when the user clicks the 'clear' icon */
   onClear: () => void;
-};
+  ref: React.ForwardedRef<HTMLInputElement>;
+} & TextFieldProps &
+  TestProps;
 
-const SearchField = React.forwardRef<HTMLInputElement, Props & TextFieldProps & TestProps>(
-  (props, ref) => {
-    const theme = useTheme();
+const SearchField: React.FC<Props> = ({
+  placeholder = 'Search',
+  isDisabled,
+  size = DEFAULT_SIZE,
+  isDark = false,
+  onClear,
+  dataTestId,
+  value = '',
+  ref,
+  ...rest
+}) => {
+  const theme = useTheme();
 
-    const {
-      placeholder = 'Search',
-      disabled,
-      size = DEFAULT_SIZE,
-      dark = false,
-      onClear,
-      dataTestId,
-      value = '',
-      ...rest
-    } = props;
+  const isClearVisible = (value as string).length > 0;
 
-    const shouldShowClear = (value as string).length > 0;
+  return (
+    <React.Fragment>
+      <TextInputBase
+        dataTestId={dataTestId}
+        isDisabled={isDisabled}
+        size={size}
+        styleType={'outlined'}
+        leftIcon={'search'}
+        rightIcon={'close'}
+        sx={{ wrapper: { borderRadius: rem(100) } }}
+      >
+        <IconWrapper iconPosition={'left'}>
+          <Icon name={'search'} size={20} color={theme.utils.getColor('lightGrey', 650)} />
+        </IconWrapper>
 
-    return (
-      <React.Fragment>
-        <TextInputBase
-          dataTestId={dataTestId}
-          disabled={disabled}
-          size={size}
-          styleType={'outlined'}
-          leftIcon={'search'}
-          rightIcon={'close'}
-          sx={{ wrapper: { borderRadius: rem(100) } }}
-        >
-          <IconWrapper iconPosition={'left'}>
-            <Icon name={'search'} size={20} color={theme.utils.getColor('lightGrey', 650)} />
+        <div css={{ width: '100%' }}>
+          <input
+            css={inputStyle({ size, isDark, placeholder })}
+            placeholder={placeholder}
+            disabled={isDisabled}
+            value={value}
+            ref={ref}
+            {...rest}
+          />
+        </div>
+
+        {isClearVisible && !isDisabled && (
+          <IconWrapper
+            onClick={() => {
+              onClear();
+            }}
+            iconPosition={'right'}
+          >
+            <Icon name={'close'} size={20} color={theme.utils.getColor('lightGrey', 650)} />
           </IconWrapper>
-
-          <div css={{ width: '100%' }}>
-            <input
-              css={inputStyle({ size, dark, placeholder })}
-              placeholder={placeholder}
-              disabled={disabled}
-              value={value}
-              ref={ref}
-              {...rest}
-            />
-          </div>
-
-          {shouldShowClear && !disabled && (
-            <IconWrapper
-              onClick={() => {
-                onClear();
-              }}
-              iconPosition={'right'}
-            >
-              <Icon name={'close'} size={20} color={theme.utils.getColor('lightGrey', 650)} />
-            </IconWrapper>
-          )}
-        </TextInputBase>
-      </React.Fragment>
-    );
-  }
-);
+        )}
+      </TextInputBase>
+    </React.Fragment>
+  );
+};
 
 SearchField.displayName = 'SearchField';
 
-export default SearchField;
+export default React.forwardRef<HTMLInputElement, Props>((props, ref) => (
+  <SearchField {...props} ref={ref} />
+));

--- a/src/components/Table/TableRowContext.ts
+++ b/src/components/Table/TableRowContext.ts
@@ -13,7 +13,7 @@ export type TableRowContextProps<T extends { [key: string]: unknown }> = {
   hasFixedHeader: boolean;
   tChange: () => void;
   type: TableType;
-  bordered: boolean;
+  isBordered: boolean;
   actionWidth?: number;
 };
 
@@ -33,5 +33,5 @@ export const TableRowContext = React.createContext<
   hasFixedHeader: false,
   tChange: () => {},
   type: 'normal',
-  bordered: false,
+  isBordered: false,
 }) as React.Context<TableRowContextProps<{ [key: string]: unknown }>>;

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.style.ts
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.style.ts
@@ -5,10 +5,10 @@ import { Theme } from 'theme';
 import { getBorderColor } from 'components/Table/utils';
 
 export const borderedRowStyle =
-  ({ bordered, isCustomCell }: { bordered: boolean; isCustomCell?: boolean }) =>
+  ({ isBordered, isCustomCell }: { isBordered: boolean; isCustomCell?: boolean }) =>
   (theme: Theme): SerializedStyles =>
     css({
-      borderBottom: bordered ? `${rem(1)} solid ${getBorderColor(theme)}` : 'none',
+      borderBottom: isBordered ? `${rem(1)} solid ${getBorderColor(theme)}` : 'none',
       'td:first-of-type': {
         paddingLeft: theme.spacing.md,
       },

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -125,9 +125,9 @@ const RenderRowOrNestedRow = <T extends { [key: string]: unknown }>({
 }) => {
   const { isRowSelected, columnCount, hasFixedHeader } = React.useContext(TableRowContext);
   const { expanded } = row;
-  const [checked, toggleChecked] = useToggle(false);
+  const [isChecked, toggleIsChecked] = useToggle(false);
   const ExpandedComponent = expanded
-    ? expanded({ row, selected: isRowSelected, expanded: checked })
+    ? expanded({ row, selected: isRowSelected, expanded: isChecked })
     : null;
 
   return (
@@ -146,11 +146,11 @@ const RenderRowOrNestedRow = <T extends { [key: string]: unknown }>({
               <table css={tableStyle()()}>
                 <tbody>
                   <RenderRowWithCells
-                    {...{ checked, toggleChecked }}
+                    {...{ isChecked, toggleIsChecked }}
                     dataTestIdPrefix={dataTestIdPrefix}
                     rowIndex={rowIndex}
                   />
-                  {checked && (
+                  {isChecked && (
                     <TableRow isNested>
                       <TableCell
                         colSpan={columnCount}

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -33,7 +33,7 @@ const RenderRowWithCells = React.memo(
       row,
       type,
       isRowSelected,
-      bordered,
+      isBordered,
       actionWidth,
     } = React.useContext(TableRowContext);
     const { expanded } = row;
@@ -45,7 +45,7 @@ const RenderRowWithCells = React.memo(
         isSelected={isRowSelected}
         onClick={isExpandedExists ? toggleChecked : undefined}
         css={borderedRowStyle({
-          bordered,
+          isBordered,
           isCustomCell: isExpandedExists || isComponentFunctionType(lastItem.content),
         })}
       >

--- a/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
+++ b/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
@@ -56,7 +56,7 @@ const TableRowWrapper = <T extends Record<string, unknown>>(props: TableRowWrapp
         type,
         columnCount,
         isRowSelected,
-        bordered: !isExpanded,
+        isBordered: !isExpanded,
         actionWidth,
       }}
     >

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -14,11 +14,11 @@ export type Props = {
   /** The placeholder of the input that will be used. This is shown if no label exists */
   placeholder?: string;
   /** If the text field value is required */
-  required?: boolean;
+  isRequired?: boolean;
   /** If the text field is disabled */
-  disabled?: boolean;
+  isDisabled?: boolean;
   /** If the text area can be resized */
-  resizeEnabled?: boolean;
+  isResizeEnabled?: boolean;
   /** Style of input field */
   styleType?: formFieldStyles;
   /** Error message */
@@ -35,20 +35,22 @@ export type Props = {
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   /** Callback fired when the `input` value typed is changed */
   onInput?: React.EventHandler<any>;
-};
+  ref: React.ForwardedRef<HTMLTextAreaElement>;
+} & TestProps;
 
-const TextArea = React.forwardRef<HTMLTextAreaElement, Props & TestProps>((props, ref) => {
+const TextArea: React.FC<Props> = (props) => {
   const {
     id = undefined,
     placeholder = '',
-    required = false,
-    disabled,
-    resizeEnabled = true,
+    isRequired = false,
+    isDisabled,
+    isResizeEnabled = true,
+    ref,
     ...rest
   } = props;
 
   const theme = useTheme();
-  const sx = sxProp(!disabled && resizeEnabled, theme);
+  const sx = sxProp(!isDisabled && isResizeEnabled, theme);
 
   return (
     <React.Fragment>
@@ -60,9 +62,9 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, Props & TestProps>((props
               sx,
             })}
             placeholder={placeholder}
-            required={required}
+            required={isRequired}
             id={id}
-            disabled={disabled}
+            disabled={isDisabled}
             {...omit(rest, ['styleType', 'hintMsg'])}
             ref={ref}
           />
@@ -70,8 +72,10 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, Props & TestProps>((props
       </TextInputBase>
     </React.Fragment>
   );
-});
+};
 
 TextArea.displayName = 'TextArea';
 
-export default TextArea;
+export default React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => (
+  <TextArea {...props} ref={ref} />
+));

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -80,12 +80,11 @@ const TextField = React.forwardRef<HTMLInputElement, Props & InputProps & TestPr
             />
             {label && (
               <Label
-                size={size}
                 htmlFor={id}
                 label={label}
-                required={required}
-                animateToTop={Boolean(rest.value)}
-                error={status === 'error'}
+                isRequired={required}
+                isAnimated={Boolean(rest.value)}
+                hasError={status === 'error'}
               />
             )}
           </div>

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -11,6 +11,8 @@ import { AcceptedIconNames } from 'components/Icon/types';
 import TextInputBase, { Props as TextInputWrapperProps } from 'components/TextInputBase';
 import { inputStyle } from 'components/TextInputBase/TextInputBase.style';
 
+type InputProps = Partial<Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>>;
+
 export type Props = {
   /** The id of the text field that will be used as for in label too */
   id?: string;
@@ -24,88 +26,92 @@ export type Props = {
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   /** Callback fired when the `input` value typed is changed */
   onInput?: React.EventHandler<any>;
-} & TextInputWrapperProps;
+  /** Boolean to make the input readonly. Default to false. */
+  isReadOnly?: boolean;
+  ref: React.ForwardedRef<HTMLInputElement>;
+} & TextInputWrapperProps &
+  InputProps &
+  TestProps;
 
-type InputProps = Partial<Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>>;
+const TextField: React.FC<Props> = (props) => {
+  const {
+    id = undefined,
+    rightIcon = null,
+    leftIcon = null,
+    label,
+    placeholder = '',
+    isRequired = false,
+    isDisabled,
+    isLocked = false,
+    size = DEFAULT_SIZE,
+    isDark = false,
+    isLean,
+    hintMsg: __hintMsg,
+    styleType: __styleType,
+    isReadOnly = false,
+    status,
+    ref,
+    ...rest
+  } = props;
+  const theme = useTheme();
 
-const TextField = React.forwardRef<HTMLInputElement, Props & InputProps & TestProps>(
-  (props, ref) => {
-    const {
-      id = undefined,
-      rightIcon = null,
-      leftIcon = null,
-      label,
-      placeholder = '',
-      required = false,
-      disabled,
-      locked = false,
-      size = DEFAULT_SIZE,
-      dark = false,
-      lean,
-      hintMsg: __hintMsg,
-      styleType: __styleType,
-      readOnly,
-      status,
-      ...rest
-    } = props;
-    const theme = useTheme();
+  const getIcon = (icon: AcceptedIconNames | JSX.Element | null) =>
+    icon ? (
+      typeof icon === 'string' ? (
+        <Icon
+          name={icon as AcceptedIconNames}
+          size={24}
+          color={theme.utils.getColor('lightGrey', 650)}
+        />
+      ) : (
+        icon
+      )
+    ) : null;
 
-    const getIcon = (icon: AcceptedIconNames | JSX.Element | null) =>
-      icon ? (
-        typeof icon === 'string' ? (
-          <Icon
-            name={icon as AcceptedIconNames}
-            size={24}
-            color={theme.utils.getColor('lightGrey', 650)}
+  return (
+    <React.Fragment>
+      <TextInputBase {...props}>
+        {leftIcon && <IconWrapper iconPosition={'left'}>{getIcon(leftIcon)}</IconWrapper>}
+        <div css={{ width: '100% ' }}>
+          <input
+            readOnly={isReadOnly}
+            css={inputStyle({ label, placeholder, size, isDark, isLean })}
+            placeholder={!label && placeholder ? `${placeholder} ${isRequired ? '*' : ''}` : label}
+            required={isRequired}
+            id={id}
+            disabled={isDisabled || isLocked}
+            {...omit(rest, 'dataTestId')}
+            ref={ref}
           />
-        ) : (
-          icon
-        )
-      ) : null;
-
-    return (
-      <React.Fragment>
-        <TextInputBase {...props}>
-          {leftIcon && <IconWrapper iconPosition={'left'}>{getIcon(leftIcon)}</IconWrapper>}
-          <div css={{ width: '100% ' }}>
-            <input
-              readOnly={readOnly}
-              css={inputStyle({ label, placeholder, size, dark, lean })}
-              placeholder={!label && placeholder ? `${placeholder} ${required ? '*' : ''}` : label}
-              required={required}
-              id={id}
-              disabled={disabled || locked}
-              {...omit(rest, 'dataTestId')}
-              ref={ref}
+          {label && (
+            <Label
+              htmlFor={id}
+              label={label}
+              isRequired={isRequired}
+              isAnimated={Boolean(rest.value)}
+              hasError={status === 'error'}
             />
-            {label && (
-              <Label
-                htmlFor={id}
-                label={label}
-                isRequired={required}
-                isAnimated={Boolean(rest.value)}
-                hasError={status === 'error'}
-              />
-            )}
-          </div>
-          {rightIcon && !locked && (
-            <IconWrapper iconPosition={'right'}>{getIcon(rightIcon)}</IconWrapper>
           )}
-          {locked && (
-            <IconWrapper iconPosition={'right'}>
-              <Icon
-                name="lock"
-                size={size === 'md' ? 20 : 16}
-                color={theme.utils.getColor('lightGrey', 650)}
-              />
-            </IconWrapper>
-          )}
-        </TextInputBase>
-      </React.Fragment>
-    );
-  }
-);
+        </div>
+        {rightIcon && !isLocked && (
+          <IconWrapper iconPosition={'right'}>{getIcon(rightIcon)}</IconWrapper>
+        )}
+        {isLocked && (
+          <IconWrapper iconPosition={'right'}>
+            <Icon
+              name="lock"
+              size={size === 'md' ? 20 : 16}
+              color={theme.utils.getColor('lightGrey', 650)}
+            />
+          </IconWrapper>
+        )}
+      </TextInputBase>
+    </React.Fragment>
+  );
+};
 
 TextField.displayName = 'TextField';
 
-export default TextField;
+export default React.forwardRef<HTMLInputElement, Props>((props, ref) => (
+  <TextField {...props} ref={ref} />
+));

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -9,14 +9,18 @@ import { textInputConfig } from './config';
 import { Props } from './TextInputBase';
 import { LABEL_TRANSFORM_LEFT_SPACING } from 'components/Label/Label.style';
 
-const wrapperStyleSwitch = (
-  theme: Theme,
-  colorScheme: ColorScheme = 'light',
-  lean?: boolean,
-  error?: boolean,
-  disabled?: boolean
-) => {
-  if (lean) {
+const wrapperStyleSwitch = ({
+  theme,
+  colorScheme = 'light',
+  isLean,
+  hasError,
+  isDisabled,
+}: {
+  theme: Theme;
+  colorScheme: ColorScheme;
+  hasError?: boolean;
+} & Pick<Props, 'isLean' | 'isDisabled'>) => {
+  if (isLean) {
     return {
       backgroundColor: 'transparent',
     };
@@ -25,12 +29,14 @@ const wrapperStyleSwitch = (
 
   const backgroundColor =
     colorScheme === 'dark' ? theme.utils.getColor('darkGrey', 700) : theme.palette.white;
-  const borderColorName = !error ? borderConfig.color.pressed.name : borderConfig.color.error.name;
-  const borderColorShade = !error
+  const borderColorName = !hasError
+    ? borderConfig.color.pressed.name
+    : borderConfig.color.error.name;
+  const borderColorShade = !hasError
     ? borderConfig.color.pressed.shade
     : borderConfig.color.error.shade;
 
-  const events = disabled
+  const events = isDisabled
     ? {
         '&:focus-within': {
           boxShadow: `0 0 0 ${rem(1)} transparent`,
@@ -59,118 +65,128 @@ const wrapperStyleSwitch = (
  * this wrapper must remain simple and not mess with children properties as it will be used
  * in custom implementation needed eg: datepicker
  * */
-export const wrapperStyle = ({ disabled, locked, status, lean, dark, size, sx }: Props) => (
-  theme: Theme
-): SerializedStyles => {
-  const colorScheme = dark ? 'dark' : theme.colorScheme;
-  const error = status === 'error';
-  const textFieldSize = !lean ? getTextFieldSize(size) : getTextFieldSize();
-  const borderConfig = textInputConfig.types[colorScheme].outlined.border;
+export const wrapperStyle =
+  ({ isDisabled, isLocked, status, isLean, isDark, size, sx }: Props) =>
+  (theme: Theme): SerializedStyles => {
+    const colorScheme = isDark ? 'dark' : theme.colorScheme;
+    const hasError = status === 'error';
+    const textFieldSize = !isLean ? getTextFieldSize(size) : getTextFieldSize();
+    const borderConfig = textInputConfig.types[colorScheme].outlined.border;
 
-  return css({
-    display: 'flex',
-    alignItems: 'center',
-    position: 'relative',
-    transition: `background-color 0.25s, box-shadow 0.25s, border-color 0.25s`,
-    boxShadow: `0 0 0 ${rem(borderConfig.width)} ${
-      error
-        ? theme.utils.getColor(borderConfig.color.error.name, borderConfig.color.error.shade)
-        : theme.utils.getColor(borderConfig.color.default.name, borderConfig.color.default.shade)
-    }`,
-    borderRadius: theme.spacing.xsm,
-    userSelect: 'none',
-    opacity: disabled ? getDisabled().opacity : 1,
-    cursor: disabled || locked ? getDisabled().cursor : 'auto',
-    ...textFieldSize,
-    ...wrapperStyleSwitch(theme, colorScheme, lean, error, Boolean(disabled || locked)),
-    ...sx?.wrapper,
-  });
-};
-
-export const textFieldStyle = ({ lean, sx }: Props) => (theme: Theme): SerializedStyles => {
-  return css({
-    position: 'relative',
-    display: 'inline-flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    verticalAlign: 'top',
-    width: 'fill-available',
-    padding: !lean ? `0 ${theme.spacing.md}` : '',
-
-    '> div': {
+    return css({
+      display: 'flex',
+      alignItems: 'center',
       position: 'relative',
-    },
+      transition: `background-color 0.25s, box-shadow 0.25s, border-color 0.25s`,
+      boxShadow: `0 0 0 ${rem(borderConfig.width)} ${
+        hasError
+          ? theme.utils.getColor(borderConfig.color.error.name, borderConfig.color.error.shade)
+          : theme.utils.getColor(borderConfig.color.default.name, borderConfig.color.default.shade)
+      }`,
+      borderRadius: theme.spacing.xsm,
+      userSelect: 'none',
+      opacity: isDisabled ? getDisabled().opacity : 1,
+      cursor: isDisabled || isLocked ? getDisabled().cursor : 'auto',
+      ...textFieldSize,
+      ...wrapperStyleSwitch({
+        theme,
+        colorScheme,
+        isLean,
+        hasError,
+        isDisabled: Boolean(isDisabled || isLocked),
+      }),
+      ...sx?.wrapper,
+    });
+  };
 
-    ...sx?.textField,
-  });
-};
+export const textFieldStyle =
+  ({ isLean, sx }: Props) =>
+  (theme: Theme): SerializedStyles => {
+    return css({
+      position: 'relative',
+      display: 'inline-flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      verticalAlign: 'top',
+      width: 'fill-available',
+      padding: !isLean ? `0 ${theme.spacing.md}` : '',
 
-export const inputStyle = ({ label, placeholder, size = DEFAULT_SIZE, dark, sx }: Props) => (
-  theme: Theme
-): SerializedStyles =>
-  css({
-    background: 'transparent',
-    border: 'none',
-    color:
-      theme.colorScheme === 'dark' || dark
-        ? theme.palette.white
-        : theme.utils.getColor('darkGrey', 850),
-    display: 'block',
-    position: 'relative',
-    top: label ? rem(7) : undefined,
-    zIndex: 1,
-    fontSize: theme.typography.fontSizes[size === 'md' ? '15' : '13'],
-    textOverflow: 'ellipsis',
-    width: 0,
-    minWidth: '100%',
+      '> div': {
+        position: 'relative',
+      },
 
-    '& + label': {
+      ...sx?.textField,
+    });
+  };
+
+export const inputStyle =
+  ({ label, placeholder, size = DEFAULT_SIZE, isDark, sx }: Props) =>
+  (theme: Theme): SerializedStyles =>
+    css({
+      background: 'transparent',
+      border: 'none',
+      color:
+        theme.colorScheme === 'dark' || isDark
+          ? theme.palette.white
+          : theme.utils.getColor('darkGrey', 850),
+      display: 'block',
+      position: 'relative',
+      top: label ? rem(7) : undefined,
+      zIndex: 1,
       fontSize: theme.typography.fontSizes[size === 'md' ? '15' : '13'],
-    },
+      textOverflow: 'ellipsis',
+      width: 0,
+      minWidth: '100%',
 
-    '&:focus': {
-      outline: 'none',
-    },
-
-    '&::placeholder': {
-      color: !label && placeholder ? theme.utils.getColor('lightGrey', 650) : 'transparent',
-    },
-
-    '&:not(:focus):placeholder-shown': {
       '& + label': {
-        fontWeight: 'normal',
+        fontSize: theme.typography.fontSizes[size === 'md' ? '15' : '13'],
       },
-    },
 
-    '&:focus, &:not(:placeholder-shown)': {
-      '& + label': {
-        transform: `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -35%) scale(0.8)`,
-        fontWeight: theme.typography.weights.bold,
+      '&:focus': {
+        outline: 'none',
       },
-    },
 
-    '&:disabled': {
-      cursor: 'not-allowed',
-    },
-    ...sx?.input,
-  });
+      '&::placeholder': {
+        color: !label && placeholder ? theme.utils.getColor('lightGrey', 650) : 'transparent',
+      },
 
-export const errorMsgStyle = ({ status }: Props) => (theme: Theme): SerializedStyles =>
-  css({
-    display: 'flex',
-    color:
-      status === 'error'
-        ? theme.utils.getColor('error', 550, 'normal')
-        : theme.utils.getColor('lightGrey', 650),
-    fontSize: theme.typography.fontSizes['12'],
-    lineHeight: 1,
-    padding: `${rem(8)} 0 0`,
-    svg: {
-      padding: `0 ${rem(2)}`,
-    },
+      '&:not(:focus):placeholder-shown': {
+        '& + label': {
+          fontWeight: 'normal',
+        },
+      },
 
-    span: {
-      alignItems: 'stretch',
-      padding: `0 ${rem(2)}`,
-    },
-  });
+      '&:focus, &:not(:placeholder-shown)': {
+        '& + label': {
+          transform: `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -35%) scale(0.8)`,
+          fontWeight: theme.typography.weights.bold,
+        },
+      },
+
+      '&:disabled': {
+        cursor: 'not-allowed',
+      },
+      ...sx?.input,
+    });
+
+export const errorMsgStyle =
+  ({ status }: Props) =>
+  (theme: Theme): SerializedStyles =>
+    css({
+      display: 'flex',
+      color:
+        status === 'error'
+          ? theme.utils.getColor('error', 550, 'normal')
+          : theme.utils.getColor('lightGrey', 650),
+      fontSize: theme.typography.fontSizes['12'],
+      lineHeight: 1,
+      padding: `${rem(8)} 0 0`,
+      svg: {
+        padding: `0 ${rem(2)}`,
+      },
+
+      span: {
+        alignItems: 'stretch',
+        padding: `0 ${rem(2)}`,
+      },
+    });

--- a/src/components/TextInputBase/TextInputBase.tsx
+++ b/src/components/TextInputBase/TextInputBase.tsx
@@ -21,19 +21,19 @@ export type Props = {
   /** An optional icon to show to the right */
   rightIcon?: AcceptedIconNames | JSX.Element | null;
   /** If the text field value is required */
-  required?: boolean;
+  isRequired?: boolean;
   /** If the text field is disabled */
-  disabled?: boolean;
+  isDisabled?: boolean;
   /** If the text field is locked. Locked state is unique to this and the system */
-  locked?: boolean;
+  isLocked?: boolean;
   /** dark mode of the text field */
-  dark?: boolean;
+  isDark?: boolean;
   /** Error message */
   hintMsg?: React.ReactNode | string;
   /** value of the input */
   value?: string | number;
   /** if the input will be without default style for use inside the library */
-  lean?: boolean;
+  isLean?: boolean;
   /** Style of input field */
   styleType?: formFieldStyles;
   /** Sets the size of the textField */
@@ -46,20 +46,20 @@ export type Props = {
     textField?: CSSObject;
     input?: CSSObject;
   };
-};
+} & TestProps;
 
 /** This Component is a wrapper for all primitives that hold text like Select, TextArea, TextInput. Here we keep the
  * logic of all the hover, focus status etc and the styling of these centralized **/
-const TextInputBase: FC<Props & TestProps> = ({
-  lean = false,
-  disabled,
+const TextInputBase: FC<Props> = ({
+  isLean = false,
+  isDisabled,
   hintMsg,
   styleType = 'filled',
   dataTestId,
   status = 'normal',
-  locked = false,
+  isLocked = false,
   size = DEFAULT_SIZE,
-  dark = false,
+  isDark = false,
   children,
   sx,
 }) => {
@@ -80,17 +80,17 @@ const TextInputBase: FC<Props & TestProps> = ({
       <div
         data-testid={dataTestId}
         css={wrapperStyle({
-          dark,
-          locked,
-          disabled,
+          isDark,
+          isLocked,
+          isDisabled,
           status,
-          lean,
+          isLean,
           styleType,
           size,
           sx,
         })}
       >
-        <div css={textFieldStyle({ lean, sx })}>{children}</div>
+        <div css={textFieldStyle({ isLean, sx })}>{children}</div>
       </div>
       {hintMsg && status !== 'normal' && hintMessageToShow}
     </React.Fragment>

--- a/src/components/utils/PositionInScreen/PositionInScreen.tsx
+++ b/src/components/utils/PositionInScreen/PositionInScreen.tsx
@@ -25,9 +25,9 @@ const usePositionInScreen = (
       ? itemRef?.current?.children[0]?.getBoundingClientRect()
       : { width: 0, height: 0 };
 
-    const itemYOutOfScreenHeight = itemY + parrentOffsetHeight + height > window.innerHeight;
+    const isItemYOutOfScreenHeight = itemY + parrentOffsetHeight + height > window.innerHeight;
 
-    if (itemYOutOfScreenHeight) {
+    if (isItemYOutOfScreenHeight) {
       itemY -= height;
       if (itemY < 0) {
         itemY = 0;
@@ -36,8 +36,8 @@ const usePositionInScreen = (
       itemY += parrentOffsetHeight;
     }
 
-    const itemXOutOfScreenWidth = itemX + width > window.innerWidth;
-    if (itemXOutOfScreenWidth) {
+    const isItemXOutOfScreenWidth = itemX + width > window.innerWidth;
+    if (isItemXOutOfScreenWidth) {
       itemX = window.innerWidth - width;
     }
 

--- a/src/hooks/useCheck.ts
+++ b/src/hooks/useCheck.ts
@@ -3,10 +3,10 @@ import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 export type OnCheckHandler = (val: boolean, e?: ChangeEvent) => void;
 
 export const useCheck = (isChecked: boolean, onCheck?: OnCheckHandler) => {
-  const [checked, setIsChecked] = useState(() => isChecked);
+  const [isCheckedState, setIsCheckedState] = useState(() => isChecked);
 
   useEffect(() => {
-    setIsChecked(isChecked);
+    setIsCheckedState(isChecked);
   }, [isChecked]);
 
   const handleCheck = useCallback(
@@ -15,10 +15,10 @@ export const useCheck = (isChecked: boolean, onCheck?: OnCheckHandler) => {
         onCheck(checkedCheckbox, e);
       }
 
-      setIsChecked(checkedCheckbox);
+      setIsCheckedState(checkedCheckbox);
     },
-    [onCheck, setIsChecked]
+    [onCheck, setIsCheckedState]
   );
 
-  return { checked, handleCheck };
+  return { isCheckedState, handleCheck };
 };

--- a/src/hooks/useLoading.ts
+++ b/src/hooks/useLoading.ts
@@ -6,13 +6,13 @@ export type ClickHandler =
   | undefined;
 
 export const useLoading = (clickHandler: ClickHandler, defaultState = false) => {
-  const [loading, setLoading] = useState(defaultState);
+  const [isLoading, setIsLoading] = useState(defaultState);
 
   const updateLoadingState = useCallback(
-    (isLoading: boolean) => {
-      setLoading(isLoading);
+    (isLoadingProp: boolean) => {
+      setIsLoading(isLoadingProp);
     },
-    [setLoading]
+    [setIsLoading]
   );
 
   const handleAsyncOperation = useCallback(
@@ -24,5 +24,5 @@ export const useLoading = (clickHandler: ClickHandler, defaultState = false) => 
     [updateLoadingState, clickHandler]
   );
 
-  return { loading, handleAsyncOperation };
+  return { isLoading, handleAsyncOperation };
 };

--- a/src/hooks/useLocationToGetCurrentMenuItem.ts
+++ b/src/hooks/useLocationToGetCurrentMenuItem.ts
@@ -13,11 +13,11 @@ const useLocationToGetCurrentMenuItem = (
   // we need to show an indication on the currently selected option
   // we get that information from the current URL and then comparing it with the urls of each menuItem
   useLayoutEffect(() => {
-    menuItems.forEach(menuItem => {
-      const menuItemUrls = menuItem.options.map(subMenuItem => subMenuItem.url);
-      const urlFound =
+    menuItems.forEach((menuItem) => {
+      const menuItemUrls = menuItem.options.map((subMenuItem) => subMenuItem.url);
+      const isUrlFound =
         menuItemUrls.includes(location.pathname) || menuItem.url === location.pathname;
-      if (urlFound) {
+      if (isUrlFound) {
         setCurrentMenuItem(menuItem.url);
         setOpenMenuItems([menuItem.url]); // expand the current menu item
       }

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 const useToggle = (initialState = false): [boolean, () => void] => {
-  const [state, setState] = React.useState(initialState);
-  const toggle = React.useCallback(() => setState(state => !state), []);
+  const [isToggled, setIsToggled] = React.useState(initialState);
+  const toggle = React.useCallback(() => setIsToggled((oldState) => !oldState), []);
 
-  return [state, toggle];
+  return [isToggled, toggle];
 };
 
 export default useToggle;

--- a/src/theme/states/utils.ts
+++ b/src/theme/states/utils.ts
@@ -12,10 +12,11 @@ export const getShadeWithStep = ({
   step = 50,
   colorScheme,
 }: Props): typeof colorShades[number] => {
-  const calculation = colorScheme === 'light' ? shade + step > MAX_SHADE : shade - step > MIN_SHADE;
+  const isOutOfBoundsForColorScheme =
+    colorScheme === 'light' ? shade + step > MAX_SHADE : shade - step > MIN_SHADE;
   let calculatedShade = shade;
 
-  if (calculation) {
+  if (isOutOfBoundsForColorScheme) {
     calculatedShade -= step;
   } else {
     calculatedShade += step;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -12,7 +12,10 @@ export type EventProps = {
 
 //@TODO fix props to not overwrite button props from base
 export type ButtonProps = Partial<
-  Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'css' | 'onBlur' | 'onClick' | 'type'>
+  Omit<
+    ButtonHTMLAttributes<HTMLButtonElement>,
+    'size' | 'css' | 'onBlur' | 'onClick' | 'type' | 'disabled'
+  >
 >;
 
 //@TODO fix props to not overwrite div props from base

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,5 +41,5 @@
     "**/*.test.tsx",
     "__mocks__",
     "./jest.config.js"
-  ]
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4381,14 +4381,14 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.30.5":
-  version "5.30.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.30.5.tgz#e9a0afd6eb3b1d663db91cf1e7bc7584d394503d"
-  integrity sha512-lftkqRoBvc28VFXEoRgyZuztyVUQ04JvUnATSPtIRFAccbXTWL6DEtXGYMcbg998kXw1NLUJm7rTQ9eUt+q6Ig==
+"@typescript-eslint/eslint-plugin@^5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.31.0.tgz#cae1967b1e569e6171bbc6bec2afa4e0c8efccfe"
+  integrity sha512-VKW4JPHzG5yhYQrQ1AzXgVgX8ZAJEvCz0QI6mLRX4tf7rnFfh5D8SKm0Pq6w5PyNfAWJk6sv313+nEt3ohWMBQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.30.5"
-    "@typescript-eslint/type-utils" "5.30.5"
-    "@typescript-eslint/utils" "5.30.5"
+    "@typescript-eslint/scope-manager" "5.31.0"
+    "@typescript-eslint/type-utils" "5.31.0"
+    "@typescript-eslint/utils" "5.31.0"
     debug "^4.3.4"
     functional-red-black-tree "^1.0.1"
     ignore "^5.2.0"
@@ -4414,12 +4414,20 @@
     "@typescript-eslint/types" "5.30.5"
     "@typescript-eslint/visitor-keys" "5.30.5"
 
-"@typescript-eslint/type-utils@5.30.5":
-  version "5.30.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.30.5.tgz#7a9656f360b4b1daea635c4621dab053d08bf8a9"
-  integrity sha512-k9+ejlv1GgwN1nN7XjVtyCgE0BTzhzT1YsQF0rv4Vfj2U9xnslBgMYYvcEYAFVdvhuEscELJsB7lDkN7WusErw==
+"@typescript-eslint/scope-manager@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.31.0.tgz#f47a794ba84d9b818ab7f8f44fff55a61016c606"
+  integrity sha512-8jfEzBYDBG88rcXFxajdVavGxb5/XKXyvWgvD8Qix3EEJLCFIdVloJw+r9ww0wbyNLOTYyBsR+4ALNGdlalLLg==
   dependencies:
-    "@typescript-eslint/utils" "5.30.5"
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/visitor-keys" "5.31.0"
+
+"@typescript-eslint/type-utils@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.31.0.tgz#70a0b7201360b5adbddb0c36080495aa08f6f3d9"
+  integrity sha512-7ZYqFbvEvYXFn9ax02GsPcEOmuWNg+14HIf4q+oUuLnMbpJ6eHAivCg7tZMVwzrIuzX3QCeAOqKoyMZCv5xe+w==
+  dependencies:
+    "@typescript-eslint/utils" "5.31.0"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
@@ -4427,6 +4435,11 @@
   version "5.30.5"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.5.tgz#36a0c05a72af3623cdf9ee8b81ea743b7de75a98"
   integrity sha512-kZ80w/M2AvsbRvOr3PjaNh6qEW1LFqs2pLdo2s5R38B2HYXG8Z0PP48/4+j1QHJFL3ssHIbJ4odPRS8PlHrFfw==
+
+"@typescript-eslint/types@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.31.0.tgz#7aa389122b64b18e473c1672fb3b8310e5f07a9a"
+  integrity sha512-/f/rMaEseux+I4wmR6mfpM2wvtNZb1p9hAV77hWfuKc3pmaANp5dLAZSiE3/8oXTYTt3uV9KW5yZKJsMievp6g==
 
 "@typescript-eslint/typescript-estree@5.30.5":
   version "5.30.5"
@@ -4441,15 +4454,28 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.30.5":
-  version "5.30.5"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.5.tgz#3999cbd06baad31b9e60d084f20714d1b2776765"
-  integrity sha512-o4SSUH9IkuA7AYIfAvatldovurqTAHrfzPApOZvdUq01hHojZojCFXx06D/aFpKCgWbMPRdJBWAC3sWp3itwTA==
+"@typescript-eslint/typescript-estree@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.31.0.tgz#eb92970c9d6e3946690d50c346fb9b1d745ee882"
+  integrity sha512-3S625TMcARX71wBc2qubHaoUwMEn+l9TCsaIzYI/ET31Xm2c9YQ+zhGgpydjorwQO9pLfR/6peTzS/0G3J/hDw==
+  dependencies:
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/visitor-keys" "5.31.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.31.0.tgz#e146fa00dca948bfe547d665b2138a2dc1b79acd"
+  integrity sha512-kcVPdQS6VIpVTQ7QnGNKMFtdJdvnStkqS5LeALr4rcwx11G6OWb2HB17NMPnlRHvaZP38hL9iK8DdE9Fne7NYg==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.30.5"
-    "@typescript-eslint/types" "5.30.5"
-    "@typescript-eslint/typescript-estree" "5.30.5"
+    "@typescript-eslint/scope-manager" "5.31.0"
+    "@typescript-eslint/types" "5.31.0"
+    "@typescript-eslint/typescript-estree" "5.31.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -4459,6 +4485,14 @@
   integrity sha512-D+xtGo9HUMELzWIUqcQc0p2PO4NyvTrgIOK/VnSH083+8sq0tiLozNRKuLarwHYGRuA6TVBQSuuLwJUDWd3aaA==
   dependencies:
     "@typescript-eslint/types" "5.30.5"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.31.0":
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.31.0.tgz#b0eca264df01ce85dceb76aebff3784629258f54"
+  integrity sha512-ZK0jVxSjS4gnPirpVjXHz7mgdOsZUHzNYSfTw2yPa3agfbt9YfqaBiBZFSSxeBWnpWkzCxTfUpnzA3Vily/CSg==
+  dependencies:
+    "@typescript-eslint/types" "5.31.0"
     eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":


### PR DESCRIPTION
## Description

**FOR V5**

This PR is part of a chain of PRs to follow regarding props globalization.

ticket: https://orfium.atlassian.net/browse/NDS-338

Also added the rule `"@typescript-eslint/naming-convention"` with the following configuration:
```
 "@typescript-eslint/naming-convention": [
      "error",
      { "selector": "variable", "types": ["boolean"],
        "format": ["PascalCase"],// As per documentation, prefix is trimmed before checking for format , so we need pascal case for values like `isBoolean`  https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/naming-convention.md#format-options
        "prefix": ["is", "has"] }
    ],
```

First, it complies with the general coding convention we have in the chapter and it also helps identify the places where the eslint rule about props is not working (forwarded components for example )

## Test Plan

Everything will be updated on a PR later. It's too much to keep track right now.