### PR TITLE
[NDS-495] feat: change the second portion of components

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -1,6 +1,6 @@
 import { Theme } from 'theme';
 
-import { Props } from './Button';
+import { ButtonProps } from './Button';
 
 export const buttonSpanStyle = () => () => {
   return {
@@ -19,7 +19,10 @@ export const childrenWrapperStyle =
     iconLeft,
     iconRight,
     hasChildren,
-  }: Omit<Props, 'block' | 'isIconButton' | 'buttonType' | 'dataTestId' | 'onClick' | 'ref'> & {
+  }: Omit<
+    ButtonProps,
+    'block' | 'isIconButton' | 'buttonType' | 'dataTestId' | 'onClick' | 'ref'
+  > & {
     hasChildren: boolean;
   }) =>
   (theme: Theme) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,16 +1,19 @@
 import { ClickHandler, useLoading } from 'hooks/useLoading';
 import React, { useRef } from 'react';
-import { ButtonProps } from 'utils/common';
+import { CommonButtonProps } from 'utils/common';
 import { TestProps } from 'utils/types';
 
-import ButtonBase, { Props as ButtonBaseProps } from '../ButtonBase/ButtonBase';
+import ButtonBase, { ButtonBaseProps } from '../ButtonBase/ButtonBase';
 import { buttonSpanStyle, childrenWrapperStyle, iconStyle } from './Button.style';
 import ButtonLoader from './ButtonLoader';
 
-type onClickProp = { onClick: ClickHandler };
-export type Props = Omit<ButtonBaseProps, 'onClick'> & TestProps & onClickProp & ButtonProps;
+export type onClickProp = { onClick: ClickHandler };
+export type ButtonProps = Omit<ButtonBaseProps, 'onClick'> &
+  TestProps &
+  onClickProp &
+  CommonButtonProps;
 
-const Button = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
   const {
     size = 'md',
     type = 'primary',

--- a/src/components/Button/ButtonLoader/ButtonLoader.tsx
+++ b/src/components/Button/ButtonLoader/ButtonLoader.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 
 import { useTypeColorToColorMatch } from '../../../hooks/useTypeColorToColorMatch';
 import { useTheme } from '../../../index';
-import { Props as ButtonBaseProps } from '../../ButtonBase/ButtonBase';
+import { ButtonBaseProps } from '../../ButtonBase/ButtonBase';
 import { centralizedLoader } from './ButtonLoader.style';
 import Loader from 'components/Loader';
 
-export type Props = {
+export type ButtonLoaderProps = {
   innerButtonWidth?: number;
 } & Pick<ButtonBaseProps, 'type' | 'color'>;
 
-const ButtonLoader: React.FC<Props> = ({ innerButtonWidth, type = 'primary', color = '' }) => {
+const ButtonLoader: React.FC<ButtonLoaderProps> = ({
+  innerButtonWidth,
+  type = 'primary',
+  color = '',
+}) => {
   const theme = useTheme();
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();
   const calculatedColor = calculateColorBetweenColorAndType(color, type);

--- a/src/components/Button/ButtonLoader/index.ts
+++ b/src/components/Button/ButtonLoader/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ButtonLoader';
+export * from './ButtonLoader';

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Button';
+export * from './Button';

--- a/src/components/ButtonBase/ButtonBase.style.ts
+++ b/src/components/ButtonBase/ButtonBase.style.ts
@@ -4,7 +4,7 @@ import { rem } from 'theme/utils';
 import { Theme } from '../../theme';
 import { getDisabled, getFocus, getHover, getPressed } from '../../theme/states';
 import { ColorShapeFromComponent } from '../../utils/themeFunctions';
-import { Props } from './ButtonBase';
+import { ButtonBaseProps } from './ButtonBase';
 import { buttonConfig, buttonSizes } from './config';
 import { calculateButtonColor, defineBackgroundColor } from './utils';
 
@@ -26,7 +26,7 @@ export const buttonBaseStyle =
     isTransparent,
     childrenCount,
     sx,
-  }: Omit<Props, 'buttonType' | 'ref'> & {
+  }: Omit<ButtonBaseProps, 'buttonType' | 'ref'> & {
     calculatedColor: ColorShapeFromComponent;
     childrenCount: number;
   }) =>

--- a/src/components/ButtonBase/ButtonBase.tsx
+++ b/src/components/ButtonBase/ButtonBase.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ClickEvent } from '../../hooks/useLoading';
 import { useTypeColorToColorMatch } from '../../hooks/useTypeColorToColorMatch';
-import { ButtonProps } from '../../utils/common';
+import { CommonButtonProps } from '../../utils/common';
 import { generateTestDataId } from '../../utils/helpers';
 import { AcceptedColorComponentTypes } from '../../utils/themeFunctions';
 import { TestProps } from '../../utils/types';
@@ -15,7 +15,7 @@ export type EventButtonProps = {
   onBlur?: () => void;
 };
 
-export type Props = {
+export type ButtonBaseProps = {
   /** Type indicating the type of the button */
   type?: AcceptedColorComponentTypes;
   /** the color of the button based on our colors eg. red-500 */
@@ -46,10 +46,10 @@ export type Props = {
   };
 } & TestProps &
   EventButtonProps &
-  ButtonProps;
+  CommonButtonProps;
 
 //@TODO fix props to not overwrite button props
-const ButtonBase = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
+const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>((props, ref) => {
   const {
     size = 'md',
     type = 'primary',

--- a/src/components/ButtonBase/index.ts
+++ b/src/components/ButtonBase/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ButtonBase';
+export * from './ButtonBase';

--- a/src/components/ButtonBase/utils.ts
+++ b/src/components/ButtonBase/utils.ts
@@ -3,7 +3,7 @@ import { Theme } from 'theme';
 import { mainTypes } from 'theme/palette';
 
 import { ColorShapeFromComponent, getColorFromType } from '../../utils/themeFunctions';
-import { Props } from './ButtonBase';
+import { ButtonBaseProps } from './ButtonBase';
 import { buttonConfig } from './config';
 
 /**
@@ -44,7 +44,7 @@ export const calculateButtonColor = ({
   backGroundColor,
   calculatedColor,
   theme,
-}: Pick<Props, 'type'> & {
+}: Pick<ButtonBaseProps, 'type'> & {
   calculatedColor: ColorShapeFromComponent;
   isBackgroundTransparent: boolean;
   backGroundColor: string;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -21,9 +21,9 @@ export type OwnProps = {
   variant?: typeof colorShades[number];
 };
 
-type Props = OwnProps & TestProps;
+export type IconProps = OwnProps & TestProps;
 
-const Icon = React.forwardRef<HTMLSpanElement, Props>(
+const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
   ({ variant, name, color = 'primary', size = 16, dataTestId, onClick = () => {} }, ref) => {
     const Icon = iconSelector[name];
 

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Icon';
-export *  from './Icon';
+export * from './Icon';
+export * from './types';

--- a/src/components/IconButton/IconButton.style.ts
+++ b/src/components/IconButton/IconButton.style.ts
@@ -1,7 +1,7 @@
-import { Props } from '../Button/Button';
+import { ButtonProps } from '../Button/Button';
 import { heightBasedOnSize } from '../ButtonBase/ButtonBase.style';
 
-export const sxProp = ({ size }: Pick<Props, 'size'>) => {
+export const sxProp = ({ size }: Pick<ButtonProps, 'size'>) => {
   return {
     container: {
       display: 'flex',

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -8,9 +8,9 @@ import { defineBackgroundColor } from '../Button/utils';
 import Icon from '../Icon';
 import { AcceptedIconNames } from '../Icon/types';
 import { sxProp } from './IconButton.style';
-import ButtonBase, { Props as ButtonBaseProps } from 'components/ButtonBase/ButtonBase';
+import ButtonBase, { ButtonBaseProps } from 'components/ButtonBase/ButtonBase';
 
-export type Props = Omit<ButtonBaseProps, 'isIconButton' | 'iconLeft' | 'iconRight'> & {
+export type IconButtonProps = Omit<ButtonBaseProps, 'isIconButton' | 'iconLeft' | 'iconRight'> & {
   /** Property indicating the size of the icon. Defaults to 16 */
   iconSize?: number;
   /** This property defines witch icon to use */
@@ -18,7 +18,7 @@ export type Props = Omit<ButtonBaseProps, 'isIconButton' | 'iconLeft' | 'iconRig
 } & TestProps &
   EventProps;
 
-const IconButton = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
   const { iconSize, color = '', type = 'primary', isFilled = true, name, isTransparent } = props;
   const theme = useTheme();
   const { calculateColorBetweenColorAndType } = useTypeColorToColorMatch();

--- a/src/components/IconButton/index.ts
+++ b/src/components/IconButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from './IconButton';
+export * from './IconButton';

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -6,17 +6,17 @@ import { rem } from '../../theme/utils';
 import { TestProps } from '../../utils/types';
 import Icon from '../Icon';
 import { IconWrapper } from '../TextField/components/commons';
-import { Props as TextFieldProps } from 'components/TextField/TextField';
+import { TextFieldProps } from 'components/TextField/TextField';
 import TextInputBase from 'components/TextInputBase';
 import { inputStyle } from 'components/TextInputBase/TextInputBase.style';
 
-export type Props = {
+export type SearchFieldProps = {
   /** A callback that's called when the user clicks the 'clear' icon */
   onClear: () => void;
 } & TextFieldProps &
   TestProps;
 
-const SearchField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+const SearchField = React.forwardRef<HTMLInputElement, SearchFieldProps>((props, ref) => {
   const {
     placeholder = 'Search',
     isDisabled,
@@ -58,26 +58,25 @@ const SearchField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           />
         </div>
 
-          {isClearVisible && !isDisabled && (
-            <IconWrapper
-              onClick={() => {
-                onClear();
-              }}
-              iconPosition={'right'}
-            >
-              <Icon
-                name={'close'}
-                size={20}
-                color={theme.utils.getColor('lightGrey', 650)}
-                dataTestId={'search-clear'}
-              />
-            </IconWrapper>
-          )}
-        </TextInputBase>
-      </React.Fragment>
-    );
-  }
-);
+        {isClearVisible && !isDisabled && (
+          <IconWrapper
+            onClick={() => {
+              onClear();
+            }}
+            iconPosition={'right'}
+          >
+            <Icon
+              name={'close'}
+              size={20}
+              color={theme.utils.getColor('lightGrey', 650)}
+              dataTestId={'search-clear'}
+            />
+          </IconWrapper>
+        )}
+      </TextInputBase>
+    </React.Fragment>
+  );
+});
 
 SearchField.displayName = 'SearchField';
 

--- a/src/components/SearchField/SearchFieldShowcase.tsx
+++ b/src/components/SearchField/SearchFieldShowcase.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 
 import Stack from '../storyUtils/Stack';
-import { Props as TextFieldProps } from '../TextField/TextField';
-import SearchField, { Props } from './SearchField';
+import { TextFieldProps } from '../TextField/TextField';
+import SearchField, { SearchFieldProps } from './SearchField';
 
 const SearchFieldShowcase = ({
   isDisabled,
   placeholder,
   initialValue,
-}: Partial<Props & TextFieldProps> & { initialValue?: string }) => {
+}: Partial<SearchFieldProps & TextFieldProps> & { initialValue?: string }) => {
   const [value, setValue] = useState(initialValue ?? '');
 
   return (

--- a/src/components/SearchField/index.ts
+++ b/src/components/SearchField/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SearchField';
+export * from './SearchField';

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -8,7 +8,7 @@ import TextInputBase from '../TextInputBase/TextInputBase';
 import { sxProp } from './TextArea.style';
 import { inputStyle as baseInputStyle } from 'components/TextInputBase/TextInputBase.style';
 
-export type Props = {
+export type TextAreaProps = {
   /** The id of the text field that will be used as for in label too */
   id?: string;
   /** The placeholder of the input that will be used. This is shown if no label exists */
@@ -37,7 +37,7 @@ export type Props = {
   onInput?: React.EventHandler<any>;
 } & TestProps;
 
-const TextArea = React.forwardRef<HTMLTextAreaElement, Props>((props, ref) => {
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => {
   const {
     id = undefined,
     placeholder = '',

--- a/src/components/TextArea/index.ts
+++ b/src/components/TextArea/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TextArea';
+export * from './TextArea';

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -8,14 +8,14 @@ import Icon from '../Icon';
 import Label from '../Label';
 import { IconWrapper } from './components/commons';
 import { AcceptedIconNames } from 'components/Icon/types';
-import TextInputBase, { Props as TextInputWrapperProps } from 'components/TextInputBase';
+import TextInputBase, { TextInputBaseProps } from 'components/TextInputBase';
 import { inputStyle } from 'components/TextInputBase/TextInputBase.style';
 
 type InputProps = Partial<
   Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly' | 'disabled'>
 >;
 
-export type Props = {
+export type TextFieldProps = {
   /** The id of the text field that will be used as for in label too */
   id?: string;
   /** Callback fired when the `input` is blurred. */
@@ -33,7 +33,7 @@ export type Props = {
   /** @deprecated This is a compatibility prop that will be removed in the next version, along with the min-width value
    * of the TextField. It will be replaced by a fullWidth prop. */
   hasMinWidthCompat?: boolean;
-} & TextInputWrapperProps &
+} & TextInputBaseProps &
   InputProps &
   TestProps;
 
@@ -42,7 +42,7 @@ console.warn(
     'hasMinWidthCompat prop has been added to temporarily disable min-width when necessary'
 );
 
-const TextField = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
   const {
     id = undefined,
     rightIcon = null,

--- a/src/components/TextField/index.ts
+++ b/src/components/TextField/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TextField';
+export * from './TextField';

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -6,7 +6,7 @@ import { DEFAULT_SIZE, getTextFieldSize } from 'utils/size-utils';
 import { getDisabled, getHover, getPressed } from '../../theme/states';
 import { ColorScheme } from '../../theme/types';
 import { textInputConfig } from './config';
-import { Props } from './TextInputBase';
+import { TextInputBaseProps } from './TextInputBase';
 import { LABEL_TRANSFORM_LEFT_SPACING } from 'components/Label/Label.style';
 
 const wrapperStyleSwitch = ({
@@ -19,7 +19,7 @@ const wrapperStyleSwitch = ({
   theme: Theme;
   colorScheme: ColorScheme;
   hasError?: boolean;
-} & Pick<Props, 'isLean' | 'isDisabled'>) => {
+} & Pick<TextInputBaseProps, 'isLean' | 'isDisabled'>) => {
   if (isLean) {
     return {
       backgroundColor: 'transparent',
@@ -66,7 +66,16 @@ const wrapperStyleSwitch = ({
  * in custom implementation needed eg: datepicker
  * */
 export const wrapperStyle =
-  ({ isDisabled, isLocked, status, isLean, isDark, size, sx, hasMinWidthCompat }: Props) =>
+  ({
+    isDisabled,
+    isLocked,
+    status,
+    isLean,
+    isDark,
+    size,
+    sx,
+    hasMinWidthCompat,
+  }: TextInputBaseProps) =>
   (theme: Theme): SerializedStyles => {
     const colorScheme = isDark ? 'dark' : theme.colorScheme;
     const hasError = status === 'error';
@@ -102,7 +111,7 @@ export const wrapperStyle =
   };
 
 export const textFieldStyle =
-  ({ isLean, sx }: Props) =>
+  ({ isLean, sx }: TextInputBaseProps) =>
   (theme: Theme): SerializedStyles => {
     return css({
       position: 'relative',
@@ -122,7 +131,7 @@ export const textFieldStyle =
   };
 
 export const inputStyle =
-  ({ label, placeholder, size = DEFAULT_SIZE, isDark, sx }: Props) =>
+  ({ label, placeholder, size = DEFAULT_SIZE, isDark, sx }: TextInputBaseProps) =>
   (theme: Theme): SerializedStyles =>
     css({
       background: 'transparent',
@@ -172,7 +181,7 @@ export const inputStyle =
     });
 
 export const errorMsgStyle =
-  ({ status }: Props) =>
+  ({ status }: TextInputBaseProps) =>
   (theme: Theme): SerializedStyles =>
     css({
       display: 'flex',

--- a/src/components/TextInputBase/TextInputBase.tsx
+++ b/src/components/TextInputBase/TextInputBase.tsx
@@ -11,7 +11,7 @@ import { errorMsgStyle, textFieldStyle, wrapperStyle } from './TextInputBase.sty
 import Icon from 'components/Icon';
 import { AcceptedIconNames } from 'components/Icon/types';
 
-export type Props = {
+export type TextInputBaseProps = {
   /** The label of the text field that will be used as a placeholder and a label */
   label?: string;
   /** The placeholder of the input that will be used. This is shown if no label exists */
@@ -55,7 +55,7 @@ export type Props = {
 
 /** This Component is a wrapper for all primitives that hold text like Select, TextArea, TextInput. Here we keep the
  * logic of all the hover, focus status etc and the styling of these centralized **/
-const TextInputBase: FC<Props> = ({
+const TextInputBase: FC<TextInputBaseProps> = ({
   isLean = false,
   isDisabled,
   hintMsg,

--- a/src/components/TextInputBase/index.ts
+++ b/src/components/TextInputBase/index.ts
@@ -1,2 +1,2 @@
-export * from './TextInputBase';
 export { default } from './TextInputBase';
+export * from './TextInputBase';

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -11,7 +11,7 @@ export type EventProps = {
 };
 
 //@TODO fix props to not overwrite button props from base
-export type ButtonProps = Partial<
+export type CommonButtonProps = Partial<
   Omit<
     ButtonHTMLAttributes<HTMLButtonElement>,
     'size' | 'css' | 'onBlur' | 'onClick' | 'type' | 'disabled'


### PR DESCRIPTION
## Description

This is part TWO of the goal, to fix all internal types so they can be easily accessible on the root of the library by an external user.

Based on the ticket, what you are expecting to see is:

- Change all default Props naming we use on each component to ComponentNameProps so we can export and import easily
- Export all types and exported functions by default from each component
- Make all types by default exportable