### PR TITLE
[NDS-494] theme reconfiguration leftovers

### DIFF
--- a/src/theme/borderRadius.ts
+++ b/src/theme/borderRadius.ts
@@ -1,0 +1,14 @@
+import borderRadiusFigma from './constants/borderRadius';
+import { FigmaTokenValueType, getFigmaTokensValue } from './utils';
+
+export type BorderRadiusKey = keyof typeof borderRadiusFigma;
+
+export type BorderRadius = {
+  get: (val: BorderRadiusKey) => string;
+};
+
+const borderRadius: BorderRadius = {
+  get: getFigmaTokensValue<BorderRadiusKey>(borderRadiusFigma, FigmaTokenValueType.Pixels),
+};
+
+export default borderRadius;

--- a/src/theme/borderWidth.ts
+++ b/src/theme/borderWidth.ts
@@ -1,0 +1,14 @@
+import borderWidthFigma from './constants/borderWidth';
+import { FigmaTokenValueType, getFigmaTokensValue } from './utils';
+
+export type BorderWidthKey = keyof typeof borderWidthFigma;
+
+export type BorderWidth = {
+  get: (val: BorderWidthKey) => string;
+};
+
+const borderWidth: BorderWidth = {
+  get: getFigmaTokensValue<BorderWidthKey>(borderWidthFigma, FigmaTokenValueType.Pixels),
+};
+
+export default borderWidth;

--- a/src/theme/boxShadow.ts
+++ b/src/theme/boxShadow.ts
@@ -1,0 +1,14 @@
+import boxShadowFigma from './constants/boxShadow';
+import { FigmaTokenValueType, getFigmaTokensValue } from './utils';
+
+export type BoxShadowKey = keyof typeof boxShadowFigma;
+
+export type BoxShadow = {
+  get: (val: BoxShadowKey) => string;
+};
+
+const boxShadow: BoxShadow = {
+  get: getFigmaTokensValue<BoxShadowKey>(boxShadowFigma, FigmaTokenValueType.BoxShadow),
+};
+
+export default boxShadow;

--- a/src/theme/constants/borderRadius.ts
+++ b/src/theme/constants/borderRadius.ts
@@ -1,0 +1,44 @@
+const borderRadius = {
+  '0': {
+    value: '0px',
+    type: 'borderRadius',
+    description: 'Corner radius = 0px',
+  },
+  '1': {
+    value: '2px',
+    type: 'borderRadius',
+    description: 'Corner radius = 2px',
+  },
+  '2': {
+    value: '4px',
+    type: 'borderRadius',
+    description: 'Corner radius = 4px',
+  },
+  '3': {
+    value: '8px',
+    type: 'borderRadius',
+    description: 'Corner radius = 8px',
+  },
+  '4': {
+    value: '16px',
+    type: 'borderRadius',
+    description: 'Corner radius = 16px',
+  },
+  '5': {
+    value: '36px',
+    type: 'borderRadius',
+    description: 'Corner radius = 36px',
+  },
+  '6': {
+    value: '48px',
+    type: 'borderRadius',
+    description: 'Corner radius = 48px',
+  },
+  '7': {
+    value: '100px',
+    type: 'borderRadius',
+    description: 'Corner radius = 100px used for circles and pill shaped elements',
+  },
+} as const;
+
+export default borderRadius;

--- a/src/theme/constants/borderWidth.ts
+++ b/src/theme/constants/borderWidth.ts
@@ -1,0 +1,13 @@
+const borderWidth = {
+  '1': {
+    value: '1px',
+    type: 'borderWidth',
+    description: 'Default 1pxs stroke',
+  },
+  '2': {
+    value: '2px',
+    type: 'borderWidth',
+  },
+} as const;
+
+export default borderWidth;

--- a/src/theme/constants/boxShadow.ts
+++ b/src/theme/constants/boxShadow.ts
@@ -1,0 +1,59 @@
+const boxShadow = {
+  '0': {
+    value: {
+      x: '0',
+      y: '0',
+      blur: '0',
+      spread: '0',
+      color: '#',
+      type: 'innerShadow',
+    },
+    type: 'boxShadow',
+  },
+  '1': {
+    value: {
+      x: '0',
+      y: '2',
+      blur: '5',
+      spread: '0',
+      color: '#10306612',
+      type: 'dropShadow',
+    },
+    type: 'boxShadow',
+  },
+  '2': {
+    value: {
+      x: '0',
+      y: '4',
+      blur: '8',
+      spread: '0',
+      color: '#10306612',
+      type: 'dropShadow',
+    },
+    type: 'boxShadow',
+  },
+  '3': {
+    value: {
+      color: '#10306612',
+      type: 'dropShadow',
+      x: '0',
+      y: '8',
+      blur: '16',
+      spread: '0',
+    },
+    type: 'boxShadow',
+  },
+  '4': {
+    value: {
+      color: '#10306612',
+      type: 'dropShadow',
+      x: '0',
+      y: '16',
+      blur: '24',
+      spread: '0',
+    },
+    type: 'boxShadow',
+  },
+} as const;
+
+export default boxShadow;

--- a/src/theme/constants/opacity.ts
+++ b/src/theme/constants/opacity.ts
@@ -1,0 +1,30 @@
+const opacity = {
+  '0': {
+    value: '0',
+    type: 'opacity',
+  },
+  '1': {
+    value: '7%',
+    type: 'opacity',
+  },
+  '2': {
+    value: '14%',
+    type: 'opacity',
+  },
+  '3': {
+    value: '21%',
+    type: 'opacity',
+  },
+  '4': {
+    value: '50%',
+    type: 'opacity',
+    description: 'used in disabled state',
+  },
+  '5': {
+    value: '75%',
+    type: 'opacity',
+    description: 'used in backdrop overlays',
+  },
+} as const;
+
+export default opacity;

--- a/src/theme/constants/sizing.ts
+++ b/src/theme/constants/sizing.ts
@@ -1,0 +1,84 @@
+const sizing = {
+  '0': {
+    value: '0',
+    type: 'sizing',
+  },
+  '1': {
+    value: '4',
+    type: 'sizing',
+  },
+  '2': {
+    value: '8',
+    type: 'sizing',
+  },
+  '3': {
+    value: '12',
+    type: 'sizing',
+  },
+  '4': {
+    value: '16',
+    type: 'sizing',
+  },
+  '5': {
+    value: '20',
+    type: 'sizing',
+  },
+  '6': {
+    value: '24',
+    type: 'sizing',
+  },
+  '7': {
+    value: '28',
+    type: 'sizing',
+  },
+  '8': {
+    value: '32',
+    type: 'sizing',
+  },
+  '9': {
+    value: '36',
+    type: 'sizing',
+  },
+  '10': {
+    value: '40',
+    type: 'sizing',
+  },
+  '11': {
+    value: '44',
+    type: 'sizing',
+  },
+  '12': {
+    value: '48',
+    type: 'sizing',
+  },
+  '13': {
+    value: '52',
+    type: 'sizing',
+  },
+  '14': {
+    value: '56',
+    type: 'sizing',
+  },
+  '15': {
+    value: '64',
+    type: 'sizing',
+  },
+  '16': {
+    value: '72',
+    type: 'sizing',
+  },
+  '17': {
+    value: '80',
+    type: 'sizing',
+  },
+  '18': {
+    value: '88',
+    type: 'sizing',
+  },
+  '19': {
+    value: '92',
+    type: 'sizing',
+  },
+} as const;
+
+export default sizing;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,7 +1,12 @@
+import borderRadius from './borderRadius';
+import borderWidth from './borderWidth';
+import boxShadow from './boxShadow';
 import elevation from './elevation';
+import opacity from './opacity';
 import overrides from './overrides';
 import { getAAColor, getAAColorFromSwatches, getColor } from './palette';
 import { darkPaletteConfig, lightPaletteConfig } from './palette.config';
+import sizing from './sizing';
 import spacing from './spacing';
 import { ColorScheme, TextColorTypes, Theme, ThemeConfig } from './types';
 import typography from './typography';
@@ -20,6 +25,11 @@ const defaultTheme = (theming: ColorScheme): Theme => {
     elevation,
     colorScheme: theming,
     overrides,
+    borderRadius,
+    borderWidth,
+    boxShadow,
+    opacity,
+    sizing,
     utils: {
       getColor: getColor(palette),
       getAAColorFromSwatches: getAAColorFromSwatches(palette),

--- a/src/theme/opacity.ts
+++ b/src/theme/opacity.ts
@@ -1,0 +1,14 @@
+import opacityFigma from './constants/opacity';
+import { FigmaTokenValueType, getFigmaTokensValue } from './utils';
+
+export type OpacityKey = keyof typeof opacityFigma;
+
+export type Opacity = {
+  get: (val: OpacityKey) => string;
+};
+
+const opacity: Opacity = {
+  get: getFigmaTokensValue<OpacityKey>(opacityFigma, FigmaTokenValueType.String),
+};
+
+export default opacity;

--- a/src/theme/sizing.ts
+++ b/src/theme/sizing.ts
@@ -1,0 +1,14 @@
+import sizingFigma from './constants/sizing';
+import { FigmaTokenValueType, getFigmaTokensValue } from './utils';
+
+export type SizingKey = keyof typeof sizingFigma;
+
+export type Sizing = {
+  get: (val: SizingKey) => string;
+};
+
+const sizing: Sizing = {
+  get: getFigmaTokensValue<SizingKey>(sizingFigma, FigmaTokenValueType.Pixels),
+};
+
+export default sizing;

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -1,7 +1,12 @@
+import { BorderRadius } from './borderRadius';
+import { BorderWidth } from './borderWidth';
+import { BoxShadow } from './boxShadow';
 import { Elevation } from './elevation';
+import { Opacity } from './opacity';
 import { Overrides } from './overrides';
 import { GetAAColor, GetAAColorFromSwatches, GetColor, Palette } from './palette';
 import { PaletteConfig } from './palette.config';
+import { Sizing } from './sizing';
 import { Spacing } from './spacing';
 import { Typography } from './typography';
 
@@ -23,6 +28,11 @@ export type Theme = {
   elevation: Elevation;
   colorScheme: ColorScheme;
   overrides: Overrides;
+  borderRadius: BorderRadius;
+  borderWidth: BorderWidth;
+  boxShadow: BoxShadow;
+  opacity: Opacity;
+  sizing: Sizing;
   utils: {
     getColor: GetColor;
     getAAColorFromSwatches: GetAAColorFromSwatches;

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -86,7 +86,28 @@ export enum FigmaTokenValueType {
   Pixels = 'pixels',
   String = 'string',
   Number = 'number',
+  BoxShadow = 'boxShadow',
 }
+
+/** The type of the object inside the theme/constants folder  */
+export type FigmaTokensObject<T extends string | symbol> = Record<
+  T,
+  Record<string, string | Record<string, string>>
+>;
+
+const getFigmaTokensBoxShadowValue = <T extends string | symbol>(
+  figmaTokensObject: FigmaTokensObject<T>,
+  val: T
+) => {
+  const x = rem(Number(get(figmaTokensObject, [val, 'value', 'x'], '0')));
+  const y = rem(Number(get(figmaTokensObject, [val, 'value', 'y'], '0')));
+  const blur = rem(Number(get(figmaTokensObject, [val, 'value', 'blur'], '0')));
+  const spread = rem(Number(get(figmaTokensObject, [val, 'value', 'spread'], '0')));
+  const color = get(figmaTokensObject, [val, 'value', 'color'], 'transparent');
+
+  return `${x} ${y} ${blur} ${spread} ${color}`;
+};
+
 /**
  * @param figmaTokensObject The parsed objects from Figma Tokens in the src/theme/constants/ dir
  * @param type 'pixels' refers to all the string values that need to be converted to rem
@@ -95,22 +116,23 @@ export enum FigmaTokenValueType {
  */
 export const getFigmaTokensValue: {
   <T extends string | symbol>(
-    figmaTokensObject: Record<T, Record<string, string>>,
+    figmaTokensObject: FigmaTokensObject<T>,
     type: FigmaTokenValueType.Number
   ): (val: T) => number;
   <T extends string | symbol>(
-    figmaTokensObject: Record<T, Record<string, string>>,
+    figmaTokensObject: FigmaTokensObject<T>,
     type: FigmaTokenValueType.String
   ): (val: T) => string;
   <T extends string | symbol>(
-    figmaTokensObject: Record<T, Record<string, string>>,
+    figmaTokensObject: FigmaTokensObject<T>,
     type: FigmaTokenValueType.Pixels
   ): (val: T) => string;
-} =
   <T extends string | symbol>(
-    figmaTokensObject: Record<T, Record<string, string>>,
-    type: FigmaTokenValueType
-  ) =>
+    figmaTokensObject: FigmaTokensObject<T>,
+    type: FigmaTokenValueType.BoxShadow
+  ): (val: T) => string;
+} =
+  <T extends string | symbol>(figmaTokensObject: FigmaTokensObject<T>, type: FigmaTokenValueType) =>
   (val: T): any => {
     switch (type) {
       case FigmaTokenValueType.Pixels:
@@ -119,5 +141,7 @@ export const getFigmaTokensValue: {
         return get(figmaTokensObject, [val, 'value'], '0') as string;
       case FigmaTokenValueType.Number:
         return Number(get(figmaTokensObject, [val, 'value'], '0')) as number;
+      case FigmaTokenValueType.BoxShadow:
+        return getFigmaTokensBoxShadowValue(figmaTokensObject, val);
     }
   };


### PR DESCRIPTION
## Description

[NDS-494](https://orfium.atlassian.net/browse/NDS-494)

[part IV of [NDS-489](https://orfium.atlassian.net/browse/NDS-489)]

In this PR the leftovers of the global theme reconfiguration are implemented.
That includes: 
- `border-width`
- `opacity`
- `border-radius`
- `opacity`
- `sizing`

