### PR TITLE
[NDS-623] make notification actions optional [v4.5]

### DIFF
--- a/src/components/Notification/Banner/Banner.tsx
+++ b/src/components/Notification/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { TestId } from '../../../utils/types';
-import { NotificationStyleType, NotificationTypes } from '../Notification';
+import { NotificationActions, NotificationStyleType, NotificationTypes } from '../Notification';
 import CompactNotification from '../subcomponents/CompactNotification';
 
 export type Props = {
@@ -15,15 +15,11 @@ export type Props = {
   type: NotificationTypes;
   /** The style type of the Notification. Defaults to elevated */
   styleType?: NotificationStyleType;
-  /** The primary call-to-action label of the Notification */
-  primaryCTALabel?: string;
-  /** The primary call-to-action of the Notification */
-  primaryCTA?: () => void;
   /** The closing call-to-action of the Notification */
   closeCTA?: () => void;
   /** The data test id if needed */
   dataTestId?: TestId;
-};
+} & Pick<NotificationActions, 'primaryCTALabel' | 'primaryCTA'>;
 
 const Banner: React.FC<Props> = ({
   withIcon = false,

--- a/src/components/Notification/InlineNotification/InlineNotification.tsx
+++ b/src/components/Notification/InlineNotification/InlineNotification.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { TestId } from '../../../utils/types';
-import { NotificationStyleType, NotificationTypes } from '../Notification';
+import { NotificationActions, NotificationStyleType, NotificationTypes } from '../Notification';
 import CompactNotification from '../subcomponents/CompactNotification';
 
 export type Props = {
@@ -13,15 +13,11 @@ export type Props = {
   type: NotificationTypes;
   /** The style type of the Notification. Defaults to elevated */
   styleType?: NotificationStyleType;
-  /** The primary call-to-action label of the Notification */
-  primaryCTALabel?: string;
-  /** The primary call-to-action of the Notification */
-  primaryCTA?: () => void;
   /** The closing call-to-action of the Notification */
   closeCTA?: () => void;
   /** The data test id if needed */
   dataTestId?: TestId;
-};
+} & Pick<NotificationActions, 'primaryCTALabel' | 'primaryCTA'>;
 
 const InlineNotification: React.FC<Props> = ({
   withIcon = false,

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -8,7 +8,9 @@ import Banner from '../Notification/Banner';
 import NotificationsContainer from '../Notification/NotificationsContainer';
 import PresentComponent from '../storyUtils/PresentComponent';
 import Stack from '../storyUtils/Stack';
-import NotificationShowcase, { NotificationContainerWithinDOMElement } from '../storyUtils/NotificationShowcase';
+import NotificationShowcase, {
+  NotificationContainerWithinDOMElement,
+} from '../storyUtils/NotificationShowcase';
 
 <Meta title="Design System/Notification" component={InlineNotification} />
 
@@ -143,7 +145,12 @@ import { NotificationsContainer, Banner } from '@orfium/ictinus';
           />
           <Banner
             withIcon={boolean('icon', true)}
-            message={<div style={{ maxWidth: '404px'}}>This is a very long text in order to check how the component wraps the text.This is a very long text in order to check how the component wraps the text </div>}
+            message={
+              <div style={{ maxWidth: '404px' }}>
+                This is a very long text in order to check how the component wraps the text.This is
+                a very long text in order to check how the component wraps the text{' '}
+              </div>
+            }
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             closeCTA={() => console.log('close action clicked')}
@@ -170,7 +177,7 @@ import { NotificationsContainer, Banner } from '@orfium/ictinus';
 import { Toast, NotificationVisual } from '@orfium/ictinus';
 
 <NotificationsContainer position="bottom-right">
-  <Toast message="message" type="info" expanded closeCTA={closeCTA}>
+  <Toast message="message" type="info" expanded hasMinimumHeight={false} closeCTA={closeCTA}>
     <NotificationVisual
       title="title"
       primaryCTALabel="Primary CTA Label"
@@ -198,6 +205,23 @@ import { Toast, NotificationVisual } from '@orfium/ictinus';
             message={text('message', 'Informative Message')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
             expanded
+            hasMinimumHeight={false}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
+            closeCTA={() => console.log('close action clicked')}
+          >
+            <NotificationVisual
+              title={text('title', 'Message heading')}
+              description={text(
+                'description',
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed viverra neque nec est porttitor'
+              )}
+            />
+          </Toast>
+          <Toast
+            message={text('message', 'Informative Message')}
+            type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+            expanded
+            hasMinimumHeight={false}
             styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
             closeCTA={() => console.log('close action clicked')}
           >
@@ -255,6 +279,16 @@ import { Snackbar } from '@orfium/ictinus';
             'bottom-right'
           )}
         >
+          <Snackbar
+            message={text('message', 'This is the info')}
+            type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
+            styleType={select('styleType', ['outlined', 'elevated'], 'elevated')}
+            description={text(
+              'description',
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed viverra neque nec est porttitor'
+            )}
+            closeCTA={() => console.log('close action clicked')}
+          />
           <Snackbar
             message={text('message', 'This is the info')}
             type={select('type', ['success', 'error', 'info', 'warning'], 'success')}
@@ -429,7 +463,6 @@ import { Snackbar } from '@orfium/ictinus';
     </PresentComponent>
   </Story>
 </Preview>
-
 
 ## Playground 3
 

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -35,7 +35,7 @@ export const actionsContainer = () => (theme: Theme): SerializedStyles => css`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  margin-top: ${theme.spacing.md};
+  padding-top: ${theme.spacing.xl};
   position: sticky;
   bottom: ${theme.spacing.md};
   top: 100%;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -3,3 +3,14 @@ export type NotificationTypes = 'success' | 'error' | 'info' | 'warning';
 export type NotificationVariants = 'inline' | 'banner';
 
 export type NotificationStyleType = 'elevated' | 'outlined';
+
+export type NotificationActions = {
+  /** The primary call-to-action label of the Notification */
+  primaryCTALabel?: string | undefined;
+  /** The primary call-to-action of the Notification */
+  primaryCTA?: (() => void) | undefined;
+  /** The secondary call-to-action label of the Notification */
+  secondaryCTALabel?: string | undefined;
+  /** The secondary call-to-action of the Notification */
+  secondaryCTA?: (() => void) | undefined;
+};

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -6,11 +6,11 @@ export type NotificationStyleType = 'elevated' | 'outlined';
 
 export type NotificationActions = {
   /** The primary call-to-action label of the Notification */
-  primaryCTALabel?: string | undefined;
+  primaryCTALabel?: string;
   /** The primary call-to-action of the Notification */
-  primaryCTA?: (() => void) | undefined;
+  primaryCTA?: () => void;
   /** The secondary call-to-action label of the Notification */
-  secondaryCTALabel?: string | undefined;
+  secondaryCTALabel?: string;
   /** The secondary call-to-action of the Notification */
-  secondaryCTA?: (() => void) | undefined;
+  secondaryCTA?: () => void;
 };

--- a/src/components/Notification/NotificationVisual/NotificationVisual.style.tsx
+++ b/src/components/Notification/NotificationVisual/NotificationVisual.style.tsx
@@ -3,13 +3,19 @@ import { rem } from 'theme/utils';
 
 import { Theme } from '../../../theme';
 
-export const visualContainer = () => (theme: Theme): SerializedStyles => css`
-  margin: ${theme.spacing.md};
-`;
+export const visualContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      padding: ${theme.spacing.md};
+    `;
 
-export const descriptionContainer = () => (theme: Theme): SerializedStyles => css`
-  margin-top: ${theme.spacing.sm};
-  max-height: ${rem(180)};
-  overflow: auto;
-  max-width: fit-content;
-`;
+export const descriptionContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      padding-top: ${theme.spacing.sm};
+      max-height: ${rem(180)};
+      overflow: auto;
+      width: ${rem(547)};
+    `;

--- a/src/components/Notification/NotificationVisual/NotificationVisual.tsx
+++ b/src/components/Notification/NotificationVisual/NotificationVisual.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 import { generateTestDataId } from '../../../utils/helpers';
 import { TestId } from '../../../utils/types';
-import Button from '../../Button';
 import { NotificationActions } from '../Notification';
-import { actionContainer, actionsContainer, boldMessageContainer } from '../Notification.style';
+import { boldMessageContainer } from '../Notification.style';
+import NotificationActionsArea from '../subcomponents/NotificationActionsArea';
 import { visualContainer, descriptionContainer } from './NotificationVisual.style';
 
 export type Props = {
@@ -29,31 +29,27 @@ const NotificationVisual: React.FC<Props> = ({
 
   return (
     <div css={visualContainer()}>
-      <div css={boldMessageContainer()}>{title}</div>
-      <div css={descriptionContainer()}>{description}</div>
+      <div
+        css={boldMessageContainer()}
+        data-testid={generateTestDataId('visual-title', dataTestId)}
+      >
+        {title}
+      </div>
+      <div
+        css={descriptionContainer()}
+        data-testid={generateTestDataId('visual-description', dataTestId)}
+      >
+        {description}
+      </div>
       {hasActions && (
-        <div css={actionsContainer()}>
-          {secondaryCTA && secondaryCTALabel && (
-            <div
-              css={actionContainer()}
-              data-testid={generateTestDataId('visual-secondary', dataTestId)}
-            >
-              <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
-                {secondaryCTALabel}
-              </Button>
-            </div>
-          )}
-          {primaryCTA && primaryCTALabel && (
-            <div
-              css={actionContainer()}
-              data-testid={generateTestDataId('visual-primary', dataTestId)}
-            >
-              <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
-                {primaryCTALabel}
-              </Button>
-            </div>
-          )}
-        </div>
+        <NotificationActionsArea
+          primaryCTA={primaryCTA}
+          primaryCTALabel={primaryCTALabel}
+          secondaryCTA={secondaryCTA}
+          secondaryCTALabel={secondaryCTALabel}
+          dataTestPrefixId="visual"
+          dataTestId={dataTestId}
+        />
       )}
     </div>
   );

--- a/src/components/Notification/NotificationVisual/NotificationVisual.tsx
+++ b/src/components/Notification/NotificationVisual/NotificationVisual.tsx
@@ -3,25 +3,18 @@ import * as React from 'react';
 import { generateTestDataId } from '../../../utils/helpers';
 import { TestId } from '../../../utils/types';
 import Button from '../../Button';
+import { NotificationActions } from '../Notification';
 import { actionContainer, actionsContainer, boldMessageContainer } from '../Notification.style';
 import { visualContainer, descriptionContainer } from './NotificationVisual.style';
 
 export type Props = {
   /** The message heading of the Notification */
   title: string | undefined;
-  /** The primary call-to-action label of the Notification */
-  primaryCTALabel: string | undefined;
-  /** The primary call-to-action of the Notification */
-  primaryCTA: (() => void) | undefined;
-  /** The secondary call-to-action label of the Notification */
-  secondaryCTALabel: string | undefined;
-  /** The secondary call-to-action of the Notification */
-  secondaryCTA: (() => void) | undefined;
   /** The description of the Notification (only for toast) */
   description: string | undefined;
   /** The data test id if needed */
   dataTestId?: TestId;
-};
+} & NotificationActions;
 
 const NotificationVisual: React.FC<Props> = ({
   title,
@@ -32,25 +25,36 @@ const NotificationVisual: React.FC<Props> = ({
   description,
   dataTestId,
 }) => {
+  const hasActions = (primaryCTA && primaryCTALabel) || (secondaryCTA && secondaryCTALabel);
+
   return (
     <div css={visualContainer()}>
       <div css={boldMessageContainer()}>{title}</div>
       <div css={descriptionContainer()}>{description}</div>
-      <div css={actionsContainer()}>
-        <div
-          css={actionContainer()}
-          data-testid={generateTestDataId('visual-secondary', dataTestId)}
-        >
-          <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
-            {secondaryCTALabel}
-          </Button>
+      {hasActions && (
+        <div css={actionsContainer()}>
+          {secondaryCTA && secondaryCTALabel && (
+            <div
+              css={actionContainer()}
+              data-testid={generateTestDataId('visual-secondary', dataTestId)}
+            >
+              <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
+                {secondaryCTALabel}
+              </Button>
+            </div>
+          )}
+          {primaryCTA && primaryCTALabel && (
+            <div
+              css={actionContainer()}
+              data-testid={generateTestDataId('visual-primary', dataTestId)}
+            >
+              <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
+                {primaryCTALabel}
+              </Button>
+            </div>
+          )}
         </div>
-        <div css={actionContainer()} data-testid={generateTestDataId('visual-primary', dataTestId)}>
-          <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
-            {primaryCTALabel}
-          </Button>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/Notification/Snackbar/Snackbar.style.ts
+++ b/src/components/Notification/Snackbar/Snackbar.style.ts
@@ -19,37 +19,43 @@ const snackbarContainerPerType = (
     box-shadow: ${theme.elevation['02']};
 `;
 
-export const cardContainer = (type: NotificationTypes, styleType: NotificationStyleType) => (
-  theme: Theme
-): SerializedStyles => css`
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  padding: ${theme.spacing.md};
-  box-sizing: border-box;
-  min-height: ${rem(164)};
-  max-height: ${rem(294)};
-  border-radius: ${rem(8)};
-  background: ${theme.palette.white};
-  ${snackbarContainerPerType(type, styleType, theme)};
-`;
+export const cardContainer =
+  (type: NotificationTypes, styleType: NotificationStyleType) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      padding: ${theme.spacing.md};
+      box-sizing: border-box;
+      max-height: ${rem(294)};
+      border-radius: ${rem(8)};
+      background: ${theme.palette.white};
+      ${snackbarContainerPerType(type, styleType, theme)};
+    `;
 
-export const topContainer = () => (theme: Theme): SerializedStyles => css`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-bottom: ${theme.spacing.md};
-`;
+export const topContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding-bottom: ${theme.spacing.md};
+    `;
 
-export const infoContainer = () => (): SerializedStyles => css`
-  display: flex;
-  align-items: center;
-`;
+export const infoContainer = () => (): SerializedStyles =>
+  css`
+    display: flex;
+    align-items: center;
+  `;
 
-export const descriptionContainer = () => (theme: Theme): SerializedStyles => css`
-  padding-bottom: ${theme.spacing.md};
-  font-size: ${theme.typography.fontSizes['14']};
-  max-height: ${rem(194)};
-  overflow: auto;
-  max-width: fit-content;
-`;
+export const descriptionContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      font-size: ${theme.typography.fontSizes['14']};
+      max-height: ${rem(194)};
+      overflow: auto;
+      width: ${rem(547)};
+    `;

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -3,15 +3,10 @@ import * as React from 'react';
 import useTheme from '../../../hooks/useTheme';
 import { generateTestDataId } from '../../../utils/helpers';
 import { TestId } from '../../../utils/types';
-import Button from '../../Button';
 import { NotificationActions, NotificationStyleType, NotificationTypes } from '../Notification';
-import {
-  actionContainer,
-  iconContainer,
-  actionsContainer,
-  boldMessageContainer,
-} from '../Notification.style';
+import { actionContainer, iconContainer, boldMessageContainer } from '../Notification.style';
 import { typeToIconName } from '../subcomponents/CompactNotification/CompactNotification';
+import NotificationActionsArea from '../subcomponents/NotificationActionsArea';
 import { cardContainer, topContainer, infoContainer, descriptionContainer } from './Snackbar.style';
 import Icon from 'components/Icon';
 
@@ -63,30 +58,21 @@ const Snackbar: React.FC<Props> = ({
           <Icon name="close" color={utils.getColor('lightGrey', 650)} size={20} />
         </span>
       </div>
-      <div css={descriptionContainer()}>{description}</div>
+      <div
+        css={descriptionContainer()}
+        data-testid={generateTestDataId('snackbar-description', dataTestId)}
+      >
+        {description}
+      </div>
       {hasActions && (
-        <div css={actionsContainer()}>
-          {secondaryCTA && secondaryCTALabel && (
-            <div
-              css={actionContainer()}
-              data-testid={generateTestDataId('snackbar-secondary', dataTestId)}
-            >
-              <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
-                {secondaryCTALabel}
-              </Button>
-            </div>
-          )}
-          {primaryCTA && primaryCTALabel && (
-            <div
-              css={actionContainer()}
-              data-testid={generateTestDataId('snackbar-primary', dataTestId)}
-            >
-              <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
-                {primaryCTALabel}
-              </Button>
-            </div>
-          )}
-        </div>
+        <NotificationActionsArea
+          primaryCTA={primaryCTA}
+          primaryCTALabel={primaryCTALabel}
+          secondaryCTA={secondaryCTA}
+          secondaryCTALabel={secondaryCTALabel}
+          dataTestPrefixId="snackbar"
+          dataTestId={dataTestId}
+        />
       )}
     </div>
   );

--- a/src/components/Notification/Snackbar/Snackbar.tsx
+++ b/src/components/Notification/Snackbar/Snackbar.tsx
@@ -4,7 +4,7 @@ import useTheme from '../../../hooks/useTheme';
 import { generateTestDataId } from '../../../utils/helpers';
 import { TestId } from '../../../utils/types';
 import Button from '../../Button';
-import { NotificationStyleType, NotificationTypes } from '../Notification';
+import { NotificationActions, NotificationStyleType, NotificationTypes } from '../Notification';
 import {
   actionContainer,
   iconContainer,
@@ -22,21 +22,13 @@ export type Props = {
   type: NotificationTypes;
   /** The style type of the Notification. Defaults to elevated */
   styleType?: NotificationStyleType;
-  /** The primary call-to-action label of the Notification */
-  primaryCTALabel: string | undefined;
-  /** The primary call-to-action of the Notification */
-  primaryCTA: (() => void) | undefined;
-  /** The secondary call-to-action label of the Notification */
-  secondaryCTALabel: string | undefined;
-  /** The secondary call-to-action of the Notification */
-  secondaryCTA: (() => void) | undefined;
   /** The description of the Notification (only for toast) */
   description: string | undefined;
   /** The closing call-to-action of the Toast */
   closeCTA: (() => void) | undefined;
   /** The data test id if needed */
   dataTestId?: TestId;
-};
+} & NotificationActions;
 
 const Snackbar: React.FC<Props> = ({
   message,
@@ -51,6 +43,8 @@ const Snackbar: React.FC<Props> = ({
   dataTestId,
 }) => {
   const { utils } = useTheme();
+
+  const hasActions = (primaryCTA && primaryCTALabel) || (secondaryCTA && secondaryCTALabel);
 
   return (
     <div css={cardContainer(type, styleType)} notification-type="snackbar">
@@ -70,24 +64,30 @@ const Snackbar: React.FC<Props> = ({
         </span>
       </div>
       <div css={descriptionContainer()}>{description}</div>
-      <div css={actionsContainer()}>
-        <div
-          css={actionContainer()}
-          data-testid={generateTestDataId('snackbar-secondary', dataTestId)}
-        >
-          <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
-            {secondaryCTALabel}
-          </Button>
+      {hasActions && (
+        <div css={actionsContainer()}>
+          {secondaryCTA && secondaryCTALabel && (
+            <div
+              css={actionContainer()}
+              data-testid={generateTestDataId('snackbar-secondary', dataTestId)}
+            >
+              <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
+                {secondaryCTALabel}
+              </Button>
+            </div>
+          )}
+          {primaryCTA && primaryCTALabel && (
+            <div
+              css={actionContainer()}
+              data-testid={generateTestDataId('snackbar-primary', dataTestId)}
+            >
+              <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
+                {primaryCTALabel}
+              </Button>
+            </div>
+          )}
         </div>
-        <div
-          css={actionContainer()}
-          data-testid={generateTestDataId('snackbar-primary', dataTestId)}
-        >
-          <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
-            {primaryCTALabel}
-          </Button>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.tsx
@@ -5,7 +5,7 @@ import { generateTestDataId } from '../../../../utils/helpers';
 import { TestId } from '../../../../utils/types';
 import Button from '../../../Button';
 import Icon from '../../../Icon';
-import { NotificationStyleType, NotificationTypes } from '../../Notification';
+import { NotificationActions, NotificationStyleType, NotificationTypes } from '../../Notification';
 import { iconContainer, actionContainer } from '../../Notification.style';
 import {
   actionsContainer,
@@ -30,25 +30,15 @@ export type Props = {
   type: NotificationTypes;
   /** The style type of the Notification. Defaults to elevated */
   styleType: NotificationStyleType;
-  /** The primary call-to-action label of the Notification */
-  primaryCTALabel?: string;
-  /** The primary call-to-action of the Notification */
-  primaryCTA?: () => void;
+  /** The description of the Notification (only for toast) */
+  description?: string;
   /** The closing call-to-action of the Notification */
   closeCTA?: () => void;
   /** The title (message heading) of the Notification */
   title?: string;
   /** The data test id if needed */
   dataTestId?: TestId;
-
-  /** The secondary call-to-action label of the Notification */
-  secondaryCTALabel?: string;
-  /** The secondary call-to-action of the Notification */
-  secondaryCTA?: () => void;
-  /** The description of the Notification (only for toast) */
-  description?: string;
-  /** The closing call-to-action of the Toast */
-};
+} & NotificationActions;
 
 export const typeToIconName = (type: NotificationTypes): AcceptedIconNames =>
   type === 'warning' ? 'alert' : type;

--- a/src/components/Notification/subcomponents/NotificationActionsArea/NotificationActionsArea.tsx
+++ b/src/components/Notification/subcomponents/NotificationActionsArea/NotificationActionsArea.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { TestProps } from 'utils/types';
+
+import { generateTestDataId } from '../../../../utils/helpers';
+import Button from '../../../Button';
+import { NotificationActions } from '../../Notification';
+import { actionContainer, actionsContainer } from '../../Notification.style';
+
+type Props = NotificationActions & TestProps;
+
+const NotificationActionsArea: React.FC<Props> = ({
+  primaryCTA,
+  primaryCTALabel,
+  secondaryCTA,
+  secondaryCTALabel,
+  dataTestPrefixId,
+  dataTestId,
+}) => {
+  return (
+    <div css={actionsContainer()}>
+      {secondaryCTA && secondaryCTALabel && (
+        <div
+          css={actionContainer()}
+          data-testid={generateTestDataId(`${dataTestPrefixId}-secondary`, dataTestId)}
+        >
+          <Button type={'link'} transparent size="sm" onClick={secondaryCTA}>
+            {secondaryCTALabel}
+          </Button>
+        </div>
+      )}
+      {primaryCTA && primaryCTALabel && (
+        <div
+          css={actionContainer()}
+          data-testid={generateTestDataId(`${dataTestPrefixId}-primary`, dataTestId)}
+        >
+          <Button type={'link'} transparent size="sm" onClick={primaryCTA}>
+            {primaryCTALabel}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationActionsArea;

--- a/src/components/Notification/subcomponents/NotificationActionsArea/index.ts
+++ b/src/components/Notification/subcomponents/NotificationActionsArea/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NotificationActionsArea';

--- a/src/components/Toast/Toast.style.ts
+++ b/src/components/Toast/Toast.style.ts
@@ -22,57 +22,69 @@ const toastContainerPerType = (
     : `box-shadow: ${theme.elevation['02']}
 `;
 
-export const toastContainer = (
-  type: AcceptedColorComponentTypes,
-  styleType: NotificationStyleType
-) => (theme: Theme): SerializedStyles => css`
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  border-radius: ${rem(8)};
-  ${toastContainerPerType(type, styleType, theme)};
-`;
+export const toastContainer =
+  (type: AcceptedColorComponentTypes, styleType: NotificationStyleType) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      border-radius: ${rem(8)};
+      ${toastContainerPerType(type, styleType, theme)};
+    `;
 
-export const topContainer = (type: AcceptedColorComponentTypes) => (
-  theme: Theme
-): SerializedStyles => css`
-  color: ${theme.palette.white};
-  display: flex;
-  justify-content: space-between;
-  overflow: hidden;
-  height: ${rem(58)};
-  background: ${theme.utils.getColor(type, 500, 'normal')};
-`;
+export const topContainer =
+  (type: AcceptedColorComponentTypes) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      color: ${theme.palette.white};
+      display: flex;
+      justify-content: space-between;
+      overflow: hidden;
+      height: ${rem(58)};
+      background: ${theme.utils.getColor(type, 500, 'normal')};
+    `;
 
-export const infoContainer = () => (theme: Theme): SerializedStyles => css`
-  ${flexCenter};
-  padding: 0 ${theme.spacing.md};
-`;
+export const infoContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      ${flexCenter};
+      padding: 0 ${theme.spacing.md};
+    `;
 
-export const infoIconContainer = () => (theme: Theme): SerializedStyles => css`
-  padding-right: ${theme.spacing.sm};
-`;
+export const infoIconContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      padding-right: ${theme.spacing.sm};
+    `;
 
-export const actionIconsContainer = () => (theme: Theme): SerializedStyles => css`
-  display: flex;
-  align-items: center;
-  padding-right: ${theme.spacing.md};
-`;
+export const actionIconsContainer =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      display: flex;
+      align-items: center;
+      padding-right: ${theme.spacing.md};
+    `;
 
-export const chevronIconContainer = (expanded: boolean) => (): SerializedStyles => css`
-  cursor: pointer;
-  transform: rotate(${expanded ? '180' : '0'}deg);
-  ${transition(0.2)}
-`;
+export const chevronIconContainer = (expanded: boolean) => (): SerializedStyles =>
+  css`
+    cursor: pointer;
+    transform: rotate(${expanded ? '180' : '0'}deg);
+    ${transition(0.2)}
+  `;
 
-export const expandedContainer = (type: AcceptedColorComponentTypes, isExpanded: boolean) => (
-  theme: Theme
-): SerializedStyles => css`
-  ${transition(0.1)};
-  min-height: ${isExpanded ? rem(146) : rem(0)};
-  ${isNotificationTypes(type) ? maxHeightOptions['notification'] : maxHeightOptions['generic']}
-  height: ${!isExpanded ? rem(0) : 'inherit'};
-  font-size: ${theme.typography.fontSizes['14']};
-  position: relative;
-  background: ${theme.palette.white};
-`;
+export const expandedContainer =
+  (type: AcceptedColorComponentTypes, isExpanded: boolean, hasMinimumHeight: boolean) =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      ${transition(0.1)};
+      min-height: ${hasMinimumHeight && isExpanded ? rem(146) : rem(0)};
+      ${isNotificationTypes(type) ? maxHeightOptions['notification'] : maxHeightOptions['generic']}
+      height: ${!isExpanded ? rem(0) : 'inherit'};
+      font-size: ${theme.typography.fontSizes['14']};
+      position: relative;
+      background: ${theme.palette.white};
+    `;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -29,6 +29,8 @@ export type Props = {
   closeCTA: (() => void) | undefined;
   /** Initialize toast as expanded */
   expanded?: boolean;
+  /** If true, the Toast has a minimum-height */
+  hasMinimumHeight?: boolean;
   /** The data test id if needed */
   dataTestId?: TestId;
 };
@@ -43,6 +45,7 @@ const Toast: React.FC<Props> = ({
   styleType = 'elevated',
   closeCTA,
   expanded = false,
+  hasMinimumHeight = true,
   children,
   dataTestId,
 }) => {
@@ -81,7 +84,7 @@ const Toast: React.FC<Props> = ({
         </div>
       </div>
       <div
-        css={expandedContainer(type, isExpanded)}
+        css={expandedContainer(type, isExpanded, hasMinimumHeight)}
         data-testid={generateTestDataId('expanded-container', dataTestId)}
       >
         {children}


### PR DESCRIPTION
## Description

[NDS-623](https://orfium.atlassian.net/browse/NDS-623)

- Make `primaryCTA`, `primaryCTALabel`, `secondaryCTA`, `secondaryCTALabel` optional for all types of Notifications.
- Add `hasMinimumHeight` to Toast component (defaults to `true` so it doesn't break all current usages). This is needed for the Toast Notification in order to support the case of no CTAs. 
- Minor style changes for Notifications to support the case of no CTAs.
- Create `NotificationActionsArea` to reduce duplicate code. This component includes the Actions for `ToastNotification` and `Snackbar`

[NDS-623]: https://orfium.atlassian.net/browse/NDS-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ