### PR TITLE
[NDS-495] feat: change the first portion of components

### DIFF
--- a/src/components/Avatar/Avatar.style.ts
+++ b/src/components/Avatar/Avatar.style.ts
@@ -4,7 +4,7 @@ import { rem } from 'theme/utils';
 import { Theme } from '../../theme';
 import { flex } from '../../theme/functions';
 import { colorShades, flatColors } from '../../theme/palette';
-import { AvatarSizes } from './Avatar';
+import { AvatarSizes } from './Avatar.types';
 
 export const sizeBasedOnProp = (size: AvatarSizes): number => {
   switch (size) {
@@ -32,36 +32,39 @@ const fontSizeBasedOnProp = (theme: Theme, size: AvatarSizes) => {
   }
 };
 
-export const avatarStyle = ({
-  size,
-  fill,
-  fillShade,
-}: {
-  size: AvatarSizes;
-  fill: typeof flatColors[number];
-  fillShade: typeof colorShades[number];
-}) => (theme: Theme): SerializedStyles => css`
-  ${flex};
-  width: ${rem(sizeBasedOnProp(size))};
-  height: ${rem(sizeBasedOnProp(size))};
-  border-radius: 100%;
-  border: ${rem(1)} solid ${theme.utils.getColor('lightGrey', 100)};
-  box-sizing: border-box;
-  background: ${theme.utils.getColor(fill, fillShade)};
-  overflow: hidden;
-  position: relative;
-  font-size: ${fontSizeBasedOnProp(theme, size)};
-  font-weight: ${theme.typography.weights.medium};
-  align-items: center;
-  flex-shrink: 0;
-  line-height: 1;
-  user-select: none;
-  justify-content: center;
-  color: ${theme.utils.getAAColorFromSwatches(fill, fillShade)};
+export const avatarStyle =
+  ({
+    size,
+    fill,
+    fillShade,
+  }: {
+    size: AvatarSizes;
+    fill: typeof flatColors[number];
+    fillShade: typeof colorShades[number];
+  }) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      ${flex};
+      width: ${rem(sizeBasedOnProp(size))};
+      height: ${rem(sizeBasedOnProp(size))};
+      border-radius: 100%;
+      border: ${rem(1)} solid ${theme.utils.getColor('lightGrey', 100)};
+      box-sizing: border-box;
+      background: ${theme.utils.getColor(fill, fillShade)};
+      overflow: hidden;
+      position: relative;
+      font-size: ${fontSizeBasedOnProp(theme, size)};
+      font-weight: ${theme.typography.weights.medium};
+      align-items: center;
+      flex-shrink: 0;
+      line-height: 1;
+      user-select: none;
+      justify-content: center;
+      color: ${theme.utils.getAAColorFromSwatches(fill, fillShade)};
 
-  img {
-    border-radius: 100%;
-    width: 100%;
-    height: 100%;
-  }
-`;
+      img {
+        border-radius: 100%;
+        width: 100%;
+        height: 100%;
+      }
+    `;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -4,10 +4,10 @@ import { useTheme } from '../../index';
 import { calculateActualColorFromComponentProp } from '../../utils/themeFunctions';
 import Icon from '../Icon';
 import { avatarStyle } from './Avatar.style';
-import { Props, AvatarSizes } from './Avatar.types';
+import { AvatarProps, AvatarSizes } from './Avatar.types';
 import { iconSizeBasedOnAvatar } from './utils';
 
-const Avatar = React.forwardRef<HTMLDivElement, Props>(
+const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
   (
     { src = '', iconName = 'user', size = 'md', color = 'lightGrey-600', children, className },
     ref
@@ -41,6 +41,3 @@ const Avatar = React.forwardRef<HTMLDivElement, Props>(
 Avatar.displayName = 'Avatar';
 
 export default Avatar;
-
-//TODO: Remove on v5 and change import where necessary
-export { Props, AvatarSizes };

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -1,7 +1,7 @@
 import { DivProps } from '../../utils/common';
 import { AcceptedIconNames } from '../Icon/types';
 
-export type Props = {
+export type AvatarProps = {
   /** the src of the image to show **/
   src?: string;
   /** The icon name to pick from our library of icons

--- a/src/components/Avatar/AvatarStack/AvatarStack.style.ts
+++ b/src/components/Avatar/AvatarStack/AvatarStack.style.ts
@@ -2,28 +2,26 @@ import { css, SerializedStyles } from '@emotion/react';
 import { flex } from 'theme/functions';
 import { rem } from 'theme/utils';
 
-import { AvatarSizes } from '../Avatar';
 import { sizeBasedOnProp } from '../Avatar.style';
+import { AvatarSizes } from '../Avatar.types';
 
 const OVERLAP_FACTOR = 0.8;
 
-export const avatarStackStyle = ({ size }: { size: AvatarSizes }) => (): SerializedStyles =>
-  css`
-    ${flex};
+export const avatarStackStyle =
+  ({ size }: { size: AvatarSizes }) =>
+  (): SerializedStyles =>
+    css`
+      ${flex};
 
-    div:last-child {
-      width: ${rem(sizeBasedOnProp(size))};
-    }
-  `;
+      div:last-child {
+        width: ${rem(sizeBasedOnProp(size))};
+      }
+    `;
 
-export const avatarWrapperStyle = ({
-  zIndex,
-  size,
-}: {
-  zIndex: number;
-  size: AvatarSizes;
-}) => (): SerializedStyles =>
-  css`
-    z-index: ${zIndex};
-    width: ${rem(sizeBasedOnProp(size) * OVERLAP_FACTOR)};
-  `;
+export const avatarWrapperStyle =
+  ({ zIndex, size }: { zIndex: number; size: AvatarSizes }) =>
+  (): SerializedStyles =>
+    css`
+      z-index: ${zIndex};
+      width: ${rem(sizeBasedOnProp(size) * OVERLAP_FACTOR)};
+    `;

--- a/src/components/Avatar/AvatarStack/AvatarStack.tsx
+++ b/src/components/Avatar/AvatarStack/AvatarStack.tsx
@@ -5,10 +5,10 @@ import { TestProps } from 'utils/types';
 
 import Avatar from '../Avatar';
 import { avatarStackStyle, avatarWrapperStyle } from './AvatarStack.style';
-import { Props } from './AvatarStack.types';
+import { AvatarStackProps } from './AvatarStack.types';
 import { errors } from './utils';
 
-const AvatarStack = React.forwardRef<HTMLDivElement, Props & TestProps & DivProps>(
+const AvatarStack = React.forwardRef<HTMLDivElement, AvatarStackProps & TestProps & DivProps>(
   (
     {
       maxAvatars = 4,
@@ -19,7 +19,7 @@ const AvatarStack = React.forwardRef<HTMLDivElement, Props & TestProps & DivProp
     },
     ref
   ) => {
-    errorHandler<Props>(errors, { maxAvatars });
+    errorHandler<AvatarStackProps>(errors, { maxAvatars });
 
     const children = React.Children.toArray(childrenProp);
 
@@ -58,6 +58,3 @@ const AvatarStack = React.forwardRef<HTMLDivElement, Props & TestProps & DivProp
 AvatarStack.displayName = 'AvatarStack';
 
 export default AvatarStack;
-
-//TODO: Remove on v5 and change import where necessary
-export { Props };

--- a/src/components/Avatar/AvatarStack/AvatarStack.types.ts
+++ b/src/components/Avatar/AvatarStack/AvatarStack.types.ts
@@ -1,6 +1,6 @@
-import { AvatarSizes } from '../Avatar';
+import { AvatarSizes } from '../Avatar.types';
 
-export type Props = {
+export type AvatarStackProps = {
   /** the maximum number of avatars to be displayed **/
   maxAvatars?: number;
   /** The size of the extra avatar, if any **/

--- a/src/components/Avatar/AvatarStack/index.ts
+++ b/src/components/Avatar/AvatarStack/index.ts
@@ -1,1 +1,2 @@
 export { default } from './AvatarStack';
+export * from './AvatarStack';

--- a/src/components/Avatar/AvatarStack/utils.ts
+++ b/src/components/Avatar/AvatarStack/utils.ts
@@ -1,9 +1,9 @@
 import { PropsValidationError } from '../../../utils/errors';
-import { Props } from './AvatarStack.types';
+import { AvatarStackProps } from './AvatarStack.types';
 
 export const errors = [
   {
-    condition: ({ maxAvatars = 4 }: Props): boolean => Boolean(maxAvatars < 1),
+    condition: ({ maxAvatars = 4 }: AvatarStackProps): boolean => Boolean(maxAvatars < 1),
     error: new PropsValidationError('maxAvatars prop must be greater than 0'),
   },
 ];

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,1 +1,3 @@
 export { default } from './Avatar';
+export * from './Avatar';
+export * from './Avatar.types';

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -7,7 +7,7 @@ import { breadcrumbLinkStyles, breadcrumbStyles } from './Breadcrumb.style';
 import BreadcrumbItem from './BreadcrumbItem/BreadcrumbItem';
 import { BreadcrumbItemData } from './types';
 
-export type Props = {
+export type BreadcrumbProps = {
   /** Defines the data for constructing the related breadcrumb items */
   data?: BreadcrumbItemData[];
 };
@@ -15,7 +15,7 @@ export type Props = {
 const isLastItem = (dataItems: React.ReactNode[], itemIndex: number) =>
   itemIndex === dataItems.length - 1;
 
-const Breadcrumb: React.FC<Props> = ({ children, data = [] }) => {
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ children, data = [] }) => {
   const passDataToRouterLink = React.useCallback(
     (dataItem: BreadcrumbItemData, index: number) => {
       const { to, label } = dataItem;

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { breadcrumbItemStyles } from './BreadcrumbItem.style';
 import Separator from 'components/Breadcrumb/Separator/Separator';
 
-type Props = {
+export type BreadcrumbItemProps = {
   /** Defines the child element that will be rendered inside the list element */
   childComponent: React.ReactNode;
   /** Defines if the current item of the breadcrumb is the last one */
@@ -11,7 +11,7 @@ type Props = {
   /** Defines the label of the current level of breadcrumb */
 };
 
-const BreadcrumbItem: React.FC<Props> = ({ childComponent, isLastItem = false }) => {
+const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({ childComponent, isLastItem = false }) => {
   return (
     <li>
       <div css={breadcrumbItemStyles({ isActive: isLastItem })}>

--- a/src/components/Breadcrumb/Separator/Separator.tsx
+++ b/src/components/Breadcrumb/Separator/Separator.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import Icon from '../../Icon';
 import { separatorStyles } from './Separator.style';
 
-type Props = {
+export type SeparatorProps = {
   /** Defines if the current item of the breadcrumb is the last one */
   isLastItem?: boolean;
 };
 
-const Separator: React.FC<Props> = props => {
+const Separator: React.FC<SeparatorProps> = (props) => {
   const { isLastItem = false } = props;
   if (isLastItem) return null;
 

--- a/src/components/Breadcrumb/index.ts
+++ b/src/components/Breadcrumb/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Breadcrumb';
+export * from './Breadcrumb';

--- a/src/components/Card/Card.style.ts
+++ b/src/components/Card/Card.style.ts
@@ -2,10 +2,10 @@ import { css, SerializedStyles } from '@emotion/react';
 import { Elevation, Spacing } from 'index';
 
 import { Theme } from '../../theme';
-import { Props } from './Card';
+import { CardProps } from './Card';
 
 export const cardStyle =
-  ({ elevated, isTransparent, radius }: Props) =>
+  ({ elevated, isTransparent, radius }: CardProps) =>
   (theme: Theme): SerializedStyles =>
     css`
       ${elevated && cardElevation(theme, elevated, isTransparent, radius)};

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { cardStyle } from './Card.style';
 
-export type Props = {
+export type CardProps = {
   /** Elevation of Card */
   elevated?: keyof Elevation;
   /** Transparency of Card: if false the Card's background is white, otherwise it's transparent */
@@ -12,7 +12,7 @@ export type Props = {
   radius?: keyof Spacing;
 };
 
-const Card: React.FC<Props> = ({ elevated, isTransparent = false, radius, children }) => {
+const Card: React.FC<CardProps> = ({ elevated, isTransparent = false, radius, children }) => {
   return <div css={cardStyle({ elevated, isTransparent, radius })}>{children}</div>;
 };
 

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Card';
+export * from './Card';

--- a/src/components/Chip/Chip.style.ts
+++ b/src/components/Chip/Chip.style.ts
@@ -4,7 +4,7 @@ import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
 import { getDisabled, getFocus, getHover, getPressed } from '../../theme/states';
-import { Props } from './Chip.types';
+import { ChipProps } from './Chip.types';
 
 export const chipStyle =
   ({
@@ -13,7 +13,7 @@ export const chipStyle =
     isSelected,
     onClear,
     onClick,
-  }: Pick<Props, 'styleType' | 'fill' | 'isSelected' | 'onClear' | 'onClick'>) =>
+  }: Pick<ChipProps, 'styleType' | 'fill' | 'isSelected' | 'onClear' | 'onClick'>) =>
   (theme: Theme): SerializedStyles => {
     const isInteractive = styleType === 'interactive';
     const customFilled = styleType === 'read-only' || onClear || isSelected;
@@ -57,7 +57,7 @@ export const chipStyle =
       };
     }
 
-    
+
       :disabled {
         opacity: ${getDisabled().opacity};
         cursor: ${getDisabled().cursor};

--- a/src/components/Chip/Chip.types.ts
+++ b/src/components/Chip/Chip.types.ts
@@ -1,6 +1,6 @@
 import { ClickEvent } from '../../hooks/useLoading';
 import { flatColors } from '../../theme/palette';
-import { ButtonProps } from '../../utils/common';
+import { CommonButtonProps } from '../../utils/common';
 import { TestProps } from '../../utils/types';
 
 export const READ_ONLY = 'read-only' as const;
@@ -8,7 +8,7 @@ export const INTERACTIVE = 'interactive' as const;
 
 export const styleType = [READ_ONLY, INTERACTIVE] as const;
 
-export type Props = {
+export type ChipBaseProps = {
   /**
    * Determines whether the chip should be read-only or interactive.
    * @default read-only
@@ -32,4 +32,4 @@ export type Props = {
   isDisabled?: boolean;
 };
 
-export type ChipProps = Props & TestProps & ButtonProps;
+export type ChipProps = ChipBaseProps & TestProps & CommonButtonProps;

--- a/src/components/Chip/components/Badge/Badge.tsx
+++ b/src/components/Chip/components/Badge/Badge.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { generateTestDataId } from 'utils/helpers';
 import { TestId } from 'utils/types';
 
-import { Props } from '../../Chip.types';
+import { ChipProps } from '../../Chip.types';
 import { badgeStyle } from './Badge.style';
 
 type TestProps = {
   dataTestId?: TestId;
 };
 
-export type BadgeProps = Pick<Props, 'fill' | 'isSelected' | 'badgeNumber'> & TestProps;
+export type BadgeProps = Pick<ChipProps, 'fill' | 'isSelected' | 'badgeNumber'> & TestProps;
 
 const Badge: React.FC<BadgeProps> = ({ fill, isSelected, badgeNumber, dataTestId }) => {
   return (

--- a/src/components/Chip/components/Badge/index.ts
+++ b/src/components/Chip/components/Badge/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Badge';
+export * from './Badge';

--- a/src/components/Chip/index.ts
+++ b/src/components/Chip/index.ts
@@ -1,1 +1,3 @@
 export { default } from './Chip';
+export * from './Chip';
+export * from './Chip.types';

--- a/src/components/Chip/utils.tsx
+++ b/src/components/Chip/utils.tsx
@@ -1,23 +1,29 @@
 import { PropsValidationError } from '../../utils/errors';
 import { TestProps } from '../../utils/types';
-import { INTERACTIVE, Props, READ_ONLY, styleType } from './Chip.types';
+import { INTERACTIVE, ChipProps, READ_ONLY, styleType } from './Chip.types';
 
 export const defaultProps = {
   isDisabled: false,
   styleType: READ_ONLY as typeof styleType[number],
   dataTestId: '',
-} as Pick<Props & TestProps, 'isDisabled' | 'styleType' | 'dataTestId'>;
+} as Pick<ChipProps & TestProps, 'isDisabled' | 'styleType' | 'dataTestId'>;
 
 export const errors = [
   {
-    condition: ({ styleType, isSelected, isChecked, badgeNumber, isDisabled }: Props): boolean =>
+    condition: ({
+      styleType,
+      isSelected,
+      isChecked,
+      badgeNumber,
+      isDisabled,
+    }: ChipProps): boolean =>
       Boolean(styleType === READ_ONLY && (isSelected || isChecked || badgeNumber || isDisabled)),
     error: new PropsValidationError(
       'The properties isSelected, isChecked, badgeNumber and disabled are only for Interactive style type Chips.'
     ),
   },
   {
-    condition: ({ styleType, thumbnail }: Props): boolean =>
+    condition: ({ styleType, thumbnail }: ChipProps): boolean =>
       Boolean(styleType === INTERACTIVE && thumbnail),
     error: new PropsValidationError(
       'The property thumbnail is only for Read-Only style type Chips.'


### PR DESCRIPTION
## Description

This is part ONE of the goal, to fix all internal types so they can be easily accessible on the root of the library by an external user.

Based on the ticket, what you are expecting to see is:

- Change all default Props naming we use on each component to ComponentNameProps so we can export and import easily
- Export all types and exported functions by default from each component
- Make all types by default exportable