### PR TITLE
[NDS-495] feat: change the 7th portion of components

### DIFF
--- a/src/components/Notification/Banner/Banner.tsx
+++ b/src/components/Notification/Banner/Banner.tsx
@@ -4,7 +4,7 @@ import { TestId } from '../../../utils/types';
 import { NotificationStyleType, NotificationTypes } from '../Notification';
 import CompactNotification from '../subcomponents/CompactNotification';
 
-export type Props = {
+export type BannerProps = {
   /** Show notification icon based on the type */
   hasIcon?: boolean;
   /** The title (message heading) of the Notification */
@@ -25,7 +25,7 @@ export type Props = {
   dataTestId?: TestId;
 };
 
-const Banner: React.FC<Props> = ({
+const Banner: React.FC<BannerProps> = ({
   hasIcon = false,
   title,
   message,

--- a/src/components/Notification/Banner/index.tsx
+++ b/src/components/Notification/Banner/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Banner';
+export * from './Banner';

--- a/src/components/Notification/InlineNotification/InlineNotification.tsx
+++ b/src/components/Notification/InlineNotification/InlineNotification.tsx
@@ -4,7 +4,7 @@ import { TestId } from '../../../utils/types';
 import { NotificationStyleType, NotificationTypes } from '../Notification';
 import CompactNotification from '../subcomponents/CompactNotification';
 
-export type Props = {
+export type InlineNotificationProps = {
   /** Show notification icon based on the type */
   hasIcon?: boolean;
   /** The informative message of the Notification */
@@ -23,7 +23,7 @@ export type Props = {
   dataTestId?: TestId;
 };
 
-const InlineNotification: React.FC<Props> = ({
+const InlineNotification: React.FC<InlineNotificationProps> = ({
   hasIcon = false,
   message,
   type,

--- a/src/components/Notification/InlineNotification/index.tsx
+++ b/src/components/Notification/InlineNotification/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './InlineNotification';
+export * from './InlineNotification';

--- a/src/components/Notification/NotificationVisual/NotificationVisual.tsx
+++ b/src/components/Notification/NotificationVisual/NotificationVisual.tsx
@@ -6,7 +6,7 @@ import Button from '../../Button';
 import { actionContainer, actionsContainer, boldMessageContainer } from '../Notification.style';
 import { visualContainer, descriptionContainer } from './NotificationVisual.style';
 
-export type Props = {
+export type NotificationVisualProps = {
   /** The message heading of the Notification */
   title: string | undefined;
   /** The primary call-to-action label of the Notification */
@@ -23,7 +23,7 @@ export type Props = {
   dataTestId?: TestId;
 };
 
-const NotificationVisual: React.FC<Props> = ({
+const NotificationVisual: React.FC<NotificationVisualProps> = ({
   title,
   primaryCTALabel = 'OK',
   primaryCTA,

--- a/src/components/Notification/NotificationVisual/index.tsx
+++ b/src/components/Notification/NotificationVisual/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './NotificationVisual';
+export * from './NotificationVisual';

--- a/src/components/Notification/NotificationsContainer/NotificationsContainer.tsx
+++ b/src/components/Notification/NotificationsContainer/NotificationsContainer.tsx
@@ -4,16 +4,20 @@ import ReactDOM from 'react-dom';
 
 import { notificationsContainer } from './NotificationsContainer.style';
 
-type Positions = 'top-right' | 'top-left' | 'bottom-left' | 'bottom-right';
+export type NotificationsContainerPositions =
+  | 'top-right'
+  | 'top-left'
+  | 'bottom-left'
+  | 'bottom-right';
 
-type Props = {
+export type NotificationsContainerProps = {
   /** Notifications Container position */
-  position: Positions;
+  position: NotificationsContainerPositions;
   children: ReactNode;
   parent?: HTMLElement | null;
 };
 
-const NotificationsContainer: React.FC<Props> = props => {
+const NotificationsContainer: React.FC<NotificationsContainerProps> = (props) => {
   const { children, position, parent = document.body } = props;
 
   if (parent === null) {

--- a/src/components/Notification/NotificationsContainer/index.ts
+++ b/src/components/Notification/NotificationsContainer/index.ts
@@ -1,1 +1,2 @@
 export { default } from './NotificationsContainer';
+export * from './NotificationsContainer';

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -15,7 +15,7 @@ import { typeToIconName } from '../subcomponents/CompactNotification/CompactNoti
 import { cardContainer, topContainer, infoContainer, descriptionContainer } from './Snackbar.style';
 import Icon from 'components/Icon';
 
-export type Props = {
+export type SnackbarProps = {
   /** The informative message of the Toast */
   message: string;
   /** The type of the Notification */
@@ -38,7 +38,7 @@ export type Props = {
   dataTestId?: TestId;
 };
 
-const Snackbar: React.FC<Props> = ({
+const Snackbar: React.FC<SnackbarProps> = ({
   message,
   type,
   styleType = 'elevated',

--- a/src/components/Notification/Snackbar/index.tsx
+++ b/src/components/Notification/Snackbar/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './Snackbar';
+export * from './Snackbar';

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
@@ -19,7 +19,7 @@ import { AcceptedIconNames } from 'components/Icon/types';
 
 export type CompactNotificationVariants = 'inline' | 'banner' | 'card';
 
-export type Props = {
+export type CompactNotificationProps = {
   /** Show notification icon based on the type */
   hasIcon?: boolean;
   /** The informative message of the Notification */
@@ -53,7 +53,7 @@ export type Props = {
 export const typeToIconName = (type: NotificationTypes): AcceptedIconNames =>
   type === 'warning' ? 'alert' : type;
 
-const CompactNotification: React.FC<Props> = ({
+const CompactNotification: React.FC<CompactNotificationProps> = ({
   hasIcon = false,
   message,
   variant,

--- a/src/components/Notification/subcomponents/CompactNotification/index.tsx
+++ b/src/components/Notification/subcomponents/CompactNotification/index.tsx
@@ -1,1 +1,2 @@
 export { default } from './CompactNotification';
+export * from './CompactNotification';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -43,7 +43,7 @@ export type Selection = string | number;
 
 export type TableType = 'normal' | 'nested-header';
 
-type Props<T> = {
+type TableProps<T> = {
   /** The data for the table that needs to display. */
   data: Row<T>[];
   /** An array of titles or objects to define columns. */
@@ -107,7 +107,7 @@ function Table<T>({
   actionWidth,
   isInitiallyExpanded = false,
   dataTestIdPrefix,
-}: Props<T>) {
+}: TableProps<T>) {
   const breakpoints = useBreakpoints();
   const actionCellWidth = actionWidth ? `${actionWidth}%` : breakpoints.des1920 ? '5%' : '7%';
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -43,7 +43,7 @@ export type Selection = string | number;
 
 export type TableType = 'normal' | 'nested-header';
 
-type TableProps<T> = {
+export type TableProps<T> = {
   /** The data for the table that needs to display. */
   data: Row<T>[];
   /** An array of titles or objects to define columns. */

--- a/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
+++ b/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.tsx
@@ -7,24 +7,18 @@ import { containerStyles, contentStyles } from './ExtendedColumnItem.style';
 import Icon from 'components/Icon';
 import Tooltip from 'components/Tooltip';
 
-type Props = {
+export type ExtendedColumnItemProps = {
   item: ExtendedColumn | string;
   isNumerical?: boolean;
   sorting?: Sort;
 };
 
-const ExtendedColumnItem: React.FC<Props> = ({ item, sorting, isNumerical }) => {
+const ExtendedColumnItem: React.FC<ExtendedColumnItemProps> = ({ item, sorting, isNumerical }) => {
   const theme = useTheme();
 
   const itemContentLowerCase = !isItemString(item)
-    ? item.content.sortingKey
-        .trim()
-        .toLowerCase()
-        .replace(/ /g, '_')
-    : item
-        .trim()
-        .toLowerCase()
-        .replace(/ /g, '_');
+    ? item.content.sortingKey.trim().toLowerCase().replace(/ /g, '_')
+    : item.trim().toLowerCase().replace(/ /g, '_');
 
   const sortingItem = () =>
     //TODO: Remove type check when backwards-compatibility is removed

--- a/src/components/Table/components/ExtendedColumnItem/index.ts
+++ b/src/components/Table/components/ExtendedColumnItem/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ExtendedColumnItem';
+export * from './ExtendedColumnItem';

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
@@ -6,7 +6,7 @@ import { ContentComponent, TableType } from '../../../../Table';
 import TableCell from '../../../TableCell';
 import { nestedHeaderStyle } from './ContentCell.style';
 
-type Props = {
+type ContentCellProps = {
   columns: string[];
   isPadded: boolean;
   tooltipContent?: string;
@@ -22,7 +22,7 @@ type Props = {
   index?: number;
 };
 
-const ContentCell: React.FC<Props> = ({
+const ContentCell: React.FC<ContentCellProps> = ({
   columns,
   isPadded,
   columnWidth,
@@ -57,10 +57,7 @@ const ContentCell: React.FC<Props> = ({
         </div>
       )}
 
-      <TruncatedContent
-        placement={'bottom'}
-        tooltipContent={tooltipContent}
-      >
+      <TruncatedContent placement={'bottom'} tooltipContent={tooltipContent}>
         {isComponentFunctionType(content) ? (
           content({ content, colSpan })
         ) : (

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ExpandedButtonCell/ExpandedButtonCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ExpandedButtonCell/ExpandedButtonCell.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import TableCell from '../../../TableCell';
 import IconButton from 'components/IconButton';
 
-type Props = {
+type ExpandedButtonCellProps = {
   isExpandedExists: boolean;
   isChecked: boolean;
   toggleIsChecked: () => void;
@@ -15,7 +15,7 @@ type Props = {
   index?: number;
 };
 
-const ExpandedButtonCell: React.FC<Props> = ({
+const ExpandedButtonCell: React.FC<ExpandedButtonCellProps> = ({
   isExpandedExists,
   isChecked,
   toggleIsChecked,

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -6,7 +6,7 @@ import { parentStyles } from './TableCell.style';
 import { getTestId } from './utils';
 import { getBorderColor } from 'components/Table/utils';
 
-type Props = {
+export type TableCellProps = {
   textAlign?: 'left' | 'right';
   component?: 'td' | 'th';
   width?: number | string;
@@ -23,7 +23,7 @@ type Props = {
   onClick?: () => void;
 };
 
-const TableCell: React.FC<Props> = React.memo(
+const TableCell: React.FC<TableCellProps> = React.memo(
   ({
     textAlign = 'left',
     component = 'td',

--- a/src/components/Table/components/TableCell/index.ts
+++ b/src/components/Table/components/TableCell/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TableCell';
+export * from './TableCell';

--- a/src/components/Table/components/TableRow/TableRow.tsx
+++ b/src/components/Table/components/TableRow/TableRow.tsx
@@ -2,13 +2,19 @@ import * as React from 'react';
 
 import useTheme from '../../../../hooks/useTheme';
 
-type Props = {
+export type TableRowProps = {
   isSelected?: boolean;
   isNested?: boolean;
   onClick?: () => void;
 };
 
-const TableRow: React.FC<Props> = ({ isNested, isSelected, children, onClick, ...rest }) => {
+const TableRow: React.FC<TableRowProps> = ({
+  isNested,
+  isSelected,
+  children,
+  onClick,
+  ...rest
+}) => {
   const theme = useTheme();
 
   return (

--- a/src/components/Table/components/TableRow/index.ts
+++ b/src/components/Table/components/TableRow/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TableRow';
+export * from './TableRow';

--- a/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
+++ b/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
@@ -4,7 +4,7 @@ import { Row, Selection, TableType } from '../../Table';
 import { TableRowContext } from '../../TableRowContext';
 import RenderRowOrNestedRow from '../RenderRowOrNestedRow/RenderRowOrNestedRow';
 
-type TableRowWrapperProps<T> = {
+export type TableRowWrapperProps<T> = {
   row: Row<T>;
   isRowSelected: boolean;
   onSelectionAdd: (selection: Selection) => void;

--- a/src/components/Table/components/TableRowWrapper/index.ts
+++ b/src/components/Table/components/TableRowWrapper/index.ts
@@ -1,1 +1,2 @@
 export { default } from './TableRowWrapper';
+export * from './TableRowWrapper';

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,1 +1,3 @@
 export { default } from './Table';
+export * from './Table';
+export * from './types';


### PR DESCRIPTION
## Description

This is the SEVENTH part and last one of the goal, to fix all internal types so they can be easily accessible at the root of the library by an external user.

Based on the ticket, what you are expecting to see is:

- Change all default Props naming we use on each component to ComponentNameProps so we can export and import easily
- Export all types and exported functions by default from each component
- Make all types by default exportable