### PR TITLE
[NDS-495] feat: change the 4th portion of components

### DIFF
--- a/src/components/Chart/BarChart/BarChart.tsx
+++ b/src/components/Chart/BarChart/BarChart.tsx
@@ -42,7 +42,7 @@ export type Data = {
   options?: Option;
 };
 
-export type Props = {
+export type BarChartProps = {
   /** This property defines the data to be shown in the Line Chart */
   data: Data[];
 };
@@ -73,7 +73,7 @@ const CustomYAxisTick = ({ colors, y, width, payload }: YAxisProp) => {
 
 const WrappedChart = Wrapper(RechartsBarChart);
 
-const BarChart: React.FC<Props> = ({ data }) => {
+const BarChart: React.FC<BarChartProps> = ({ data }) => {
   const theme = useTheme();
 
   const barColors = useMemo(

--- a/src/components/Chart/BarChart/components/CustomTooltip/CustomTooltip.tsx
+++ b/src/components/Chart/BarChart/components/CustomTooltip/CustomTooltip.tsx
@@ -2,12 +2,12 @@ import React, { useState, useRef, useCallback, useEffect } from 'react';
 
 import { tickStyle, tooltipStyle, tooltipArrowStyle } from './CustomTooltip.style';
 
-type Props = {
+type CustomTooltipProps = {
   content: React.ReactNode;
   fill: string;
 };
 
-const CustomTooltip: React.FC<Props> = ({ content, fill }) => {
+const CustomTooltip: React.FC<CustomTooltipProps> = ({ content, fill }) => {
   const wrapperRef = useRef<null | HTMLDivElement>(null);
   const [isActive, setIsActive] = useState(false);
   const [isTruncated, setIsTrancated] = useState(false);

--- a/src/components/Chart/DonutChart/DonutChart.tsx
+++ b/src/components/Chart/DonutChart/DonutChart.tsx
@@ -10,7 +10,7 @@ type Data = {
   color?: string;
 };
 
-export type Props = {
+export type DonutChartProps = {
   /** This property defines the data to be shown in the Donut Chart */
   data: Data[];
   /** This property defines the value to be shown in the Donut Chart label */
@@ -21,9 +21,9 @@ export type Props = {
 
 const WrappedChart = Wrapper(PieChart);
 
-const DonutChart: React.FC<Props> = ({ data, value, units }) => {
+const DonutChart: React.FC<DonutChartProps> = ({ data, value, units }) => {
   const Colors = useMemo(() => {
-    return data.map(obj => obj?.color || '');
+    return data.map((obj) => obj?.color || '');
   }, [data]);
 
   return (

--- a/src/components/Chart/LineChart/LineChart.tsx
+++ b/src/components/Chart/LineChart/LineChart.tsx
@@ -8,7 +8,7 @@ import CustomTooltip from './components/CustomTooltip';
 import GradientLine from './components/GradientLine';
 import { Data, getKeyNames, colorPicker } from './utils';
 
-export type Props = {
+export type LineChartProps = {
   /** This property defines the data to be shown in the Line Chart */
   data: Data[];
   /** Property indicating the label name to be displayed for X axis */
@@ -23,7 +23,13 @@ export type Props = {
 
 const WrappedChart = Wrapper(AreaChart);
 
-const LineChart: React.FC<Props> = ({ data, labelX, labelY, isLegendVisible = false, color }) => {
+const LineChart: React.FC<LineChartProps> = ({
+  data,
+  labelX,
+  labelY,
+  isLegendVisible = false,
+  color,
+}) => {
   const theme = useTheme();
 
   const uniqueKeyNames = useMemo(() => getKeyNames(data), [data]);

--- a/src/components/Chart/LineChart/components/GradientLine/GradientLine.tsx
+++ b/src/components/Chart/LineChart/components/GradientLine/GradientLine.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-type Props = {
+type GradientLineProps = {
   dataLabel: string;
   color: string;
 };
 
-const GradientLine = ({ dataLabel, color }: Props) => {
+const GradientLine = ({ dataLabel, color }: GradientLineProps) => {
   return (
     <linearGradient id={`color${dataLabel}`} x1="0" y1="0" x2="0" y2="1">
       <stop offset="5%" stopColor={`${color}`} stopOpacity={0.4} />

--- a/src/components/Chart/LineChart/utils.ts
+++ b/src/components/Chart/LineChart/utils.ts
@@ -6,17 +6,21 @@ export type Data = {
   [prop: string]: number | string | undefined;
 };
 
-type Props = {
+type ColorPickerProps = {
   theme: Theme;
   uniqueKeyNames: string[];
   color?: (dataLabel: string) => string;
 };
 
 export const getKeyNames = (data: Data[]): string[] => {
-  return uniq(flatten(data.map(object => keys(omit(object, 'name')))));
+  return uniq(flatten(data.map((object) => keys(omit(object, 'name')))));
 };
 
-export const colorPicker = ({ theme, uniqueKeyNames, color }: Props): Record<string, string> => {
+export const colorPicker = ({
+  theme,
+  uniqueKeyNames,
+  color,
+}: ColorPickerProps): Record<string, string> => {
   const colorSample = sampleSize(theme.palette.flat, uniqueKeyNames.length);
 
   return uniqueKeyNames.reduce<Record<string, string>>((acc, key, index) => {

--- a/src/components/Chart/Wrapper.tsx
+++ b/src/components/Chart/Wrapper.tsx
@@ -3,12 +3,12 @@ import { ResponsiveContainer, AreaChartProps, BarChartProps } from 'recharts';
 
 type ChartProps = AreaChartProps & BarChartProps;
 
-type Props = ChartProps & {
+type ChartWrapperProps = ChartProps & {
   aspect?: number;
 };
 
 function Wrapper(Component: any) {
-  const WrappedChart = ({ children, ...rest }: Props) => {
+  const WrappedChart = ({ children, ...rest }: ChartWrapperProps) => {
     if (process.env.NODE_ENV !== 'test') {
       return (
         <ResponsiveContainer aspect={rest?.aspect}>

--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -6,7 +6,7 @@ import { TestProps } from '../../../utils/types';
 import FilterBase from '../../Filter/components/FilterBase';
 import { FilterType, StyleType } from '../../Filter/types';
 import Icon from '../../Icon';
-import TextField, { Props as TextFieldProps } from '../../TextField/TextField';
+import TextField, { TextFieldProps } from '../../TextField/TextField';
 import { DateFormatType } from '../DatePicker';
 import { Range } from '../OverlayComponent/OverlayComponent';
 import { rangeInputsWrapper } from './DatePickInput.style';
@@ -14,7 +14,7 @@ import { rangeInputsWrapper } from './DatePickInput.style';
 // TODO: Need to fix this (TextField onChange prop)
 const ON_CHANGE_MOCK = () => {};
 
-type Props = {
+export type DatePickInputProps = {
   /** Handles the focus state of the component */
   handleFocus: () => void;
   /** Handles the clear action for the datepicker */
@@ -49,7 +49,7 @@ const getLabels = (isRangePicker: boolean, formattedTo: string) => ({
   to: isRangePicker ? `- ${formattedTo}` : '',
 });
 
-const DatePickInput = React.forwardRef<HTMLInputElement, Props>(
+const DatePickInput = React.forwardRef<HTMLInputElement, DatePickInputProps>(
   (
     {
       handleFocus,

--- a/src/components/DatePicker/DatePickInput/index.ts
+++ b/src/components/DatePicker/DatePickInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from './DatePickInput';
+export * from './DatePickInput';

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { TestProps } from '../../utils/types';
 import { FilterType, StyleType } from '../Filter/types';
-import { Props as TextFieldProps } from '../TextField/TextField';
+import { TextFieldProps } from '../TextField/TextField';
 import ClickAwayListener from '../utils/ClickAwayListener';
 import PositionInScreen from '../utils/PositionInScreen';
 import { datePickerStyles } from './DatePicker.style';
@@ -18,7 +18,7 @@ export type DisabledDates = {
   before?: Date;
 };
 
-export type Props = {
+export type DatePickerProps = {
   /** This property is to define if this is a day picker or a day range picker */
   isRangePicker?: boolean;
   /** A callback to return user selection */
@@ -79,7 +79,7 @@ export const extraOptions: ExtraOption[] = [
   },
 ];
 
-const DatePicker: React.FC<Props & TestProps> = ({
+const DatePicker: React.FC<DatePickerProps & TestProps> = ({
   isRangePicker = false,
   onChange,
   disableDates,

--- a/src/components/DatePicker/Day/Day.style.ts
+++ b/src/components/DatePicker/Day/Day.style.ts
@@ -5,7 +5,7 @@ import { rem } from 'theme/utils';
 import { getHover } from '../../../theme/states';
 import { ColorShapeFromComponent } from '../../../utils/themeFunctions';
 
-type Props = {
+type DayStyleProps = {
   day?: number;
   isSelected?: boolean;
   isBetween?: boolean;
@@ -25,7 +25,7 @@ export const dayWrapperStyle =
     isFirst,
     isToday,
     isDisabled,
-  }: Props & { isToday: boolean; calculatedColor: ColorShapeFromComponent }) =>
+  }: DayStyleProps & { isToday: boolean; calculatedColor: ColorShapeFromComponent }) =>
   (theme: Theme): SerializedStyles =>
     css`
       vertical-align: middle;
@@ -85,7 +85,7 @@ export const emptyDayStyle =
     `;
 
 export const dayStyle =
-  ({ isSelected, calculatedColor, isToday, isDisabled, isBetween }: Props) =>
+  ({ isSelected, calculatedColor, isToday, isDisabled, isBetween }: DayStyleProps) =>
   (theme: Theme) =>
     css`
       border: ${rem(1)} solid ${isToday ? theme.utils.getColor('lightGrey', 450) : 'transparent'};

--- a/src/components/DatePicker/Day/Day.tsx
+++ b/src/components/DatePicker/Day/Day.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { currentDay } from '../utils';
 import { dayStyle, dayWrapperStyle, emptyDayStyle } from './Day.style';
 
-export type Props = {
+export type DayProps = {
   day?: number;
   month: number;
   year: number;
@@ -17,7 +17,7 @@ export type Props = {
   isDisabled?: boolean;
 };
 
-const Day: React.FC<Props> = ({
+const Day: React.FC<DayProps> = ({
   day,
   month,
   year,
@@ -83,4 +83,4 @@ const Day: React.FC<Props> = ({
   );
 };
 
-export default React.memo<Props>(Day);
+export default React.memo<DayProps>(Day);

--- a/src/components/DatePicker/Day/index.ts
+++ b/src/components/DatePicker/Day/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Day';
+export * from './Day';

--- a/src/components/DatePicker/Month/Month.tsx
+++ b/src/components/DatePicker/Month/Month.tsx
@@ -29,9 +29,9 @@ function getNumWeeksForMonth(year: number, month: number) {
 
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thurdsday', 'Friday', 'Saturday', 'Sunday'];
 
-type WeekRow = number[];
+export type WeekRow = number[];
 
-export type Props = {
+export type MonthProps = {
   year: number;
   month: number;
   onDaySelect?: (date: Dayjs) => void;
@@ -39,7 +39,7 @@ export type Props = {
   disabledDates?: DisabledDates;
 };
 
-const Month: React.FC<Props> = ({ year, month, onDaySelect, selectedDays, disabledDates }) => {
+const Month: React.FC<MonthProps> = ({ year, month, onDaySelect, selectedDays, disabledDates }) => {
   const weeksWithDays = React.useMemo<WeekRow[]>(() => {
     const monthDate = currentDay.month(month).year(year).date(1);
     const daysOfMonth = monthDate.daysInMonth();

--- a/src/components/DatePicker/Month/index.ts
+++ b/src/components/DatePicker/Month/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Month';
+export * from './Month';

--- a/src/components/DatePicker/OverlayComponent/OverlayComponent.tsx
+++ b/src/components/DatePicker/OverlayComponent/OverlayComponent.tsx
@@ -15,7 +15,7 @@ import {
   overlayWrapperStyle,
 } from './OverlayComponent.style';
 
-type Props = {
+export type OverlayComponentProps = {
   selectedOption?: string;
   onCancel?: () => void;
   onApply?: () => void;
@@ -31,7 +31,7 @@ export type Range = {
   from?: Dayjs;
   to?: Dayjs;
 };
-const OverlayComponent: React.FC<Props> = ({
+const OverlayComponent: React.FC<OverlayComponentProps> = ({
   selectedOption,
   setSelectedOption = () => {},
   isRangePicker = false,

--- a/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.tsx
+++ b/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.tsx
@@ -19,7 +19,7 @@ import SelectMenu from 'components/Select/components/SelectMenu';
 import { SelectOption } from 'components/Select/Select';
 import ClickAwayListener from 'components/utils/ClickAwayListener';
 
-type Props = {
+type MonthWrapperProps = {
   showedArrows?: 'left' | 'right' | 'both';
   isRangePicker?: boolean;
   date: Dayjs;
@@ -51,7 +51,7 @@ const MonthWrapper = ({
   showedArrows = 'both',
   disabledDates,
   isRangePicker = false,
-}: Props) => {
+}: MonthWrapperProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const theme = useTheme();

--- a/src/components/DatePicker/OverlayComponent/index.ts
+++ b/src/components/DatePicker/OverlayComponent/index.ts
@@ -1,1 +1,2 @@
 export { default } from './OverlayComponent';
+export * from './OverlayComponent';

--- a/src/components/DatePicker/index.ts
+++ b/src/components/DatePicker/index.ts
@@ -1,1 +1,2 @@
 export { default } from './DatePicker';
+export * from './DatePicker';

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -4,20 +4,20 @@ import React from 'react';
 
 import { drawerContainerStyle } from './Drawer.style';
 import Navigation from './Navigation/Navigation';
-import { MenuItem } from './types';
+import { DrawerMenuItem } from './types';
 
-export type Props = {
+export type DrawerProps = {
   /** Defines if the drawer is expanded */
   isExpanded: boolean;
   /** Changes if the drawer is expanded */
   setExpanded: (v: boolean) => void;
   /** The menu items to be displayed in the drawer */
-  menuItems: MenuItem[];
+  menuItems: DrawerMenuItem[];
   /** Render prop function to display something over the Navigation */
   renderHeader?: () => React.ReactNode;
 };
 
-const Drawer: React.FC<Props> = (props) => {
+const Drawer: React.FC<DrawerProps> = (props) => {
   const breakpoints = useBreakpoints();
   const isSmallDesktop = breakpoints.des1200 && !breakpoints.des1440;
 

--- a/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
+++ b/src/components/Drawer/Navigation/MenuItem/MenuItem.tsx
@@ -13,19 +13,19 @@ import {
   subMenuIconStyle,
   menuLinkStyle,
 } from '../Navigation.style';
-import { MenuItem as MenuItemProps } from 'components/Drawer/types';
+import { DrawerMenuItem } from 'components/Drawer/types';
 import ExpandCollapse from 'components/ExpandCollapse';
 import Icon from 'components/Icon';
 
-type Props = {
+export type MenuItemProps = {
   /** Defines the current menu item whose submenu item is currently selected */
   isCurrent: boolean;
   /** Defines if the menu item is expanded */
   isExpanded: boolean;
   toggleMenuItem: (newUrl: string) => void;
-} & MenuItemProps;
+} & DrawerMenuItem;
 
-const MenuItem: React.FC<Props> = memo(
+const MenuItem: React.FC<MenuItemProps> = memo(
   ({ isCurrent, isExpanded, name, url, iconName, options, toggleMenuItem, state: linkState }) => {
     const theme = useTheme();
 

--- a/src/components/Drawer/Navigation/Navigation.tsx
+++ b/src/components/Drawer/Navigation/Navigation.tsx
@@ -1,11 +1,11 @@
 import useLocationToGetCurrentMenuItem from 'hooks/useLocationToGetCurrentMenuItem';
 import React, { useCallback, useState } from 'react';
 
-import { Props } from '../Drawer';
+import { DrawerProps } from '../Drawer';
 import MenuItem from './MenuItem/MenuItem';
 import { navigationContainerStyle } from './Navigation.style';
 
-type NavigationProps = Props;
+type NavigationProps = DrawerProps;
 
 const Navigation: React.FC<NavigationProps> = ({ menuItems, isExpanded }) => {
   const [openMenuItems, setOpenMenuItems] = useState<string[]>([]); // we identify open menuitems by their url

--- a/src/components/Drawer/index.ts
+++ b/src/components/Drawer/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Drawer';
+export * from './Drawer';

--- a/src/components/Drawer/types.ts
+++ b/src/components/Drawer/types.ts
@@ -3,7 +3,7 @@ import { match } from 'react-router';
 
 import { AcceptedIconNames } from 'components/Icon/types';
 
-export type MenuItem = {
+export type DrawerMenuItem = {
   name: string;
   url: string;
   state?: Record<string, any> | null;
@@ -13,5 +13,5 @@ export type MenuItem = {
     match: match<Params> | null,
     location: Location<S>
   ): boolean;
-  options: MenuItem[];
+  options: DrawerMenuItem[];
 };

--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -2,24 +2,27 @@ import { css } from '@emotion/react';
 
 import { Theme } from '../../theme';
 import { RequiredProperties } from '../../utils/common';
-import { Props } from '../Button/Button';
+import { ButtonProps } from '../Button/Button';
 
-export const wrapperStyle = () => () => css`
-  position: relative;
-  display: inline-block;
-`;
+export const wrapperStyle = () => () =>
+  css`
+    position: relative;
+    display: inline-block;
+  `;
 
-export const buttonSpanStyle = ({
-  size,
-  iconLeft,
-  iconRight,
-  hasChildren,
-}: RequiredProperties<Props & { hasChildren: boolean }>) => (theme: Theme) => ({
-  display: iconLeft || iconRight ? 'flex' : 'block',
-  flexDirection: iconLeft || iconRight ? 'row' : 'column',
-  alignItems: iconLeft || iconRight ? ('center' as const) : ('flex-start' as const),
-  '> :first-of-type': {
-    marginLeft: iconLeft || iconRight ? (size === 'sm' ? theme.spacing.sm : theme.spacing.md) : 0,
-    marginRight: hasChildren ? theme.spacing.sm : 0,
-  },
-});
+export const buttonSpanStyle =
+  ({
+    size,
+    iconLeft,
+    iconRight,
+    hasChildren,
+  }: RequiredProperties<ButtonProps & { hasChildren: boolean }>) =>
+  (theme: Theme) => ({
+    display: iconLeft || iconRight ? 'flex' : 'block',
+    flexDirection: iconLeft || iconRight ? 'row' : 'column',
+    alignItems: iconLeft || iconRight ? ('center' as const) : ('flex-start' as const),
+    '> :first-of-type': {
+      marginLeft: iconLeft || iconRight ? (size === 'sm' ? theme.spacing.sm : theme.spacing.md) : 0,
+      marginRight: hasChildren ? theme.spacing.sm : 0,
+    },
+  });

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -16,7 +16,7 @@ import { optionsStyle, MenuPositionAllowed } from '../utils/DropdownOptions';
 import { wrapperStyle } from './Menu.style';
 import List from 'components/List';
 
-export type Props = {
+export type MenuProps = {
   /** the color of the button based on our colors eg. red-500 */
   color?: string;
   /** Items that are being declared as menu options */
@@ -52,7 +52,7 @@ export type Props = {
 } & TestProps &
   EventProps;
 
-const Menu: React.FC<Props> = (props) => {
+const Menu: React.FC<MenuProps> = (props) => {
   const {
     items,
     onSelect,

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Menu';
+export * from './Menu';

--- a/src/components/Modal/Modal.style.ts
+++ b/src/components/Modal/Modal.style.ts
@@ -3,7 +3,7 @@ import { transparentize } from 'polished';
 import { rem } from 'theme/utils';
 
 import { Theme } from '../../theme';
-import { Props } from './Modal';
+import { ModalProps } from './Modal';
 
 export const backgroundContainer = (theme: Theme): SerializedStyles => css`
   position: fixed;
@@ -23,17 +23,18 @@ export const cardSizing = css`
   max-height: ${rem(684)};
 `;
 
-export const modalContainer = ({ isContentPadded }: Pick<Props, 'isContentPadded'>) => (
-  theme: Theme
-): SerializedStyles => css`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+export const modalContainer =
+  ({ isContentPadded }: Pick<ModalProps, 'isContentPadded'>) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
 
-  padding: ${isContentPadded
-    ? `${theme.spacing.lg} ${theme.spacing.xl} ${theme.spacing.xl} ${theme.spacing.xl}`
-    : undefined};
-`;
+      padding: ${isContentPadded
+        ? `${theme.spacing.lg} ${theme.spacing.xl} ${theme.spacing.xl} ${theme.spacing.xl}`
+        : undefined};
+    `;
 
 export const closeContainer = (theme: Theme) => css`
   width: 100%;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -7,9 +7,9 @@ import Card from '../Card';
 import IconButton from '../IconButton';
 import ClickAwayListener from '../utils/ClickAwayListener';
 import { backgroundContainer, cardSizing, closeContainer, modalContainer } from './Modal.style';
-import ModalContent, { Props as ModalContentProps } from './ModalContent/ModalContent';
+import ModalContent, { ModalContentProps } from './ModalContent/ModalContent';
 
-export type Props = {
+export type ModalProps = {
   /**  If true, the modal is open. Defaults to false. */
   isOpen: boolean;
   /** Callback fired when the component requests to be closed. */
@@ -22,7 +22,7 @@ export type Props = {
   isContentPadded?: boolean;
 };
 
-const Modal: React.FC<Props> = ({
+const Modal: React.FC<ModalProps> = ({
   isOpen = false,
   onClose,
   dataTestId,

--- a/src/components/Modal/ModalContent/ModalContent.tsx
+++ b/src/components/Modal/ModalContent/ModalContent.tsx
@@ -11,7 +11,7 @@ import {
   modalContentContainer,
 } from './ModalContent.style';
 
-export type Props = {
+export type ModalContentProps = {
   /** The label of the modal. */
   label?: string;
   /** The heading of the modal. */
@@ -30,7 +30,7 @@ export type Props = {
   dataTestId?: TestId;
 };
 
-const ModalContent: React.FC<Props> = ({
+const ModalContent: React.FC<ModalContentProps> = ({
   label,
   heading,
   message,

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -10,7 +10,7 @@ import ClickAwayListener from 'components/utils/ClickAwayListener';
 
 export type AnchorType = 'bottom' | 'left' | 'right' | 'top';
 
-export type Props = {
+export type OverlayProps = {
   /**  If true, the overlay is open.*/
   isOpen: boolean;
   /** Callback fired when the component requests to be closed. */
@@ -29,7 +29,7 @@ const getAnchorStyle = ({ anchor, size }: { anchor: AnchorType; size: string }) 
     : { display: 'flex', height: '100%', width: size };
 };
 
-const Overlay = React.forwardRef<HTMLDivElement, React.PropsWithChildren<Props & DivProps>>(
+const Overlay = React.forwardRef<HTMLDivElement, React.PropsWithChildren<OverlayProps & DivProps>>(
   ({ isOpen, onClose, anchor = 'left', size, dataTestId, children }, ref) => {
     useEscape(() => {
       onClose();

--- a/src/components/Overlay/index.ts
+++ b/src/components/Overlay/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Overlay';
+export * from './Overlay';


### PR DESCRIPTION
## Description

This is part FOUR of the goal, to fix all internal types so they can be easily accessible at the root of the library by an external user.

Based on the ticket, what you are expecting to see is:

- Change all default Props naming we use on each component to ComponentNameProps so we can export and import easily
- Export all types and exported functions by default from each component
- Make all types by default exportable