### PR TITLE
[NDS-698] fix(SearchField): add unique case of 36 height on small size

### DIFF
--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -31,6 +31,17 @@ const SearchField = React.forwardRef<HTMLInputElement, Props & TextFieldProps & 
     } = props;
 
     const shouldShowClear = (value as string).length > 0;
+    const sx = {
+      wrapper: {
+        borderRadius: rem(100),
+        // @TODO this is a unique case for the SearchField where we dont need to use the sm height of the TextField, will change in v5
+        height: size === 'sm' ? rem(36) : getTextFieldHeight(size),
+      },
+      input: {
+        // @TODO this is a unique case for the SearchField where we dont need to use the sm fontSize of the TextField, will change in v5
+        fontSize: size === 'sm' ? theme.typography.fontSizes['13'] : undefined,
+      },
+    };
 
     return (
       <React.Fragment>
@@ -41,13 +52,7 @@ const SearchField = React.forwardRef<HTMLInputElement, Props & TextFieldProps & 
           styleType={'outlined'}
           leftIcon={'search'}
           rightIcon={'close'}
-          sx={{
-            wrapper: {
-              borderRadius: rem(100),
-              // @TODO this is a unique case for the SearchField where we dont need to use the sm height of the TextField, will change in v5
-              height: size === 'sm' ? rem(36) : getTextFieldHeight(size),
-            },
-          }}
+          sx={sx}
         >
           <IconWrapper iconPosition={'left'}>
             <Icon name={'search'} size={20} color={theme.utils.getColor('lightGrey', 650)} />
@@ -55,7 +60,7 @@ const SearchField = React.forwardRef<HTMLInputElement, Props & TextFieldProps & 
 
           <div css={{ width: '100%' }}>
             <input
-              css={inputStyle({ size, dark, placeholder })}
+              css={inputStyle({ size, dark, placeholder, sx })}
               placeholder={placeholder}
               disabled={disabled}
               value={value}

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -1,6 +1,6 @@
 import useTheme from 'hooks/useTheme';
 import React from 'react';
-import { DEFAULT_SIZE } from 'utils/size-utils';
+import { DEFAULT_SIZE, getTextFieldHeight } from 'utils/size-utils';
 
 import { rem } from '../../theme/utils';
 import { TestProps } from '../../utils/types';
@@ -41,7 +41,13 @@ const SearchField = React.forwardRef<HTMLInputElement, Props & TextFieldProps & 
           styleType={'outlined'}
           leftIcon={'search'}
           rightIcon={'close'}
-          sx={{ wrapper: { borderRadius: rem(100) } }}
+          sx={{
+            wrapper: {
+              borderRadius: rem(100),
+              // @TODO this is a unique case for the SearchField where we dont need to use the sm height of the TextField, will change in v5
+              height: size === 'sm' ? rem(36) : getTextFieldHeight(size),
+            },
+          }}
         >
           <IconWrapper iconPosition={'left'}>
             <Icon name={'search'} size={20} color={theme.utils.getColor('lightGrey', 650)} />

--- a/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
+++ b/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
@@ -129,7 +129,6 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   display: block;
   position: relative;
   z-index: 1;
-  font-size: 0.9375rem;
   text-overflow: ellipsis;
   width: 0;
   min-width: 100%;
@@ -213,7 +212,7 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   display: block;
   position: relative;
   z-index: 1;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   text-overflow: ellipsis;
   width: 0;
   min-width: 100%;
@@ -518,7 +517,6 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   display: block;
   position: relative;
   z-index: 1;
-  font-size: 0.9375rem;
   text-overflow: ellipsis;
   width: 0;
   min-width: 100%;
@@ -607,7 +605,7 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   display: block;
   position: relative;
   z-index: 1;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   text-overflow: ellipsis;
   width: 0;
   min-width: 100%;
@@ -910,7 +908,6 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   display: block;
   position: relative;
   z-index: 1;
-  font-size: 0.9375rem;
   text-overflow: ellipsis;
   width: 0;
   min-width: 100%;
@@ -999,7 +996,7 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   display: block;
   position: relative;
   z-index: 1;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   text-overflow: ellipsis;
   width: 0;
   min-width: 100%;

--- a/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
+++ b/src/components/SearchField/__snapshots__/SearchField.stories.storyshot
@@ -198,7 +198,7 @@ exports[`Storyshots Design System/SearchField Search Field disabled 1`] = `
   opacity: 0.5;
   cursor: not-allowed;
   min-width: 9.375rem;
-  height: 1.75rem;
+  height: 2.25rem;
   background-color: white;
 }
 
@@ -587,7 +587,7 @@ exports[`Storyshots Design System/SearchField Search Field sizes 1`] = `
   opacity: 1;
   cursor: text;
   min-width: 9.375rem;
-  height: 1.75rem;
+  height: 2.25rem;
   background-color: white;
 }
 
@@ -979,7 +979,7 @@ exports[`Storyshots Design System/SearchField Search Field with placeholder 1`] 
   opacity: 1;
   cursor: text;
   min-width: 9.375rem;
-  height: 1.75rem;
+  height: 2.25rem;
   background-color: white;
 }
 


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->
This fix solves the problem with SearchField small case where after the update of the TextField went from 36px to 28px. Also it fixes the fontSize of sm from 12px to 13px. 

This happened due to the fact that SearchField uses the TextField as the base component.

We want a special case for SearchFields and their small case to be 36px and break the rule of 28px. This will be revisited in v5.

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->
Old
![Screenshot 2023-05-25 at 12 19 03 PM](https://github.com/Orfium/orfium-ictinus/assets/6433679/80e93f24-aa9f-4228-936f-df479a3ec652)

New
![Screenshot 2023-05-26 at 4 07 46 PM](https://github.com/Orfium/orfium-ictinus/assets/6433679/c83f37eb-722f-4ad8-9a2a-a2dad03b23b5)

## Test Plan
Snapshots
<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
