### PR TITLE
[FE-58] feat: add useSearchQueryParams hook

### DIFF
--- a/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
+++ b/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
@@ -12795,6 +12795,22 @@ exports[`PaletteShowcase should render correctly 1`] = `
   text-transform: uppercase;
 }
 
+.emotion-693 {
+  width: calc(100% - 20px);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 10px;
+}
+
 .emotion-694 {
   height: 100px;
   background: white;
@@ -12818,6 +12834,21 @@ exports[`PaletteShowcase should render correctly 1`] = `
 
 .emotion-696 {
   font-size: 14px;
+}
+
+.emotion-697 {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
 }
 
 .emotion-698 {
@@ -13578,10 +13609,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
 .emotion-739 div:last-child {
   font-size: 14px;
   text-transform: uppercase;
-}
-
-.emotion-740 {
-  text-transform: capitalize;
 }
 
 .emotion-757 {
@@ -26728,6 +26755,22 @@ exports[`PaletteShowcase should render correctly 1`] = `
   text-transform: uppercase;
 }
 
+.emotion-693 {
+  width: calc(100% - 20px);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 10px;
+}
+
 .emotion-694 {
   height: 100px;
   background: white;
@@ -26751,6 +26794,21 @@ exports[`PaletteShowcase should render correctly 1`] = `
 
 .emotion-696 {
   font-size: 14px;
+}
+
+.emotion-697 {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
 }
 
 .emotion-698 {
@@ -27511,10 +27569,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
 .emotion-739 div:last-child {
   font-size: 14px;
   text-transform: uppercase;
-}
-
-.emotion-740 {
-  text-transform: capitalize;
 }
 
 .emotion-757 {
@@ -31951,7 +32005,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
       Another palette is the pale where is not having shades.
     </p>
     <div
-      class="emotion-5"
+      class="emotion-693"
     >
       <div
         class="emotion-694"
@@ -31966,7 +32020,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
         />
       </div>
       <div
-        class="emotion-9"
+        class="emotion-697"
       >
         <div
           class="emotion-698"
@@ -32225,7 +32279,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               50
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32237,7 +32291,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               100
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32249,7 +32303,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               150
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32261,7 +32315,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               200
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32273,7 +32327,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               250
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32285,7 +32339,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               300
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32297,7 +32351,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               350
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32309,7 +32363,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               400
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32321,7 +32375,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               450
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #fff
             </div>
@@ -32333,7 +32387,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               500
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               white
             </div>
@@ -32345,7 +32399,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               550
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #e5e5e5
             </div>
@@ -32357,7 +32411,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               600
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #ccc
             </div>
@@ -32369,7 +32423,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               650
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #b2b2b2
             </div>
@@ -32381,7 +32435,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               700
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #999
             </div>
@@ -32393,7 +32447,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               750
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #7f7f7f
             </div>
@@ -32405,7 +32459,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               800
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #666
             </div>
@@ -32417,7 +32471,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               850
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #4c4c4c
             </div>
@@ -32429,7 +32483,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               900
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #323232
             </div>
@@ -32441,7 +32495,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               950
             </div>
             <div
-              class="emotion-740"
+              class="emotion-11"
             >
               #191919
             </div>

--- a/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
+++ b/src/components/storyUtils/PaletteShowcase/__snapshots__/PaletteShowcase.test.tsx.snap
@@ -12795,22 +12795,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
   text-transform: uppercase;
 }
 
-.emotion-693 {
-  width: calc(100% - 20px);
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 10px;
-}
-
 .emotion-694 {
   height: 100px;
   background: white;
@@ -12834,21 +12818,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
 
 .emotion-696 {
   font-size: 14px;
-}
-
-.emotion-697 {
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
 }
 
 .emotion-698 {
@@ -13609,6 +13578,10 @@ exports[`PaletteShowcase should render correctly 1`] = `
 .emotion-739 div:last-child {
   font-size: 14px;
   text-transform: uppercase;
+}
+
+.emotion-740 {
+  text-transform: capitalize;
 }
 
 .emotion-757 {
@@ -26755,22 +26728,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
   text-transform: uppercase;
 }
 
-.emotion-693 {
-  width: calc(100% - 20px);
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  margin: 10px;
-}
-
 .emotion-694 {
   height: 100px;
   background: white;
@@ -26794,21 +26751,6 @@ exports[`PaletteShowcase should render correctly 1`] = `
 
 .emotion-696 {
   font-size: 14px;
-}
-
-.emotion-697 {
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
 }
 
 .emotion-698 {
@@ -27569,6 +27511,10 @@ exports[`PaletteShowcase should render correctly 1`] = `
 .emotion-739 div:last-child {
   font-size: 14px;
   text-transform: uppercase;
+}
+
+.emotion-740 {
+  text-transform: capitalize;
 }
 
 .emotion-757 {
@@ -32005,7 +31951,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
       Another palette is the pale where is not having shades.
     </p>
     <div
-      class="emotion-693"
+      class="emotion-5"
     >
       <div
         class="emotion-694"
@@ -32020,7 +31966,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
         />
       </div>
       <div
-        class="emotion-697"
+        class="emotion-9"
       >
         <div
           class="emotion-698"
@@ -32279,7 +32225,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               50
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32291,7 +32237,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               100
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32303,7 +32249,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               150
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32315,7 +32261,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               200
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32327,7 +32273,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               250
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32339,7 +32285,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               300
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32351,7 +32297,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               350
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32363,7 +32309,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               400
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32375,7 +32321,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               450
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #fff
             </div>
@@ -32387,7 +32333,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               500
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               white
             </div>
@@ -32399,7 +32345,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               550
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #e5e5e5
             </div>
@@ -32411,7 +32357,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               600
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #ccc
             </div>
@@ -32423,7 +32369,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               650
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #b2b2b2
             </div>
@@ -32435,7 +32381,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               700
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #999
             </div>
@@ -32447,7 +32393,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               750
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #7f7f7f
             </div>
@@ -32459,7 +32405,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               800
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #666
             </div>
@@ -32471,7 +32417,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               850
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #4c4c4c
             </div>
@@ -32483,7 +32429,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               900
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #323232
             </div>
@@ -32495,7 +32441,7 @@ exports[`PaletteShowcase should render correctly 1`] = `
               950
             </div>
             <div
-              class="emotion-11"
+              class="emotion-740"
             >
               #191919
             </div>

--- a/src/hooks/__snapshots__/useSearchQueryParams.stories.storyshot
+++ b/src/hooks/__snapshots__/useSearchQueryParams.stories.storyshot
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Hooks/useSearchQueryParams useSearchQueryParams 1`] = `
+.emotion-0 {
+  background-color: transparent;
+  color: #000;
+  outline: none;
+  border-radius: 4px;
+}
+
+<div
+  style={
+    Object {
+      "backgroundColor": "#F2F2F2",
+      "flex": 1,
+      "flexDirection": "column",
+      "height": "100vh",
+      "padding": 5,
+      "position": "relative",
+      "width": "100%",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": 15,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "justifyContent": "flex-end",
+        }
+      }
+    >
+      <button
+        className="emotion-0"
+        onClick={[Function]}
+      >
+        turn 
+        dark
+         on
+      </button>
+    </div>
+    <div>
+      <h1>
+        useSearchQueryParams hook
+      </h1>
+      <p
+        style={
+          Object {
+            "background": "#fff",
+            "padding": "1.4rem",
+          }
+        }
+      >
+        Given the url
+         
+        <code>
+          https://orfium-product.com/mypath?page=1&size=12&library=react&testing=yolo
+        </code>
+         the result of this hook is:
+        <pre>
+          <code>
+            {
+  "page": "1",
+  "size": "12",
+  "library": "react",
+  "testing": "yolo"
+}
+          </code>
+        </pre>
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/src/hooks/__snapshots__/useSearchQueryParams.stories.storyshot
+++ b/src/hooks/__snapshots__/useSearchQueryParams.stories.storyshot
@@ -57,10 +57,9 @@ exports[`Storyshots Hooks/useSearchQueryParams useSearchQueryParams 1`] = `
           }
         }
       >
-        Given the url
-         
+        Given the url 
         <code>
-          https://orfium-product.com/mypath?page=1&size=12&library=react&testing=yolo
+          /test?page=1&size=12&library=react&testing=yolo
         </code>
          the result of this hook is:
         <pre>

--- a/src/hooks/__tests__/useSearchQueryParams.test.ts
+++ b/src/hooks/__tests__/useSearchQueryParams.test.ts
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useLocation } from 'react-router-dom';
+
+import { useSearchQueryParams } from '../';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+}));
+
+describe('useSearchQueryParams', () => {
+  it('returns the search query params as an object of key / value strings (Record<string, string>)', () => {
+    (useLocation as jest.Mock).mockReturnValue({
+      search: 'page=1&size=12&library=react&testing=yolo',
+    });
+    const { result } = renderHook(() => useSearchQueryParams());
+
+    expect(result.current).toEqual({ page: '1', size: '12', library: 'react', testing: 'yolo' });
+  });
+
+  it('returns an empty object ({}) if the search query params is an empty string', () => {
+    (useLocation as jest.Mock).mockReturnValue({
+      search: '',
+    });
+    const { result } = renderHook(() => useSearchQueryParams());
+
+    expect(result.current).toEqual({});
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useSearchQueryParams } from './useSearchQueryParams';

--- a/src/hooks/storyUtils/DemoUseSearchQueryParams.tsx
+++ b/src/hooks/storyUtils/DemoUseSearchQueryParams.tsx
@@ -1,17 +1,21 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
+import { withRouter, RouterProps } from 'react-router-dom';
 
 import { useSearchQueryParams } from '../';
 
-const DemoUseSearchQueryParams: FC = () => {
+const DemoUseSearchQueryParams: FC<{ initialEntries: string } & RouterProps> = (props) => {
   const searchQueryParams = useSearchQueryParams();
+  const url = decodeURIComponent(props.initialEntries.replace(/&amp;/g, '&'));
+
+  useEffect(() => {
+    props.history.push(decodeURI(url));
+  }, [props.history, url]);
 
   return (
     <div>
       <h1>useSearchQueryParams hook</h1>
       <p style={{ padding: '1.4rem', background: '#fff' }}>
-        Given the url{' '}
-        <code>https://orfium-product.com/mypath?page=1&size=12&library=react&testing=yolo</code> the
-        result of this hook is:
+        Given the url <code>{url}</code> the result of this hook is:
         <pre>
           <code>{JSON.stringify(searchQueryParams, null, 2)}</code>
         </pre>
@@ -20,4 +24,5 @@ const DemoUseSearchQueryParams: FC = () => {
   );
 };
 
-export default DemoUseSearchQueryParams;
+// @ts-ignore
+export default withRouter(DemoUseSearchQueryParams);

--- a/src/hooks/storyUtils/DemoUseSearchQueryParams.tsx
+++ b/src/hooks/storyUtils/DemoUseSearchQueryParams.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+
+import { useSearchQueryParams } from '../';
+
+const DemoUseSearchQueryParams: FC = () => {
+  const searchQueryParams = useSearchQueryParams();
+
+  return (
+    <div>
+      <h1>useSearchQueryParams hook</h1>
+      <p style={{ padding: '1.4rem', background: '#fff' }}>
+        Given the url{' '}
+        <code>https://orfium-product.com/mypath?page=1&size=12&library=react&testing=yolo</code> the
+        result of this hook is:
+        <pre>
+          <code>{JSON.stringify(searchQueryParams, null, 2)}</code>
+        </pre>
+      </p>
+    </div>
+  );
+};
+
+export default DemoUseSearchQueryParams;

--- a/src/hooks/useSearchQueryParams.stories.mdx
+++ b/src/hooks/useSearchQueryParams.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs';
 import { withKnobs, boolean, array, select, text } from '@storybook/addon-knobs';
-import { withQuery } from '@storybook/addon-queryparams';
 import { MemoryRouter } from 'react-router-dom';
 import DemoUseSearchQueryParams from './storyUtils/DemoUseSearchQueryParams.tsx';
 
@@ -35,7 +34,6 @@ const MyComponent: FC = () => {
       },
     }}
     decorators={[
-      withQuery,
       (Story) => (
         <MemoryRouter initialEntries={['/test?page=1&size=12&library=react&testing=yolo']}>
           <Story />

--- a/src/hooks/useSearchQueryParams.stories.mdx
+++ b/src/hooks/useSearchQueryParams.stories.mdx
@@ -8,7 +8,7 @@ import DemoUseSearchQueryParams from './storyUtils/DemoUseSearchQueryParams.tsx'
 
 # useSearchQueryParams
 
-The useSearchQueryParams hooks, returns the URL search query parameters as a key - value plain object (**Record<string, string>**). Keep in mind that this hook can only be used into a react-router-dom context.
+The useSearchQueryParams hook, returns the URL search query parameters as a key - value plain object (**Record<string, string>**). Keep in mind that this hook can only be used into a react-router-dom context.
 
 # Usage
 

--- a/src/hooks/useSearchQueryParams.stories.mdx
+++ b/src/hooks/useSearchQueryParams.stories.mdx
@@ -25,6 +25,8 @@ const MyComponent: FC = () => {
 
 # useSearchQueryParams demo
 
+This demo represents how the url will be taken into an object. You can play with **knobs** as well for different types of url
+
 <Preview>
   <Story
     name="useSearchQueryParams"
@@ -34,13 +36,15 @@ const MyComponent: FC = () => {
       },
     }}
     decorators={[
-      (Story) => (
-        <MemoryRouter initialEntries={['/test?page=1&size=12&library=react&testing=yolo']}>
-          <Story />
-        </MemoryRouter>
-      ),
+      withKnobs,
+      () => {
+        const value = text('given url', '/test?page=1&size=12&library=react&testing=yolo');
+        return (
+          <MemoryRouter initialEntries={[value]}>
+            <DemoUseSearchQueryParams initialEntries={value} />
+          </MemoryRouter>
+        );
+      },
     ]}
-  >
-    <DemoUseSearchQueryParams />
-  </Story>
+  />
 </Preview>

--- a/src/hooks/useSearchQueryParams.stories.mdx
+++ b/src/hooks/useSearchQueryParams.stories.mdx
@@ -1,0 +1,48 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs';
+import { withKnobs, boolean, array, select, text } from '@storybook/addon-knobs';
+import { withQuery } from '@storybook/addon-queryparams';
+import { MemoryRouter } from 'react-router-dom';
+import DemoUseSearchQueryParams from './storyUtils/DemoUseSearchQueryParams.tsx';
+
+<Meta title="Hooks/useSearchQueryParams" component={() => true} />
+
+# useSearchQueryParams
+
+The useSearchQueryParams hooks, returns the URL search query parameters as a key - value plain object (**Record<string, string>**). Keep in mind that this hook can only be used into a react-router-dom context.
+
+# Usage
+
+```js
+import { useSearchQueryParams } from '@orfium/ictinus/dist/hooks';
+
+const MyComponent: FC = () => {
+  // URL => https://orfium-product.com/mypath?page=1&size=12&library=react&testing=yolo
+  const searchQueryParams = useSearchQueryParams();
+
+  // console.log(searchQueryParams)
+  // { "page": "1", "size": "12", "library": "react", "testing": "yolo" }
+};
+```
+
+# useSearchQueryParams demo
+
+<Preview>
+  <Story
+    name="useSearchQueryParams"
+    parameters={{
+      query: {
+        q: 'search',
+      },
+    }}
+    decorators={[
+      withQuery,
+      (Story) => (
+        <MemoryRouter initialEntries={['/test?page=1&size=12&library=react&testing=yolo']}>
+          <Story />
+        </MemoryRouter>
+      ),
+    ]}
+  >
+    <DemoUseSearchQueryParams />
+  </Story>
+</Preview>

--- a/src/hooks/useSearchQueryParams.ts
+++ b/src/hooks/useSearchQueryParams.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useSearchQueryParams = (): Record<string, string> => {
+  const { search } = useLocation();
+  const urlSearchParams = useMemo(() => new URLSearchParams(search), [search]);
+  const result: Record<string, string> = {};
+
+  urlSearchParams.forEach((value, key) => {
+    result[key] = value;
+  });
+
+  return result;
+};
+
+export default useSearchQueryParams;


### PR DESCRIPTION
## Description

The `useSearchQueryParams` hook, returns the URL search query parameters as a key - value plain object (**Record<string, string>**). Keep in mind that this hook can only be used into a `react-router-dom` context.

## Screenshot

![localhost_6006__path=_docs_hooks-usesearchqueryparams--use-search-query-params](https://user-images.githubusercontent.com/175707/228470994-a6f58907-46d5-4286-aad2-8d5cb987def6.png)


## Test Plan

- Unit testing