### PR TITLE
[NDS-653] feat: rename typography keys [v5]

### DIFF
--- a/src/components/Avatar/Avatar.style.ts
+++ b/src/components/Avatar/Avatar.style.ts
@@ -23,7 +23,7 @@ export const avatarStyle =
       overflow: hidden;
       position: relative;
       font-size: ${tokens.fontSize[size]};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
       align-items: center;
       flex-shrink: 0;
       user-select: none;

--- a/src/components/Avatar/Avatar.tokens.ts
+++ b/src/components/Avatar/Avatar.tokens.ts
@@ -53,12 +53,12 @@ const getTokens = (theme: Theme): AvatarTokens => {
         theme.tokens.palette.get(`accents.${color}.contrast`),
     },
     fontSize: {
-      1: theme.globals.typography.fontSizes.get('1'),
-      2: theme.globals.typography.fontSizes.get('2'),
-      3: theme.globals.typography.fontSizes.get('3'),
-      4: theme.globals.typography.fontSizes.get('4'),
-      5: theme.globals.typography.fontSizes.get('8'),
-      6: theme.globals.typography.fontSizes.get('10'),
+      1: theme.globals.typography.fontSize.get('1'),
+      2: theme.globals.typography.fontSize.get('2'),
+      3: theme.globals.typography.fontSize.get('3'),
+      4: theme.globals.typography.fontSize.get('4'),
+      5: theme.globals.typography.fontSize.get('8'),
+      6: theme.globals.typography.fontSize.get('10'),
     },
   };
 };

--- a/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.style.ts
+++ b/src/components/Breadcrumb/BreadcrumbItem/BreadcrumbItem.style.ts
@@ -14,10 +14,10 @@ export const breadcrumbItemStyles =
     css`
       display: flex;
       cursor: default;
-      font-size: ${theme.globals.typography.fontSizes['15']};
+      font-size: ${theme.globals.typography.fontSize['15']};
       font-weight: ${isActive
-        ? theme.globals.typography.weights.get('medium')
-        : theme.globals.typography.weights.get('regular')};
+        ? theme.globals.typography.fontWeight.get('medium')
+        : theme.globals.typography.fontWeight.get('regular')};
       color: ${isActive
         ? theme.utils.getColor('primary', BASE_SHADE, 'normal')
         : theme.utils.getColor('lightGrey', 650)};

--- a/src/components/Chart/BarChart/components/CustomTooltipContent/CustomTooltipContent.style.ts
+++ b/src/components/Chart/BarChart/components/CustomTooltipContent/CustomTooltipContent.style.ts
@@ -3,7 +3,7 @@ import { rem } from 'theme/utils';
 
 export const tooltipStyle = () => (theme: Theme) => {
   return {
-    fontSize: theme.globals.typography.fontSizes.get('3'),
+    fontSize: theme.globals.typography.fontSize.get('3'),
     padding: `${theme.globals.spacing.get('4')} ${theme.globals.spacing.get('6')}`,
     margin: theme.globals.spacing.get('4'),
     color: theme.globals.colors.white,

--- a/src/components/Chart/DonutChart/components/CustomLabel/CustomLabel.style.ts
+++ b/src/components/Chart/DonutChart/components/CustomLabel/CustomLabel.style.ts
@@ -13,7 +13,7 @@ export const labelUnitStyle =
   (theme: Theme): SerializedStyles =>
     css`
       width: 80%;
-      font-size: ${theme.globals.typography.fontSizes.get('2')};
+      font-size: ${theme.globals.typography.fontSize.get('2')};
       color: ${theme.utils.getColor('lightGrey', 650)};
       text-align: center;
     `;

--- a/src/components/Chart/DonutChart/components/CustomLabel/CustomLabel.tsx
+++ b/src/components/Chart/DonutChart/components/CustomLabel/CustomLabel.tsx
@@ -26,7 +26,7 @@ const CustomLabel: React.FC<CustomLabelProps> = ({ viewBox, value, units }) => {
           x="50%"
           dy="-7"
           alignmentBaseline="middle"
-          fontSize={theme.globals.typography.fontSizes.get('4')}
+          fontSize={theme.globals.typography.fontSize.get('4')}
           fill={theme.globals.colors.black}
         >
           {value}

--- a/src/components/Chart/LineChart/components/CustomTooltip/CustomTooltip.style.ts
+++ b/src/components/Chart/LineChart/components/CustomTooltip/CustomTooltip.style.ts
@@ -3,7 +3,7 @@ import { rem } from 'theme/utils';
 
 export const tooltipStyle = () => (theme: Theme) => {
   return {
-    fontSize: theme.globals.typography.fontSizes.get('3'),
+    fontSize: theme.globals.typography.fontSize.get('3'),
     padding: theme.globals.spacing.get('4'),
     color: theme.globals.colors.white,
     background: theme.utils.getColor('darkGrey', 750),

--- a/src/components/CheckBox/CheckBox.style.ts
+++ b/src/components/CheckBox/CheckBox.style.ts
@@ -121,8 +121,8 @@ export const labelStyle =
   (theme: Theme): SerializedStyles =>
     css`
       padding-left: ${rem(4)};
-      font-size: ${theme.globals.typography.fontSizes['15']};
-      font-weight: ${theme.globals.typography.weights.get('regular')};
+      font-size: ${theme.globals.typography.fontSize['15']};
+      font-weight: ${theme.globals.typography.fontWeight.get('regular')};
       color: ${theme.utils.getColor('darkGrey', 750)};
       white-space: nowrap;
     `;

--- a/src/components/Chip/Chip.style.ts
+++ b/src/components/Chip/Chip.style.ts
@@ -22,8 +22,8 @@ export const chipStyle =
       ${flexCenterVertical};
       height: ${theme.globals.spacing.get('8')};
       border-radius: ${theme.globals.spacing.get('8')};
-      font-size: ${theme.globals.typography.fontSizes.get('2')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-size: ${theme.globals.typography.fontSize.get('2')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
       line-height: normal;
       box-sizing: border-box;
       padding: ${theme.globals.spacing.get('3')} ${theme.globals.spacing.get('4')};

--- a/src/components/Chip/components/Badge/Badge.style.ts
+++ b/src/components/Chip/components/Badge/Badge.style.ts
@@ -15,8 +15,8 @@ export const badgeStyle =
       background: ${isSelected
         ? theme.utils.getColor(fill, 550)
         : theme.utils.getColor('lightGrey', 200)};
-      font-size: ${theme.globals.typography.fontSizes.get('1')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-size: ${theme.globals.typography.fontSize.get('1')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
       align-items: center;
       flex-shrink: 0;
       line-height: normal;

--- a/src/components/DatePicker/Month/Month.style.ts
+++ b/src/components/DatePicker/Month/Month.style.ts
@@ -20,9 +20,9 @@ export const weekDayStyle =
       color: ${theme.utils.getColor('lightGrey', 650)};
       padding: ${theme.globals.spacing.get('6')} 0;
       width: ${rem(39)};
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
       text-align: center;
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
     `;
 
 export const datesWrapperStyle =

--- a/src/components/DatePicker/OverlayComponent/OverlayComponent.style.ts
+++ b/src/components/DatePicker/OverlayComponent/OverlayComponent.style.ts
@@ -27,12 +27,12 @@ export const optionStyle =
       white-space: nowrap;
       padding: ${theme.globals.spacing.get('6')};
       font-weight: ${isSelected
-        ? theme.globals.typography.weights.get('medium')
-        : theme.globals.typography.weights.get('regular')};
+        ? theme.globals.typography.fontWeight.get('medium')
+        : theme.globals.typography.fontWeight.get('regular')};
       cursor: pointer;
       background-color: ${isSelected ? theme.utils.getColor('blue', 50) : 'transparent'};
       position: relative;
-      font-size: ${theme.globals.typography.fontSizes['13']};
+      font-size: ${theme.globals.typography.fontSize['13']};
 
       &:hover {
         background-color: ${theme.utils.getColor('lightGrey', 50)};

--- a/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.style.ts
+++ b/src/components/DatePicker/OverlayComponent/components/MonthWrapper/MonthWrapper.style.ts
@@ -54,6 +54,6 @@ export const monthHeaderTitleStyle =
       display: flex;
       justify-content: center;
       cursor: ${!isRangePicker && 'pointer'};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
       color: ${theme.utils.getColor('darkGrey', 850)};
     `;

--- a/src/components/Drawer/Navigation/Navigation.style.ts
+++ b/src/components/Drawer/Navigation/Navigation.style.ts
@@ -40,7 +40,7 @@ export const menuItemStyle =
       ${itemStyle(theme)};
       width: 100%;
       font-size: ${rem(16)};
-      font-weight: ${theme.globals.typography.weights.get('regular')};
+      font-weight: ${theme.globals.typography.fontWeight.get('regular')};
       padding: 0 ${theme.globals.spacing.get('6')};
       background: transparent;
       border: 0 solid transparent;
@@ -70,7 +70,7 @@ export const menuItemTextStyle =
   (theme: Theme): SerializedStyles =>
     css`
       ${transition(0.2)};
-      font-weight: ${isCurrent ? theme.globals.typography.weights.get('bold') : 'initial'};
+      font-weight: ${isCurrent ? theme.globals.typography.fontWeight.get('bold') : 'initial'};
     `;
 
 export const subMenuLinkStyle =
@@ -80,7 +80,7 @@ export const subMenuLinkStyle =
   ${itemStyle(theme)};
   ${transition(0.2)};
   box-sizing: border-box;
-  font-size: ${theme.globals.typography.fontSizes.get('3')};
+  font-size: ${theme.globals.typography.fontSize.get('3')};
   color: ${theme.utils.getColor('darkGrey', 850)};
   margin: ${theme.globals.spacing.get('3')} 0 ${theme.globals.spacing.get('3')} 0;
   padding-left: ${rem(ICON_PADDING)};
@@ -92,7 +92,7 @@ export const subMenuLinkStyle =
     background-color: ${getPressed({ theme, color: 'blue', shade: 50 }).backgroundColor} !important;
   }
   &.active  {
-    font-weight: ${theme.globals.typography.weights.get('bold')};
+    font-weight: ${theme.globals.typography.fontWeight.get('bold')};
     background-color: ${getPressed({ theme, color: 'blue' }).backgroundColor} !important;
     color: ${theme.utils.getAAColor(getPressed({ theme, color: 'blue' }).backgroundColor)};
 

--- a/src/components/Filter/Filter.style.ts
+++ b/src/components/Filter/Filter.style.ts
@@ -97,7 +97,7 @@ export const buttonBaseStyle =
   }: ButtonStyleProps) =>
   (theme: Theme) => {
     return {
-      fontSize: theme.globals.typography.fontSizes['13'],
+      fontSize: theme.globals.typography.fontSize['13'],
       cursor: isDisabled ? 'not-allowed' : 'pointer',
       height: '100%',
       opacity: isDisabled ? 0.5 : 1,
@@ -219,15 +219,15 @@ export const labelSpanStyle = (isOpen: boolean, hasSelectedValue: boolean) => (t
   return {
     fontWeight:
       isOpen || hasSelectedValue
-        ? theme.globals.typography.weights.get('bold')
-        : theme.globals.typography.weights.get('regular'),
+        ? theme.globals.typography.fontWeight.get('bold')
+        : theme.globals.typography.fontWeight.get('regular'),
     display: 'flex',
     alignItems: 'center',
     div: {
       flex: 'none',
     },
     span: {
-      fontWeight: theme.globals.typography.weights.get('bold'),
+      fontWeight: theme.globals.typography.fontWeight.get('bold'),
     },
   };
 };

--- a/src/components/Filter/components/Options/Options.style.ts
+++ b/src/components/Filter/components/Options/Options.style.ts
@@ -8,6 +8,6 @@ export const emptyStyle = () => (theme: Theme) =>
     color: ${theme.utils.getColor('lightGrey', 750)};
     height: ${rem(48)};
     padding: 0 ${rem(16)};
-    font-size: ${theme.globals.typography.fontSizes.get('3')};
+    font-size: ${theme.globals.typography.fontSize.get('3')};
     ${flexCenter};
   `;

--- a/src/components/Label/Label.style.ts
+++ b/src/components/Label/Label.style.ts
@@ -19,8 +19,8 @@ export const labelStyle =
       transform: ${!isAnimated
         ? `translate(${LABEL_TRANSFORM_LEFT_SPACING}, 0)`
         : `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -95%) scale(0.8);`};
-      font-size: ${theme.globals.typography.fontSizes.get('4')};
-      font-weight: ${theme.globals.typography.weights.get('regular')};
+      font-size: ${theme.globals.typography.fontSize.get('4')};
+      font-weight: ${theme.globals.typography.fontWeight.get('regular')};
       color: ${hasError
         ? theme.utils.getColor('error', BASE_SHADE, 'normal')
         : theme.utils.getColor('lightGrey', 650)};

--- a/src/components/List/List.style.ts
+++ b/src/components/List/List.style.ts
@@ -36,8 +36,8 @@ export const listStyle =
     `;
 
 export const listLabelHelperText = (theme: Theme): SerializedStyles => css`
-  font-size: ${theme.globals.typography.fontSizes.get('1')};
-  font-weight: ${theme.globals.typography.weights.get('regular')};
+  font-size: ${theme.globals.typography.fontSize.get('1')};
+  font-weight: ${theme.globals.typography.fontWeight.get('regular')};
   color: ${theme.utils.getColor('lightGrey', 650)};
   cursor: inherit;
 `;

--- a/src/components/List/ListItem/ListItem.style.ts
+++ b/src/components/List/ListItem/ListItem.style.ts
@@ -21,7 +21,7 @@ export const listItemStyle =
   (theme: Theme): SerializedStyles =>
     css`
       height: ${size === 'normal' ? rem(56) : rem(46)};
-      font-size: ${theme.globals.typography.fontSizes.get(size === 'normal' ? '4' : '3')};
+      font-size: ${theme.globals.typography.fontSize.get(size === 'normal' ? '4' : '3')};
       background-color: ${isSelected
         ? theme.utils.getColor('blue', 50)
         : theme.globals.colors.white};
@@ -29,7 +29,7 @@ export const listItemStyle =
       align-items: center;
       padding: 0px ${theme.globals.spacing.get('6')} 0px
         ${isGroupItem ? theme.globals.spacing.get('9') : theme.globals.spacing.get('6')};
-      font-weight: ${isSelected && theme.globals.typography.weights.get('medium')};
+      font-weight: ${isSelected && theme.globals.typography.fontWeight.get('medium')};
       cursor: pointer;
 
       ${isHighlighted && 'font-weight: 500;'}

--- a/src/components/List/ListItemGroup/ListGroupTitle/ListGroupTitle.style.ts
+++ b/src/components/List/ListItemGroup/ListGroupTitle/ListGroupTitle.style.ts
@@ -9,13 +9,13 @@ export const listGroupTitleStyle =
   (theme: Theme): SerializedStyles =>
     css`
       height: ${size === 'normal' ? rem(56) : rem(46)};
-      font-size: ${theme.globals.typography.fontSizes[size === 'normal' ? '13' : '11']};
+      font-size: ${theme.globals.typography.fontSize[size === 'normal' ? '13' : '11']};
       background-color: ${theme.globals.colors.white};
       color: ${theme.utils.getColor('lightGrey', 650)};
       display: flex;
       align-items: center;
       padding: 0px ${theme.globals.spacing.get('6')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
 
       ${isDisabled &&
       `

--- a/src/components/Modal/ModalContent/ModalContent.style.ts
+++ b/src/components/Modal/ModalContent/ModalContent.style.ts
@@ -11,23 +11,23 @@ export const modalContentContainer = (theme: Theme): SerializedStyles => css`
   flex-wrap: wrap;
   text-align: left;
   color: ${theme.utils.getColor('lightGrey', 700, 'flat')};
-  font-weight: ${theme.globals.typography.weights.get('regular')};
+  font-weight: ${theme.globals.typography.fontWeight.get('regular')};
 `;
 
 export const labelContainer = (theme: Theme): SerializedStyles => css`
-  font-size: ${theme.globals.typography.fontSizes.get('3')};
+  font-size: ${theme.globals.typography.fontSize.get('3')};
   margin: 0 0 ${theme.globals.spacing.get('3')} 0;
 `;
 
 export const headingContainer = (theme: Theme): SerializedStyles => css`
-  font-size: ${theme.globals.typography.fontSizes.get('9')};
+  font-size: ${theme.globals.typography.fontSize.get('9')};
   color: ${theme.utils.getColor('darkGrey', 850)};
-  font-weight: ${theme.globals.typography.weights.get('medium')};
+  font-weight: ${theme.globals.typography.fontWeight.get('medium')};
   margin: 0 0 ${theme.globals.spacing.get('9')} 0;
 `;
 
 export const messageContainer = (theme: Theme): SerializedStyles => css`
-  font-size: ${theme.globals.typography.fontSizes.get('4')};
+  font-size: ${theme.globals.typography.fontSize.get('4')};
   color: ${theme.utils.getColor('lightGrey', 750)};
   max-height: ${rem(430)};
   overflow-y: hidden;

--- a/src/components/Notification/Notification.style.ts
+++ b/src/components/Notification/Notification.style.ts
@@ -63,5 +63,5 @@ export const boldMessageContainer =
   () =>
   (theme: Theme): SerializedStyles =>
     css`
-      font-weight: ${theme.globals.typography.weights.get('bold')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
     `;

--- a/src/components/Notification/Snackbar/Snackbar.style.ts
+++ b/src/components/Notification/Snackbar/Snackbar.style.ts
@@ -54,7 +54,7 @@ export const descriptionContainer =
   () =>
   (theme: Theme): SerializedStyles =>
     css`
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
       max-height: ${rem(194)};
       overflow: auto;
       width: ${rem(547)};

--- a/src/components/Notification/subcomponents/CompactNotification/CompactNotification.style.ts
+++ b/src/components/Notification/subcomponents/CompactNotification/CompactNotification.style.ts
@@ -17,7 +17,7 @@ export const notificationsContainer =
       min-height: ${rem(46)};
       border-radius: ${theme.globals.spacing.get('3')};
       color: ${theme.utils.getColor('darkGrey', 850)};
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
       ${notificationsContainerPerType(type, styleType, theme)};
     `;
 
@@ -44,7 +44,7 @@ export const actionsContainer =
       display: flex;
       align-items: center;
       padding-right: ${theme.globals.spacing.get('6')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
     `;
 
 export const headContainer =
@@ -52,7 +52,7 @@ export const headContainer =
   (theme: Theme): SerializedStyles =>
     css`
       padding-right: ${theme.globals.spacing.get('3')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
     `;
 
 export const primaryActionContainer = () => (): SerializedStyles =>

--- a/src/components/Select/components/MultiselectTextField/MultiselectTextField.style.ts
+++ b/src/components/Select/components/MultiselectTextField/MultiselectTextField.style.ts
@@ -71,7 +71,7 @@ export const textInputBaseOverrides =
   ({ hasValue, isLoading }: { hasValue: boolean; isLoading?: boolean }) =>
   (theme: Theme) => {
     const labelStyles = {
-      fontWeight: `${theme.globals.typography.weights.get('bold')} !important` as any,
+      fontWeight: `${theme.globals.typography.fontWeight.get('bold')} !important` as any,
       transform: `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -82%) scale(0.8) !important`,
       bottom: 'auto',
     };

--- a/src/components/Select/components/SelectMenu/SelectMenu.style.tsx
+++ b/src/components/Select/components/SelectMenu/SelectMenu.style.tsx
@@ -18,7 +18,7 @@ export const optionStyle =
   (theme: Theme): SerializedStyles => {
     return css`
       padding: ${theme.globals.spacing.get('6')};
-      font-size: ${theme.globals.typography.fontSizes.get(size === 'md' ? '4' : '3')};
+      font-size: ${theme.globals.typography.fontSize.get(size === 'md' ? '4' : '3')};
       background-color: ${isSelected
         ? darken(0.07, theme.globals.colors.white)
         : theme.globals.colors.white};

--- a/src/components/Slider/components/SliderMark/SliderMark.style.tsx
+++ b/src/components/Slider/components/SliderMark/SliderMark.style.tsx
@@ -24,7 +24,7 @@ export const Mark = styled.div<{
       color: white;
       display: ${({ isDisabled }) => (isDisabled ? 'none' : 'flex')};
       justify-content: center;
-      font-size: ${({ theme }) => theme.globals.typography.fontSizes[11]};
+      font-size: ${({ theme }) => theme.globals.typography.fontSize[11]};
       background: black;
       position: absolute;
       padding: ${({ theme }) => theme.globals.spacing.get('4')};

--- a/src/components/Switch/Switch.style.tsx
+++ b/src/components/Switch/Switch.style.tsx
@@ -41,6 +41,6 @@ export const SwitchWrapper = styled.div<{ isChecked: boolean; isDisabled: boolea
 `;
 
 export const Label = styled.span`
-  font-size: ${({ theme }) => theme.globals.typography.fontSizes[15]};
+  font-size: ${({ theme }) => theme.globals.typography.fontSize[15]};
   color: ${({ theme }) => theme.utils.getColor('darkGrey', 850)};
 `;

--- a/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.style.tsx
+++ b/src/components/Table/components/ExtendedColumnItem/ExtendedColumnItem.style.tsx
@@ -15,6 +15,6 @@ export const contentStyles =
   () =>
   (theme: Theme): SerializedStyles =>
     css`
-      font-weight: ${theme.globals.typography.weights.get('medium')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
       color: ${theme.utils.getColor('lightGrey', 750)};
     `;

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.style.ts
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.style.ts
@@ -6,7 +6,7 @@ export const nestedHeaderStyle =
   (theme: Theme): SerializedStyles =>
     css({
       color: theme.utils.getColor('lightGrey', 750),
-      fontSize: theme.globals.typography.fontSizes.get('2'),
+      fontSize: theme.globals.typography.fontSize.get('2'),
       paddingBottom: theme.globals.spacing.get('3'),
-      fontWeight: theme.globals.typography.weights.get('bold'),
+      fontWeight: theme.globals.typography.fontWeight.get('bold'),
     });

--- a/src/components/Table/components/TableCell/TableCell.tsx
+++ b/src/components/Table/components/TableCell/TableCell.tsx
@@ -60,8 +60,8 @@ const TableCell: React.FC<TableCellProps> = React.memo(
           component === 'th' && {
             paddingTop: theme.globals.spacing.get('4'),
             paddingBottom: theme.globals.spacing.get('4'),
-            fontWeight: theme.globals.typography.weights.get('bold'),
-            fontSize: theme.globals.typography.fontSizes.get('3'),
+            fontWeight: theme.globals.typography.fontWeight.get('bold'),
+            fontSize: theme.globals.typography.fontSize.get('3'),
           },
           component === 'th' && isSortable && { ...parentStyles({ isActive })(theme) },
           isSticky && {

--- a/src/components/TextInputBase/TextInputBase.style.ts
+++ b/src/components/TextInputBase/TextInputBase.style.ts
@@ -144,13 +144,13 @@ export const inputStyle =
       position: 'relative',
       top: label ? rem(7) : undefined,
       zIndex: 1,
-      fontSize: theme.globals.typography.fontSizes[size === 'md' ? '15' : '13'],
+      fontSize: theme.globals.typography.fontSize[size === 'md' ? '15' : '13'],
       textOverflow: 'ellipsis',
       width: 0,
       minWidth: '100%',
 
       '& + label': {
-        fontSize: theme.globals.typography.fontSizes[size === 'md' ? '15' : '13'],
+        fontSize: theme.globals.typography.fontSize[size === 'md' ? '15' : '13'],
       },
 
       '&:focus': {
@@ -170,7 +170,7 @@ export const inputStyle =
       '&:focus, &:not(:placeholder-shown)': {
         '& + label': {
           transform: `translate(${LABEL_TRANSFORM_LEFT_SPACING}, -35%) scale(0.8)`,
-          fontWeight: theme.globals.typography.weights.get('bold'),
+          fontWeight: theme.globals.typography.fontWeight.get('bold'),
         },
       },
 
@@ -189,7 +189,7 @@ export const errorMsgStyle =
         status === 'error'
           ? theme.utils.getColor('error', 550, 'normal')
           : theme.utils.getColor('lightGrey', 650),
-      fontSize: theme.globals.typography.fontSizes.get('2'),
+      fontSize: theme.globals.typography.fontSize.get('2'),
       lineHeight: 1,
       padding: `${rem(8)} 0 0`,
       svg: {

--- a/src/components/Toast/Toast.style.ts
+++ b/src/components/Toast/Toast.style.ts
@@ -84,7 +84,7 @@ export const expandedContainer =
       min-height: ${hasMinimumHeight && isExpanded ? rem(146) : rem(0)};
       ${isNotificationTypes(type) ? maxHeightOptions['notification'] : maxHeightOptions['generic']}
       height: ${!isExpanded ? rem(0) : 'inherit'};
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
       position: relative;
       background: ${theme.globals.colors.white};
     `;

--- a/src/components/Tooltip/Tooltip.style.ts
+++ b/src/components/Tooltip/Tooltip.style.ts
@@ -14,12 +14,12 @@ export const tooltipStyle =
 
     const defineFontSizeBasedOnTooltipSize = (size: TooltipSize) => {
       if (size === 'large') {
-        return theme.globals.typography.fontSizes.get('4');
+        return theme.globals.typography.fontSize.get('4');
       } else if (size === 'small') {
-        return theme.globals.typography.fontSizes.get('2');
+        return theme.globals.typography.fontSize.get('2');
       }
 
-      return theme.globals.typography.fontSizes.get('3');
+      return theme.globals.typography.fontSize.get('3');
     };
 
     return css`
@@ -31,7 +31,7 @@ export const tooltipStyle =
         max-width: ${rem(256)};
         padding: ${theme.globals.spacing.get('4')};
         font-size: ${defineFontSizeBasedOnTooltipSize(size)};
-        font-weight: ${theme.globals.typography.weights.get('regular')};
+        font-weight: ${theme.globals.typography.fontWeight.get('regular')};
         line-height: 110%;
         border-radius: ${theme.globals.spacing.get('4')};
         text-align: start;

--- a/src/components/TopAppBar/components/UserMenu/UserMenu.style.ts
+++ b/src/components/TopAppBar/components/UserMenu/UserMenu.style.ts
@@ -3,7 +3,7 @@ import { css, SerializedStyles } from '@emotion/react';
 import { Theme } from '../../../../theme';
 
 const buttonTextStyle = (theme: Theme): SerializedStyles => css`
-  font-weight: ${theme.globals.typography.weights.get('medium')};
+  font-weight: ${theme.globals.typography.fontWeight.get('medium')};
 `;
 
 export default {

--- a/src/components/Typography/Typography.style.ts
+++ b/src/components/Typography/Typography.style.ts
@@ -8,105 +8,105 @@ export const typographyWrapper =
   (theme: Theme): SerializedStyles => {
     // headlines
     const headline01 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('10')};
-      font-size: ${theme.globals.typography.fontSizes.get('9')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('0')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('10')};
+      font-size: ${theme.globals.typography.fontSize.get('9')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('0')};
     `;
     const headline02 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('9')};
-      font-size: ${theme.globals.typography.fontSizes.get('8')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('0')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('9')};
+      font-size: ${theme.globals.typography.fontSize.get('8')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('0')};
     `;
     const headline03 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('8')};
-      font-size: ${theme.globals.typography.fontSizes.get('7')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('0')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('8')};
+      font-size: ${theme.globals.typography.fontSize.get('7')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('0')};
     `;
     const headline04 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('7')};
-      font-size: ${theme.globals.typography.fontSizes.get('6')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('0')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('7')};
+      font-size: ${theme.globals.typography.fontSize.get('6')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('0')};
     `;
     const headline05 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('6')};
-      font-size: ${theme.globals.typography.fontSizes.get('5')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('0')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('6')};
+      font-size: ${theme.globals.typography.fontSize.get('5')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('0')};
     `;
     // titles
     const title01 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('5')};
-      font-size: ${theme.globals.typography.fontSizes.get('4')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('1')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('5')};
+      font-size: ${theme.globals.typography.fontSize.get('4')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('1')};
     `;
     const title02 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('4')};
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('1')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('4')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('1')};
     `;
     const title03 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('3')};
-      font-size: ${theme.globals.typography.fontSizes.get('1')};
-      font-weight: ${theme.globals.typography.weights.get('bold')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('2')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('1')};
+      font-weight: ${theme.globals.typography.fontWeight.get('bold')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('2')};
     `;
     // labels
     const label01 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('5')};
-      font-size: ${theme.globals.typography.fontSizes.get('4')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('1')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('5')};
+      font-size: ${theme.globals.typography.fontSize.get('4')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('1')};
     `;
     const label02 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('4')};
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('2')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('4')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('2')};
     `;
     const label03 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('3')};
-      font-size: ${theme.globals.typography.fontSizes.get('1')};
-      font-weight: ${theme.globals.typography.weights.get('medium')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('2')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('1')};
+      font-weight: ${theme.globals.typography.fontWeight.get('medium')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('2')};
     `;
     // body
     const body01 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('5')};
-      font-size: ${theme.globals.typography.fontSizes.get('4')};
-      font-weight: ${theme.globals.typography.weights.get('regular')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('2')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('5')};
+      font-size: ${theme.globals.typography.fontSize.get('4')};
+      font-weight: ${theme.globals.typography.fontWeight.get('regular')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('2')};
     `;
     const body02 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('4')};
-      font-size: ${theme.globals.typography.fontSizes.get('3')};
-      font-weight: ${theme.globals.typography.weights.get('regular')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('2')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('4')};
+      font-size: ${theme.globals.typography.fontSize.get('3')};
+      font-weight: ${theme.globals.typography.fontWeight.get('regular')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('2')};
     `;
     const body03 = css`
-      font-family: ${theme.globals.typography.fontFamilies.get('roboto')};
-      line-height: ${theme.globals.typography.lineHeights.get('3')};
-      font-size: ${theme.globals.typography.fontSizes.get('1')};
-      font-weight: ${theme.globals.typography.weights.get('regular')};
-      letter-spacing: ${theme.globals.typography.letterSpacings.get('2')};
+      font-family: ${theme.globals.typography.fontFamily.get('roboto')};
+      line-height: ${theme.globals.typography.lineHeight.get('3')};
+      font-size: ${theme.globals.typography.fontSize.get('1')};
+      font-weight: ${theme.globals.typography.fontWeight.get('regular')};
+      letter-spacing: ${theme.globals.typography.letterSpacing.get('2')};
     `;
 
     const allStyles = {

--- a/src/components/storyUtils/PaletteShowcase/PaletteShowcase.style.tsx
+++ b/src/components/storyUtils/PaletteShowcase/PaletteShowcase.style.tsx
@@ -20,8 +20,8 @@ export const paletteColorWrapper = css`
 export const colorNameBox = (
   theme: Theme,
   color: string,
-  colorName?: typeof flatColors[number],
-  shade?: typeof colorShades[number]
+  colorName?: (typeof flatColors)[number],
+  shade?: (typeof colorShades)[number]
 ): SerializedStyles => css`
   height: 100px;
   background: ${color};
@@ -46,8 +46,8 @@ export const colorBoxWrapper = css`
 type ColorBoxProps = {
   theme: Theme;
   color: string;
-  colorName?: typeof flatColors[number];
-  shade?: typeof colorShades[number];
+  colorName?: (typeof flatColors)[number];
+  shade?: (typeof colorShades)[number];
   isSelectedColor: boolean;
   isHoverable?: boolean;
 };
@@ -86,6 +86,6 @@ export const colorBox = ({
 
   div:last-child {
     font-size: 14px;
-    text-transform: ${theme.globals.typography.textCases.get('uppercase')};
+    text-transform: ${theme.globals.typography.textCase.get('uppercase')};
   }
 `;

--- a/src/theme/globals/typography.ts
+++ b/src/theme/globals/typography.ts
@@ -52,17 +52,17 @@ export type TextDecoration = {
 
 export type Typography = {
   globalFontSize: number;
-  fontSizes: FontSize;
-  weights: FontWeight;
-  fontFamilies: FontFamily;
-  fontFamily: string;
-  lineHeights: LineHeight;
-  letterSpacings: LetterSpacing;
-  textCases: TextCase;
-  textDecorations: TextDecoration;
+  fontSize: FontSize;
+  fontWeight: FontWeight;
+  fontFamily: FontFamily;
+  defaultFontFamily: string;
+  lineHeight: LineHeight;
+  letterSpacing: LetterSpacing;
+  textCase: TextCase;
+  textDecoration: TextDecoration;
 };
 
-const fontSizes: FontSize = {
+const fontSize: FontSize = {
   get: getFigmaTokensValue<FontSizeKey>(fontSizeFigma, FigmaTokenValueType.Pixels),
   /** @TODO remove this custom font-sizes */
   '8': rem('8px'),
@@ -71,42 +71,41 @@ const fontSizes: FontSize = {
   '15': rem('15px'),
 };
 
-const weights: FontWeight = {
+const fontWeight: FontWeight = {
   get: getFigmaTokensValue<FontWeightKey>(fontWeightFigma, FigmaTokenValueType.Number),
 };
 
-const fontFamilies: FontFamily = {
+const fontFamily: FontFamily = {
   get: getFigmaTokensValue<FontFamilyKey>(fontFamilyFigma, FigmaTokenValueType.String),
 };
 
-const lineHeights: LineHeight = {
+const lineHeight: LineHeight = {
   get: getFigmaTokensValue<LineHeightKey>(lineHeightFigma, FigmaTokenValueType.Pixels),
 };
 
-const letterSpacings: LetterSpacing = {
+const letterSpacing: LetterSpacing = {
   get: getFigmaTokensValue<LetterSpacingKey>(letterSpacingFigma, FigmaTokenValueType.String),
 };
 
-const textCases: TextCase = {
+const textCase: TextCase = {
   get: getFigmaTokensValue<TextCaseKey>(textCaseFigma, FigmaTokenValueType.String),
 };
 
-const textDecorations: TextDecoration = {
+const textDecoration: TextDecoration = {
   get: getFigmaTokensValue<TextDecorationKey>(textDecorationFigma, FigmaTokenValueType.String),
 };
 
-const defaultFontFamily = fontFamilies.get('roboto');
-
+const defaultFontFamily = fontFamily.get('roboto');
 const typography: Typography = {
   globalFontSize: 16, // @deprecated Use fontSize.get instead
-  fontSizes,
-  weights,
-  fontFamilies,
-  fontFamily: defaultFontFamily,
-  lineHeights,
-  letterSpacings,
-  textCases,
-  textDecorations,
+  fontSize,
+  fontWeight,
+  fontFamily,
+  defaultFontFamily,
+  lineHeight,
+  letterSpacing,
+  textCase,
+  textDecoration,
 };
 
 export default typography;


### PR DESCRIPTION
## Description

[NDS-653](https://orfium.atlassian.net/browse/NDS-653)

Rename theme typography keys to match the figma tokens:

- `fontSizes` => `fontSize`
- `weights` => `fontWeight`
- `fontFamilies` => `fontFamily`
- `fontFamily` => `defaultFontFamily`
- `lineHeights` => `lineHeight`
- `letterSpacings` => `letterSpacing`
- `textCases` => `textCase`
- `textDecorations` => `textDecoration`

[NDS-653]: https://orfium.atlassian.net/browse/NDS-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ