### PR TITLE
[NDS-798] fix: select backspace does not change value [v4]

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -34,7 +34,7 @@ export type SelectOption = {
 
 export type Props = {
   /** The function that is used to return the selected options */
-  handleSelectedOption?: (selectedOption: SelectOption) => void;
+  handleSelectedOption?: (selectedOption?: SelectOption) => void;
   /** the default value of the select if needed */
   /** TODO: defaultValue is duplication of selectedOption*/
   defaultValue?: SelectOption;
@@ -302,6 +302,7 @@ const Select = React.forwardRef<HTMLInputElement, Props & InputProps & TestProps
 
       if (isBackspace) {
         setInputValue(emptyValue);
+        handleSelectedOption(undefined);
         debouncedOnChange('');
       }
     };

--- a/src/components/Select/hooks/useMultiselectUtils.ts
+++ b/src/components/Select/hooks/useMultiselectUtils.ts
@@ -63,6 +63,10 @@ const useMultiselectUtils = ({
         if (!lastItem.isCreated) {
           setAvailableMultiSelectOptions([...availableMultiSelectOptions, lastItem]);
         }
+
+        if (onOptionDelete) {
+          onOptionDelete(lastItem);
+        }
       }
     }
   };


### PR DESCRIPTION
## Description

[NDS-798](https://orfium.atlassian.net/browse/NDS-798)

In this PR: 
- Single Select: Backspace triggers the `handleSelectedOption` callback (external prop) with undefined.
- Multi Select: While BackSpace already deletes the last item from the inner state of selected options, it now also triggers the `onOptionDelete` callback (external prop) with the last item of the selectedOptions[] as an argument (this callback was only triggered when the X icon of the Chip-Option was clicked)

[NDS-798]: https://orfium.atlassian.net/browse/NDS-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ