### PR TITLE
[NDS-613] make DatePicker a controlled component [v4.5]

### DIFF
--- a/src/components/DatePicker/DatePickInput/DatePickInput.tsx
+++ b/src/components/DatePicker/DatePickInput/DatePickInput.tsx
@@ -1,5 +1,5 @@
 import dayjs, { Dayjs } from 'dayjs';
-import React, { InputHTMLAttributes } from 'react';
+import React, { useCallback, InputHTMLAttributes } from 'react';
 
 import { generateTestDataId, getLocaleFormat } from '../../../utils/helpers';
 import { TestProps } from '../../../utils/types';
@@ -63,9 +63,7 @@ const DatePickInput = React.forwardRef<HTMLInputElement, Props & InputProps & Te
     },
     ref
   ) => {
-    const getDateFormatted = React.useCallback(formatDate(dateFormatOverride), [
-      dateFormatOverride,
-    ]);
+    const getDateFormatted = useCallback(formatDate(dateFormatOverride), [dateFormatOverride]);
 
     const formattedFrom = getDateFormatted(selectedDay.from);
     const formattedTo = getDateFormatted(selectedDay.to);
@@ -107,7 +105,7 @@ const DatePickInput = React.forwardRef<HTMLInputElement, Props & InputProps & Te
             dataTestId={dataTestId}
             onChange={ON_CHANGE_MOCK}
             placeholder="Date (start) - Date (end)"
-            value={selectedDay.from && `${formattedFrom} - ${formattedTo}`}
+            value={selectedDay.from ? `${formattedFrom} - ${formattedTo}` : ''}
             rightIcon={<Icon name={'calendarEmpty'} color={'#676767'} />}
           />
         );
@@ -122,7 +120,7 @@ const DatePickInput = React.forwardRef<HTMLInputElement, Props & InputProps & Te
           dataTestId={dataTestId}
           onChange={ON_CHANGE_MOCK}
           placeholder="Select date"
-          value={selectedDay.to && formattedFrom}
+          value={selectedDay.to ? formattedFrom : ''}
           rightIcon={<Icon name={'calendarEmpty'} color={'#676767'} />}
         />
       );

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -256,6 +256,16 @@ This datepicker has a predefined initial value that can be used both for initial
   </Story>
 </Preview>
 
+# Reset DatePicker
+
+<Preview>
+  <Story name="Reset DatePicker">
+    <Stack vertical>
+      <DatePickerShowcase />
+    </Stack>
+  </Story>
+</Preview>
+
 # Dynamic disableDates with all options available and custom label - Knobs
 
 <Preview>
@@ -269,15 +279,5 @@ This datepicker has a predefined initial value that can be used both for initial
       inputLabel={text('inputLabel', 'Custom Date')}
       isRangePicker={boolean('isRangePicker', false)}
     />
-  </Story>
-</Preview>
-
-# Reset DatePicker (from parect component)
-
-<Preview>
-  <Story name="Reset DatePicker" parameters={{ decorators: [withKnobs] }}>
-    <Stack vertical>
-      <DatePickerShowcase />
-    </Stack>
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 import DatePicker, { extraOptions } from './DatePicker';
+import DatePickerShowcase from '../storyUtils/DatePickerShowcase';
 import { currentDay } from './utils';
 import dayjs from 'dayjs';
 import Stack from '../storyUtils/Stack';
@@ -268,5 +269,15 @@ This datepicker has a predefined initial value that can be used both for initial
       inputLabel={text('inputLabel', 'Custom Date')}
       isRangePicker={boolean('isRangePicker', false)}
     />
+  </Story>
+</Preview>
+
+# Reset DatePicker (from parect component)
+
+<Preview>
+  <Story name="Reset DatePicker" parameters={{ decorators: [withKnobs] }}>
+    <Stack vertical>
+      <DatePickerShowcase />
+    </Stack>
   </Story>
 </Preview>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -97,8 +97,13 @@ const DatePicker: React.FC<Props & TestProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string>('');
 
-  const [range, setRange] = useState<Range>(initDates(value, isDefaultNow));
-  const [selectedRange, setSelectedRange] = useState<Range>(initDates(value, isDefaultNow));
+  const [range, setRange] = useState<Range>(() => initDates(value, isDefaultNow));
+  const [selectedRange, setSelectedRange] = useState<Range>(() => initDates(value, isDefaultNow));
+
+  useEffect(() => {
+    setRange(initDates(value, isDefaultNow));
+    setSelectedRange(initDates(value, isDefaultNow));
+  }, [value, isDefaultNow]);
 
   const handleSelectedOptions = useCallback((option: string) => {
     const foundOption = extraOptions.find((optionItem) => optionItem.value === option);

--- a/src/components/storyUtils/DatePickerShowcase/DatePickerShowcase.tsx
+++ b/src/components/storyUtils/DatePickerShowcase/DatePickerShowcase.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+import Button from '../../Button';
+import DatePicker from '../../DatePicker';
+
+const DatePickerShowcase: React.FC = () => {
+  const [date, setDate] = useState<{ from?: Date; to?: Date }>({
+    from: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    to: new Date(),
+  });
+
+  const [dateRange, setDateRange] = useState<{ from?: Date; to?: Date }>({
+    from: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    to: new Date(),
+  });
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      <DatePicker
+        value={date}
+        inputProps={{ size: 'md', styleType: 'outlined' }}
+        isDefaultNow={false}
+      />
+      <Button onClick={() => setDate({ from: undefined, to: undefined })}>
+        Reset DatePicker value
+      </Button>
+
+      <hr />
+
+      <DatePicker
+        value={dateRange}
+        inputProps={{ size: 'md', styleType: 'outlined' }}
+        isRangePicker
+        isClearable={true}
+        isDefaultNow={false}
+        dateFormatOverride="MMM D, YYYY"
+      />
+      <Button onClick={() => setDateRange({ from: undefined, to: undefined })}>
+        Reset RangePicker value
+      </Button>
+    </div>
+  );
+};
+
+export default DatePickerShowcase;

--- a/src/components/storyUtils/DatePickerShowcase/index.ts
+++ b/src/components/storyUtils/DatePickerShowcase/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DatePickerShowcase';


### PR DESCRIPTION
[NDS-613](https://orfium.atlassian.net/browse/NDS-613)

## Description

On the current DatePicker component, if you select a date (or range), you cannot reset it's value (`{ from: undefined, to: undefined }`). You can only change it ti another value. This creates problems in scenarios that you want to reset a form and you have already select a value into the DatePicker component. This PR resolves the above issue.

## Screenshot

![chrome-capture-2023-2-15](https://user-images.githubusercontent.com/175707/225361533-5a478648-545a-442a-bccf-6a515cba24d1.gif)


## Test Plan

You must have a "controlled DatePicker" hence the value of the `DatePicker` must be controlled from it's parent component. Then simply reset it's value to ` { from: undefined, to: undefined }`. Everything else must work as expected. 

<!--
  Have any questions? Check out the contributing doc for more
-->


[NDS-613]: https://orfium.atlassian.net/browse/NDS-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ