### PR TITLE
[NDS-590] fix: add fake date to only affect storybook as intended

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,3 +17,5 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        env:
+          STORYBOOK_ENV: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       PRODUCT: ictinus
       CI: false
-      # CSP_HEADER: "default-src 'self'; connect-src ${{ secrets.REACT_APP_API_BASE_URL }} https://*.s3.amazonaws.com; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'"
+      CSP_HEADER: "default-src 'self'; connect-src 'self' https://*.s3.amazonaws.com; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'"
       # Add all the env vars needed for yarn build to work. For secret values, add them first to your repo and then here
       # Example of secret:
       # SECRET_ENV: ${{ secrets.mysecret }}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -75,4 +75,8 @@ module.exports = {
 
     return config;
   },
+  env: (config: any) => ({
+    ...config,
+    STORYBOOK_ENV: 'true',
+  }),
 };

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -1,10 +1,15 @@
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
+
 import { Range } from './OverlayComponent/OverlayComponent';
 
-export const currentDay = dayjs('11-03-2020 12:00:00');
+const fakeDate = dayjs('11-03-2020 12:00:00');
+const getDefaultDate = (date?: undefined | Dayjs) =>
+  process.env.NODE_ENV !== 'test' ? date : fakeDate;
 
-export const datepickerPropValue =
-  process.env.NODE_ENV !== 'test' ? undefined : dayjs('11-03-2020 12:00:00');
+export const currentDay =
+  process.env.STORYBOOK_ENV === 'true' ? fakeDate : (getDefaultDate(dayjs()) as Dayjs);
+
+export const datepickerPropValue = getDefaultDate();
 
 export const initDates = (
   value: {
@@ -13,7 +18,7 @@ export const initDates = (
   },
   isDefaultNow: boolean
 ): Range => {
-  const hasDefaultDate = isDefaultNow || Object.values(value).some(v => v);
+  const hasDefaultDate = isDefaultNow || Object.values(value).some((v) => v);
 
   return {
     from: hasDefaultDate ? dayjs(value.from) : undefined,


### PR DESCRIPTION
## Description

### What is the problem?

Datepicker has the wrong date when opens. Although the values selected are correct. 

### Steps to Reproduce

If you have selected values to 1/1/2023 for datepicker and you open to select a date you can see that the background is set to the fake date of 2020

Experimental version for testing: https://www.npmjs.com/package/@orfium/ictinus/v/4.55.1-alpha.0

## Screenshot
Visually the problem
<img width="1233" alt="Screenshot 2023-02-20 at 12 29 41 PM" src="https://user-images.githubusercontent.com/6433679/220081589-7a2dbf48-f94d-4cbf-84a6-457e3deb2a8d.png">

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan
* Nothing changed for the project
* already tested locally against MET
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
