### PR TITLE
[NDS-495] feat: change the 5th portion of components

### DIFF
--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -8,11 +8,11 @@ import FilterBase from './components/FilterBase';
 import Options from './components/Options/Options';
 import SearchInput from './components/SearchInput/SearchInput';
 import { menuStyle } from './Filter.style';
-import { FilterOption, Props } from './types';
+import { FilterOption, FilterProps } from './types';
 import { errors } from './utils';
 import handleSearch from 'components/utils/handleSearch';
 
-const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
+const Filter = React.forwardRef<HTMLButtonElement, FilterProps>((props, ref) => {
   const {
     items,
     onSelect,
@@ -32,7 +32,7 @@ const Filter = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
     onClear = () => {},
   } = props;
 
-  errorHandler<Props>(errors, props);
+  errorHandler<FilterProps>(errors, props);
 
   const [isOpen, setIsOpen] = React.useState(false);
   const [searchValue, setSearchValue] = React.useState('');

--- a/src/components/Filter/components/FilterBase/FilterBase.tsx
+++ b/src/components/Filter/components/FilterBase/FilterBase.tsx
@@ -16,10 +16,10 @@ import {
   valueSpanStyle,
   wrapperStyle,
 } from '../../Filter.style';
-import { Props } from '../../types';
+import { FilterProps } from '../../types';
 import { getTextColor } from '../../utils';
 
-type FilterBaseProps = {
+export type FilterBaseProps = {
   children?: ReactNode;
   isDatePicker?: boolean;
   handleOpen: () => void;
@@ -28,7 +28,10 @@ type FilterBaseProps = {
   selectedItemLabel?: string;
   isOpen: boolean;
   hasSelectedValue: boolean;
-} & Pick<Props, 'dataTestId' | 'isDisabled' | 'label' | 'buttonType' | 'filterType' | 'styleType'>;
+} & Pick<
+  FilterProps,
+  'dataTestId' | 'isDisabled' | 'label' | 'buttonType' | 'filterType' | 'styleType'
+>;
 
 export const FilterBase = React.forwardRef<HTMLButtonElement, FilterBaseProps>((props, ref) => {
   const {

--- a/src/components/Filter/components/FilterBase/index.ts
+++ b/src/components/Filter/components/FilterBase/index.ts
@@ -1,1 +1,2 @@
 export { default } from './FilterBase';
+export * from './FilterBase';

--- a/src/components/Filter/components/Options/Options.tsx
+++ b/src/components/Filter/components/Options/Options.tsx
@@ -6,7 +6,7 @@ import { FILTER_OPTIONS_MAX_HEIGHT } from 'components/Filter/utils';
 import List from 'components/List';
 import { MAX_NON_VIRTUALIZED_ITEMS_FILTER } from 'components/List/utils';
 
-interface Props {
+export interface Props {
   items: FilterOption[];
   onSelect: (option: FilterOption) => void;
   defaultValue: FilterOption;

--- a/src/components/Filter/components/SearchInput/SearchInput.tsx
+++ b/src/components/Filter/components/SearchInput/SearchInput.tsx
@@ -8,14 +8,14 @@ import Loader from '../../../Loader';
 import TextField from '../../../TextField';
 import { textFieldWrapper, iconWrapper } from './SearchInput.style';
 
-interface Props {
+export type SearchInputProps = {
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   dataTestId?: string;
   isLoading?: boolean;
-}
+};
 
-const SearchInput = ({ onChange, value, dataTestId, isLoading }: Props) => {
+const SearchInput = ({ onChange, value, dataTestId, isLoading }: SearchInputProps) => {
   const theme = useTheme();
 
   const rightIcon = useMemo(

--- a/src/components/Filter/index.ts
+++ b/src/components/Filter/index.ts
@@ -1,1 +1,3 @@
 export { default } from './Filter';
+export * from './Filter';
+export * from './types';

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -10,7 +10,7 @@ export type StyleType = 'filled' | 'transparent';
 
 export type FilterType = 'preset' | 'added';
 
-export type Props = {
+export type FilterProps = {
   /** The type of the button - defaults to "primary" */
   buttonType?: 'primary' | 'secondary';
   /** Items that are being declared as menu options */

--- a/src/components/Filter/utils.ts
+++ b/src/components/Filter/utils.ts
@@ -3,7 +3,7 @@ import { rem } from 'theme/utils';
 import { colorShades, MAX_SHADE } from '../../theme/palette';
 import { PropsValidationError } from '../../utils/errors';
 import { defineBackgroundColor } from '../Button/utils';
-import { BackgroundColorProps, BaseColorProps, BorderProps, Props } from './types';
+import { BackgroundColorProps, BaseColorProps, BorderProps, FilterProps } from './types';
 
 export const FILTER_OPTIONS_MAX_HEIGHT = 253;
 export const HAS_SELECTED_VALUE_COLOR_SHADE = 50;
@@ -93,7 +93,7 @@ export const errors = [
      * for 'added' type design team decided that is not needed therefore in order not having to maintain
      * one more special case we dont render it
      **/
-    condition: ({ filterType, styleType }: Props): boolean =>
+    condition: ({ filterType, styleType }: FilterProps): boolean =>
       Boolean(filterType === 'added' && styleType === 'transparent'),
     error: new PropsValidationError('This filterType and styleType is not supported'),
   },

--- a/src/components/List/ListItem/ListItem.tsx
+++ b/src/components/List/ListItem/ListItem.tsx
@@ -5,7 +5,7 @@ import { ListItemType, ListRowSize, SelectHandlerType } from '../types';
 import { renderContent } from '../utils';
 import { listItemStyle, contentStyle } from './ListItem.style';
 
-type Props = {
+export type ListItemProps = {
   /** Size of the ListItem (translates to height) */
   size: ListRowSize;
   /** Content of the ListItem */
@@ -26,7 +26,7 @@ type Props = {
   isGroupItem?: boolean;
 } & TestProps;
 
-const ListItem = React.forwardRef<HTMLDivElement, Props>(
+const ListItem = React.forwardRef<HTMLDivElement, ListItemProps>(
   (
     {
       size,

--- a/src/components/List/ListItem/index.ts
+++ b/src/components/List/ListItem/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ListItem';
+export * from './ListItem';

--- a/src/components/List/ListItemGroup/ListGroupTitle/ListGroupTitle.tsx
+++ b/src/components/List/ListItemGroup/ListGroupTitle/ListGroupTitle.tsx
@@ -6,7 +6,7 @@ import { ListItemType, ListRowSize } from 'components/List/types';
 import { renderContent } from 'components/List/utils';
 import { SelectOption } from 'components/Select/Select';
 
-type Props = {
+export type ListGroupTitleProps = {
   /** Size of the ListGroupTitle (translates to height) */
   size: ListRowSize;
   /** Content of the ListItem */
@@ -17,7 +17,13 @@ type Props = {
   searchTerm?: string;
 } & TestProps;
 
-const ListGroupTitle: React.FC<Props> = ({ size, content, index, searchTerm, dataTestId }) => {
+const ListGroupTitle: React.FC<ListGroupTitleProps> = ({
+  size,
+  content,
+  index,
+  searchTerm,
+  dataTestId,
+}) => {
   return (
     <div
       css={listGroupTitleStyle({ size, isDisabled: (content as SelectOption).isDisabled })}

--- a/src/components/List/ListItemGroup/ListGroupTitle/index.ts
+++ b/src/components/List/ListItemGroup/ListGroupTitle/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ListGroupTitle';
+export * from './ListGroupTitle';

--- a/src/components/List/ListItemGroup/ListItemGroup.tsx
+++ b/src/components/List/ListItemGroup/ListItemGroup.tsx
@@ -9,7 +9,7 @@ import { isSelected } from '../utils';
 import ListGroupTitle from './ListGroupTitle';
 import { SelectOption } from 'components/Select/Select';
 
-type ListItemGroupProps = {
+export type ListItemGroupProps = {
   /** Size of the ListItem (translates to height) */
   size: ListRowSize;
   /** Content of the ListItemGroup */

--- a/src/components/List/ListItemGroup/ListItemGroup.tsx
+++ b/src/components/List/ListItemGroup/ListItemGroup.tsx
@@ -9,7 +9,7 @@ import { isSelected } from '../utils';
 import ListGroupTitle from './ListGroupTitle';
 import { SelectOption } from 'components/Select/Select';
 
-type Props = {
+type ListItemGroupProps = {
   /** Size of the ListItem (translates to height) */
   size: ListRowSize;
   /** Content of the ListItemGroup */
@@ -24,7 +24,7 @@ type Props = {
   handleOptionClick?: SelectHandlerType;
 } & TestProps;
 
-const ListItemGroup = React.forwardRef<HTMLDivElement, Props>(
+const ListItemGroup = React.forwardRef<HTMLDivElement, ListItemGroupProps>(
   ({ size, content, groupIndex, selectedItem, searchTerm, handleOptionClick, dataTestId }, ref) => {
     return (
       <li>

--- a/src/components/List/ListItemGroup/index.ts
+++ b/src/components/List/ListItemGroup/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ListItemGroup';
+export * from './ListItemGroup';

--- a/src/components/List/NormalList/NormalList.tsx
+++ b/src/components/List/NormalList/NormalList.tsx
@@ -10,7 +10,7 @@ import ListItemGroup from '../ListItemGroup';
 import { ListItemType, ListRowSize, SelectHandlerType } from '../types';
 import { isSelected } from '../utils';
 
-type Props = {
+type NormalListProps = {
   items: ListItemType[];
   /** Size of the list's row (height of ListItem Component)  */
   rowSize: ListRowSize;
@@ -30,7 +30,7 @@ type Props = {
   isSearchable?: boolean;
 } & TestProps;
 
-const NormalList = React.forwardRef<HTMLDivElement, Props>(
+const NormalList = React.forwardRef<HTMLDivElement, NormalListProps>(
   (
     {
       items,

--- a/src/components/List/NormalList/index.ts
+++ b/src/components/List/NormalList/index.ts
@@ -1,1 +1,2 @@
 export { default } from './NormalList';
+export * from './NormalList';

--- a/src/components/List/VirtualizedList/VirtualizedList.tsx
+++ b/src/components/List/VirtualizedList/VirtualizedList.tsx
@@ -10,7 +10,7 @@ import ListItemGroup from '../ListItemGroup';
 import { ListItemType, ListRowSize, SelectHandlerType } from '../types';
 import { isSelected, MAX_LARGE_HEIGHT, MAX_SMALL_HEIGHT } from '../utils';
 
-type Props = {
+type VirtualizedListProps = {
   items: ListItemType[];
   /** Size of the list's row (height of ListItem Component)  */
   rowSize: ListRowSize;
@@ -28,7 +28,7 @@ type Props = {
   handleOptionClick?: SelectHandlerType;
 } & TestProps;
 
-const VirtualizedList = React.forwardRef<HTMLDivElement, Props>(
+const VirtualizedList = React.forwardRef<HTMLDivElement, VirtualizedListProps>(
   (
     {
       items,

--- a/src/components/List/VirtualizedList/index.ts
+++ b/src/components/List/VirtualizedList/index.ts
@@ -1,1 +1,2 @@
 export { default } from './VirtualizedList';
+export * from './VirtualizedList';

--- a/src/components/List/index.ts
+++ b/src/components/List/index.ts
@@ -1,1 +1,3 @@
 export { default } from './List';
+export * from './List';
+export * from './types';

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -5,7 +5,7 @@ import { getLoader, loaderTypes } from './Loader.utils';
 
 export type LoaderType = typeof loaderTypes[number];
 
-type LoaderProps = {
+export type LoaderProps = {
   /** Loader type. Defaults to dots **/
   type?: LoaderType;
   /** The data test id if needed */

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -5,7 +5,7 @@ import { getLoader, loaderTypes } from './Loader.utils';
 
 export type LoaderType = typeof loaderTypes[number];
 
-type Props = {
+type LoaderProps = {
   /** Loader type. Defaults to dots **/
   type?: LoaderType;
   /** The data test id if needed */
@@ -14,7 +14,7 @@ type Props = {
   color?: string;
 };
 
-const Loader: React.FC<Props> = ({ type = 'dots', dataTestId, color }) => {
+const Loader: React.FC<LoaderProps> = ({ type = 'dots', dataTestId, color }) => {
   return <div css={loaderContainer()}>{getLoader(type, dataTestId, color)}</div>;
 };
 

--- a/src/components/Loader/components/DotsLoader/DotsLoader.tsx
+++ b/src/components/Loader/components/DotsLoader/DotsLoader.tsx
@@ -3,12 +3,12 @@ import { generateTestDataId } from 'utils/helpers';
 
 import { dotsContainer, dotsWrapper } from './DotsLoader.style';
 
-type Props = {
+export type DotsLoaderProps = {
   dataTestId?: string;
   color?: string;
 };
 
-const DotsLoader: React.FC<Props> = ({ dataTestId, color }) => {
+const DotsLoader: React.FC<DotsLoaderProps> = ({ dataTestId, color }) => {
   return (
     <div css={dotsWrapper} data-testid={generateTestDataId('dots-loading', dataTestId)}>
       <div css={dotsContainer(color)} />

--- a/src/components/Loader/components/DotsLoader/index.ts
+++ b/src/components/Loader/components/DotsLoader/index.ts
@@ -1,1 +1,2 @@
 export { default } from './DotsLoader';
+export * from './DotsLoader';

--- a/src/components/Loader/components/IndeterminateLoader/IndeterminateLoader.tsx
+++ b/src/components/Loader/components/IndeterminateLoader/IndeterminateLoader.tsx
@@ -8,12 +8,12 @@ import {
   LoaderIncLine,
 } from './IndeterminateLoader.style';
 
-type Props = {
+export type IndeterminateLoaderProps = {
   dataTestId?: string;
   color?: string;
 };
 
-const IndeterminateLoader: React.FC<Props> = ({ dataTestId, color }) => {
+const IndeterminateLoader: React.FC<IndeterminateLoaderProps> = ({ dataTestId, color }) => {
   return (
     <div css={LoaderContainer()} data-testid={generateTestDataId('dots-loading', dataTestId)}>
       <div css={LoaderLine()} />

--- a/src/components/Loader/components/IndeterminateLoader/index.ts
+++ b/src/components/Loader/components/IndeterminateLoader/index.ts
@@ -1,1 +1,2 @@
 export { default } from './IndeterminateLoader';
+export * from './IndeterminateLoader';

--- a/src/components/Loader/components/Spinner/Spinner.tsx
+++ b/src/components/Loader/components/Spinner/Spinner.tsx
@@ -4,7 +4,7 @@ import { generateTestDataId } from '../../../../utils/helpers';
 import { TestId } from '../../../../utils/types';
 import { spinnerContainer } from './Spinner.style';
 
-interface Props {
+export interface Props {
   dataTestId?: TestId;
   color?: string;
 }

--- a/src/components/Loader/components/Spinner/index.ts
+++ b/src/components/Loader/components/Spinner/index.ts
@@ -1,1 +1,2 @@
-export { default as Spinner } from './Spinner';
+export { default } from './Spinner';
+export * from './Spinner';

--- a/src/components/Loader/index.ts
+++ b/src/components/Loader/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Loader';
+export * from './Loader';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -4,7 +4,7 @@ import usePagination from '../../hooks/usePagination';
 import useTheme from '../../hooks/useTheme';
 import IconButton from '../IconButton';
 
-type Props = {
+export type PaginationProps = {
   /** The current page you are on if you need to control it, defaults to 1 **/
   page: number;
   /** The total pages **/
@@ -26,7 +26,7 @@ const Pagination = ({
   isEnhancedPaginationVisible = false,
   isNextPageDisabled,
   isPrevPageDisabled,
-}: Props) => {
+}: PaginationProps) => {
   const theme = useTheme();
   const {
     currentPage,

--- a/src/components/Pagination/index.ts
+++ b/src/components/Pagination/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Pagination';
+export * from './Pagination';

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ export type TooltipSize = 'large' | 'medium' | 'small';
 
 export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left';
 
-type Props = {
+export type TooltipProps = {
   /** The plain text to show inside the tooltip */
   content: React.ReactNode;
   /** The placement where the tooltip will show */
@@ -35,7 +35,7 @@ type Props = {
   children: React.ReactElement;
 };
 
-const Tooltip: React.FC<Props> = ({
+const Tooltip: React.FC<TooltipProps> = ({
   size = 'medium',
   children,
   content,

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Tooltip';
+export * from './Tooltip';


### PR DESCRIPTION
## Description

This is part FIFTH of the goal, to fix all internal types so they can be easily accessible at the root of the library by an external user.

Based on the ticket, what you are expecting to see is:

- Change all default Props naming we use on each component to ComponentNameProps so we can export and import easily
- Export all types and exported functions by default from each component
- Make all types by default exportable