### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,20 +29,10 @@ jobs:
       - name: Checkout 📥
         uses: actions/checkout@v3
 
-      - name: Get yarn cache 📦
-        id: yarn-cache
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
 
       - run: |
           yarn install


### PR DESCRIPTION
## Description

fixing github deprecation set-output and save-state while removing old caching mechanism

[github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
[github.com/marketplace/actions/yarn-install-cache](https://github.com/marketplace/actions/yarn-install-cache)
