### PR TITLE
[NDS-495] feat: change the third portion of components

### DIFF
--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -3,10 +3,10 @@ import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
 import { BASE_SHADE } from '../../theme/palette';
-import { Props } from './CheckBox';
+import { CheckboxProps } from './CheckBox';
 
 export const wrapperStyle =
-  ({ isDisabled }: Props) =>
+  ({ isDisabled }: CheckboxProps) =>
   (): SerializedStyles =>
     css`
       opacity: ${isDisabled ? 0.3 : 1};
@@ -16,7 +16,7 @@ export const wrapperStyle =
     `;
 
 export const checkboxWrapperStyle =
-  ({ isDisabled }: Props) =>
+  ({ isDisabled }: CheckboxProps) =>
   (): SerializedStyles => {
     const hoverStyle =
       !isDisabled &&
@@ -50,7 +50,7 @@ export const checkboxWrapperStyle =
     `;
   };
 
-const getBackgroundColor = ({ isChecked, isFilled, theme }: Props & { theme: Theme }) => {
+const getBackgroundColor = ({ isChecked, isFilled, theme }: CheckboxProps & { theme: Theme }) => {
   if (isChecked) {
     return `background: ${theme.utils.getColor('primary', BASE_SHADE, 'normal')}`;
   }
@@ -66,7 +66,7 @@ const getBackgroundColor = ({ isChecked, isFilled, theme }: Props & { theme: The
 };
 
 export const checkboxStyle =
-  ({ isChecked, isFilled }: Props) =>
+  ({ isChecked, isFilled }: CheckboxProps) =>
   (theme: Theme): SerializedStyles => {
     return css`
       border: 0;
@@ -102,7 +102,7 @@ export const checkboxStyle =
     `;
   };
 
-export const markerStyle = ({ isChecked }: Props): SerializedStyles => {
+export const markerStyle = ({ isChecked }: CheckboxProps): SerializedStyles => {
   return css`
     span {
       padding: 0;

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -14,7 +14,7 @@ import {
 } from './CheckBox.style';
 import Icon from 'components/Icon';
 
-export type Props = {
+export type CheckboxProps = {
   /** The label of the checkbox. */
   label?: string;
   /** Boolean defining if the checkbox is checked. */
@@ -36,7 +36,7 @@ export type Props = {
   id?: string;
 };
 
-const CheckBox = React.forwardRef<HTMLSpanElement, Props>((props, ref) => {
+const CheckBox = React.forwardRef<HTMLSpanElement, CheckboxProps>((props, ref) => {
   const {
     label,
     isChecked,

--- a/src/components/CheckBox/index.ts
+++ b/src/components/CheckBox/index.ts
@@ -1,1 +1,2 @@
 export { default } from './CheckBox';
+export * from './CheckBox';

--- a/src/components/Label/Label.style.ts
+++ b/src/components/Label/Label.style.ts
@@ -3,12 +3,12 @@ import { Theme } from 'theme';
 import { BASE_SHADE } from 'theme/palette';
 import { rem } from 'theme/utils';
 
-import { Props } from './Label';
+import { LabelProps } from './Label';
 
 export const LABEL_TRANSFORM_LEFT_SPACING = rem(3);
 
 export const labelStyle =
-  ({ isAnimated, hasError }: Pick<Props, 'isAnimated' | 'hasError'>) =>
+  ({ isAnimated, hasError }: Pick<LabelProps, 'isAnimated' | 'hasError'>) =>
   (theme: Theme): SerializedStyles =>
     css`
       transition: transform 0.25s, opacity 0.25s ease-in-out;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { labelStyle } from './Label.style';
 
-export type Props = {
+export type LabelProps = {
   /** If the label has error */
   hasError?: boolean;
   /** The label that is going to be displayed */
@@ -15,7 +15,7 @@ export type Props = {
   size?: string;
 };
 
-const Label: React.FC<Props> = ({
+const Label: React.FC<LabelProps> = ({
   hasError = false,
   htmlFor,
   label,

--- a/src/components/Label/index.ts
+++ b/src/components/Label/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Label';
+export * from './Label';

--- a/src/components/Radio/Radio.style.ts
+++ b/src/components/Radio/Radio.style.ts
@@ -4,7 +4,7 @@ import { BASE_SHADE } from 'theme/palette';
 import { ColorScheme } from 'theme/types';
 import { rem } from 'theme/utils';
 
-import { Props } from './Radio';
+import { RadioProps } from './Radio';
 
 const lightHoverColor = 'rgba(14, 14, 23, 0.07)';
 const darkHoverColor = 'rgba(255, 255, 255, 0.1)';
@@ -56,7 +56,11 @@ export const customRadioWrapperStyles =
     `;
 
 const determineColorBasedOnState =
-  ({ isChecked, isDisabled, isFilled }: Pick<Props, 'isChecked' | 'isDisabled' | 'isFilled'>) =>
+  ({
+    isChecked,
+    isDisabled,
+    isFilled,
+  }: Pick<RadioProps, 'isChecked' | 'isDisabled' | 'isFilled'>) =>
   (theme: Theme) => {
     if (isChecked) {
       return `currentColor`;
@@ -72,7 +76,7 @@ const determineColorBasedOnState =
   };
 
 export const customRadioStyles =
-  (props: Pick<Props, 'isChecked' | 'isDisabled' | 'isFilled'>) =>
+  (props: Pick<RadioProps, 'isChecked' | 'isDisabled' | 'isFilled'>) =>
   (theme: Theme): SerializedStyles => {
     return css`
       transition: all 0.2s ease;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -12,7 +12,7 @@ import {
   wrapperStyles,
 } from './Radio.style';
 
-export type Props = {
+export type RadioProps = {
   /** The value of the radio input. If no value is passed the default value, according to spec, is "on"
    *  https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#value
    *
@@ -45,7 +45,7 @@ export type Props = {
   dataTestId?: TestId;
 };
 
-const Radio = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+const Radio = React.forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const {
     isChecked: isExternallyControlledChecked,
     onChange,

--- a/src/components/Radio/index.ts
+++ b/src/components/Radio/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Radio';
+export * from './Radio';

--- a/src/components/RadioGroup/index.ts
+++ b/src/components/RadioGroup/index.ts
@@ -1,1 +1,2 @@
 export { default } from './RadioGroup';
+export * from './RadioGroup';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -8,10 +8,10 @@ import { ChangeEvent } from '../../utils/common';
 import { TestProps } from '../../utils/types';
 import Icon, { OwnProps as IconProps } from '../Icon';
 import TextField from '../TextField';
-import { Props as TextFieldProps } from '../TextField/TextField';
+import { TextFieldProps } from '../TextField/TextField';
 import ClickAwayListener from '../utils/ClickAwayListener';
 import handleSearch from '../utils/handleSearch';
-import SelectMenu from './components/SelectMenu/SelectMenu';
+import SelectMenu from './components/SelectMenu';
 import { rightIconContainer, selectWrapper } from './Select.style';
 import Loader from 'components/Loader';
 
@@ -29,7 +29,7 @@ export type SelectOption = {
 
 type InputProps = Partial<Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>>;
 
-export type Props = {
+export type SelectProps = {
   /** The function that is used to return the selected options */
   handleSelectedOption?: (selectedOption: SelectOption) => void;
   /** the default value of the select if needed */
@@ -68,7 +68,7 @@ const emptyValue = { label: '', value: '' };
 
 const ON_CHANGE_MOCK = () => {};
 
-const Select = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
+const Select = React.forwardRef<HTMLInputElement, SelectProps>((props, ref) => {
   const {
     handleSelectedOption = () => {},
     defaultValue = undefined,

--- a/src/components/Select/components/SelectMenu/SelectMenu.style.tsx
+++ b/src/components/Select/components/SelectMenu/SelectMenu.style.tsx
@@ -3,8 +3,8 @@ import { darken } from 'polished';
 import { Theme } from 'theme';
 import { rem } from 'theme/utils';
 
-import { Props } from './SelectMenu';
-import { Props as TextFieldProps } from 'components/TextField/TextField';
+import { SelectMenuProps } from './SelectMenu';
+import { TextFieldProps } from 'components/TextField/TextField';
 
 export const MAX_LARGE_HEIGHT = 277;
 export const MAX_SMALL_HEIGHT = 265;
@@ -34,7 +34,7 @@ export const optionStyle =
   };
 
 export const menuStyle =
-  ({ status, size, isVirtualized }: Props & Omit<TextFieldProps, 'ref'>) =>
+  ({ status, size, isVirtualized }: SelectMenuProps & Omit<TextFieldProps, 'ref'>) =>
   (theme: Theme): SerializedStyles =>
     css`
       background-color: ${theme.palette.white};

--- a/src/components/Select/components/SelectMenu/SelectMenu.tsx
+++ b/src/components/Select/components/SelectMenu/SelectMenu.tsx
@@ -5,7 +5,7 @@ import { menuStyle, optionStyle } from './SelectMenu.style';
 import List from 'components/List';
 import { MAX_NON_VIRTUALIZED_ITEMS_SELECT } from 'components/List/utils';
 
-export type Props = {
+export type SelectMenuProps = {
   /** Sets the size of the menu */
   size?: 'md' | 'sm';
   /** The status of the button regarding the status which is in - default normal */
@@ -18,7 +18,7 @@ export type Props = {
   searchTerm?: string;
 };
 
-const SelectMenu: React.FC<Props> = (props) => {
+const SelectMenu: React.FC<SelectMenuProps> = (props) => {
   const {
     size = 'sm',
     status = 'normal',

--- a/src/components/Select/components/SelectMenu/index.ts
+++ b/src/components/Select/components/SelectMenu/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SelectMenu';
+export * from './SelectMenu';

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Select';
+export * from './Select';

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -10,7 +10,7 @@ import SliderThumb from './components/SliderThumb';
 import SliderTrack from './components/SliderTrack';
 import { Container, InputContainer, InputsContainer } from './Slider.style';
 
-type CommonProps = {
+export type SliderProps = {
   /** Determines if the Slider is disabled or not */
   isDisabled?: boolean;
   /** Determines if the Slider will show increments along its track */
@@ -30,7 +30,7 @@ export const STEP_WITH_INCREMENTS = 20;
 export const MIN = 0;
 export const MAX = 100;
 
-const Slider: React.FC<CommonProps & TestProps> = ({
+const Slider: React.FC<SliderProps & TestProps> = ({
   values,
   onChange,
   onBlur,

--- a/src/components/Slider/components/SliderMark/SliderMark.tsx
+++ b/src/components/Slider/components/SliderMark/SliderMark.tsx
@@ -7,7 +7,7 @@ import { TestProps } from '../../../../utils/types';
 import { STEP_WITH_INCREMENTS } from '../../Slider';
 import { Mark, MarkHoverCircle } from './SliderMark.style';
 
-type Props = {
+export type SliderMarkProps = {
   values: number[];
   isDisabled: boolean;
   index: number;
@@ -15,7 +15,7 @@ type Props = {
   restProps: IMarkProps;
 };
 
-const SliderMark: FC<Props & TestProps> = ({
+const SliderMark: FC<SliderMarkProps & TestProps> = ({
   values,
   index,
   isDisabled,

--- a/src/components/Slider/components/SliderMark/index.ts
+++ b/src/components/Slider/components/SliderMark/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SliderMark';
+export * from './SliderMark';

--- a/src/components/Slider/components/SliderThumb/SliderThumb.tsx
+++ b/src/components/Slider/components/SliderThumb/SliderThumb.tsx
@@ -5,14 +5,14 @@ import { IThumbProps } from 'react-range/lib/types';
 import { TestProps } from '../../../../utils/types';
 import { Thumb } from './SliderThumb.style';
 
-interface ThumbProps {
+export interface SliderThumbProps {
   isDisabled: boolean;
   value: number;
   initialValue: number | undefined;
   restProps: IThumbProps;
 }
 
-const SliderThumb: FC<ThumbProps & TestProps> = ({
+const SliderThumb: FC<SliderThumbProps & TestProps> = ({
   isDisabled,
   value,
   initialValue,

--- a/src/components/Slider/components/SliderThumb/index.ts
+++ b/src/components/Slider/components/SliderThumb/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SliderThumb';
+export * from './SliderThumb';

--- a/src/components/Slider/components/SliderTrack/SliderTrack.tsx
+++ b/src/components/Slider/components/SliderTrack/SliderTrack.tsx
@@ -8,14 +8,14 @@ import { TestProps } from '../../../../utils/types';
 import { MAX, MIN } from '../../Slider';
 import { Track } from './SliderTrack.style';
 
-type Props = {
+export type SliderTrackProps = {
   values: number[];
   isDisabled: boolean;
   isSelector: boolean;
   restProps: ITrackProps;
 };
 
-const SliderTrack: FC<Props & TestProps> = ({
+const SliderTrack: FC<SliderTrackProps & TestProps> = ({
   values,
   isDisabled,
   isSelector,

--- a/src/components/Slider/components/SliderTrack/index.ts
+++ b/src/components/Slider/components/SliderTrack/index.ts
@@ -1,1 +1,2 @@
 export { default } from './SliderTrack';
+export * from './SliderTrack';

--- a/src/components/Slider/index.ts
+++ b/src/components/Slider/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Slider';
+export * from './Slider';

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '../../index';
 import { TestProps } from '../../utils/types';
 import { Label, SwitchWrapper, Container } from './Switch.style';
 
-type Props = {
+export type SwitchProps = {
   label?: string;
   labelPlacement?: 'left' | 'right';
   isChecked: boolean;
@@ -17,7 +17,7 @@ type Props = {
   isDisabled?: boolean;
 } & TestProps;
 
-const Switch: React.FC<Props> = ({
+const Switch: React.FC<SwitchProps> = ({
   isDisabled = false,
   label,
   isChecked,

--- a/src/components/Switch/index.ts
+++ b/src/components/Switch/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Switch';
+export * from './Switch';

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -18,7 +18,7 @@ import {
   expandedContainer,
 } from './Toast.style';
 
-export type Props = {
+export type ToastProps = {
   /** The informative message of the Toast */
   message: string;
   /** The type of the Toast, will determine the color and the icon */
@@ -37,7 +37,7 @@ export const isNotificationTypes = (type: string): type is NotificationTypes => 
   return ['success', 'error', 'warning', 'info'].includes(type);
 };
 
-const Toast: React.FC<Props> = ({
+const Toast: React.FC<ToastProps> = ({
   message,
   type = 'primary',
   styleType = 'elevated',

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Toast';
+export * from './Toast';

--- a/src/components/utils/ClickAwayListener/ClickAwayListener.tsx
+++ b/src/components/utils/ClickAwayListener/ClickAwayListener.tsx
@@ -18,14 +18,14 @@ const useClickAwayListener = (ref: React.MutableRefObject<any>, onClick: () => v
 
 export type HTMLTagsAllowed = 'div' | 'li' | 'span';
 
-type Props = {
+type ClickAwayListenerProps = {
   onClick: () => void;
   CustomHtmlTag?: HTMLTagsAllowed;
   ariaRole?: string;
   cssStyles?: { [key: string]: unknown };
 };
 
-const ClickAwayListener: React.FC<Props> = ({
+const ClickAwayListener: React.FC<ClickAwayListenerProps> = ({
   onClick,
   CustomHtmlTag = 'div',
   ariaRole = 'button',

--- a/src/components/utils/PositionInScreen/PositionInScreen.tsx
+++ b/src/components/utils/PositionInScreen/PositionInScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { container, itemContainer } from './PositionInScreen.style';
 
-type Props = {
+type PositionInScreenProps = {
   isVisible: boolean;
   isOverflowAllowed?: boolean;
   offsetX?: number;
@@ -47,7 +47,7 @@ const usePositionInScreen = (
   return position;
 };
 
-const PositionInScreen: React.FC<Props> = ({
+const PositionInScreen: React.FC<PositionInScreenProps> = ({
   isVisible,
   parent,
   isOverflowAllowed,


### PR DESCRIPTION
## Description

This is part THREE of the goal, to fix all internal types so they can be easily accessible on the root of the library by an external user.

Based on the ticket, what you are expecting to see is:

- Change all default Props naming we use on each component to ComponentNameProps so we can export and import easily
- Export all types and exported functions by default from each component
- Make all types by default exportable