### PR TITLE
[NDS-807] fix: select backspace does not clear value [v5]

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -23,6 +23,8 @@ import PositionInScreen from 'components/utils/PositionInScreen';
 
 export const emptyValue: SelectOption = { label: '', value: '' };
 
+/** @TODO: Refactor component to reduce Cognitive Complexity */
+
 const Select = React.forwardRef<HTMLInputElement, SelectProps>((props, ref) => {
   const {
     selectedOption,

--- a/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -328,6 +328,7 @@ exports[`Storyshots Design System/Select Async Select 1`] = `
                       readOnly={false}
                       required={false}
                       role="combobox"
+                      value=""
                     />
                     <label
                       className="emotion-9"
@@ -694,6 +695,7 @@ exports[`Storyshots Design System/Select Async Select with min characters 1`] = 
                       readOnly={false}
                       required={false}
                       role="combobox"
+                      value=""
                     />
                     <label
                       className="emotion-9"
@@ -2399,6 +2401,7 @@ exports[`Storyshots Design System/Select MultiSelect 1`] = `
                         readOnly={false}
                         required={false}
                         role="combobox"
+                        value=""
                       />
                       <label
                         className="emotion-58"
@@ -4717,6 +4720,7 @@ exports[`Storyshots Design System/Select Select with label and statuses 1`] = `
                         readOnly={false}
                         required={false}
                         role="combobox"
+                        value=""
                       />
                       <label
                         className="emotion-21"

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -34,7 +34,7 @@ export type MultiSelectProps = {
 };
 export type SingleSelectProps = {
   /** The function that is used to return the selected options */
-  onChange?: (selectedOption: SelectOption) => void;
+  onChange?: (selectedOption?: SelectOption) => void;
   /** If false the user can select one option */
   isMulti?: never;
   /** the value of the select if select is controlled */

--- a/src/components/storyUtils/SelectShowcase/SelectShowcase.tsx
+++ b/src/components/storyUtils/SelectShowcase/SelectShowcase.tsx
@@ -13,6 +13,7 @@ type SelectShowcaseProps = {
 };
 
 const SelectShowcase: React.FC<SelectShowcaseProps> = ({ minCharactersToSearch = 0 }) => {
+  const [selectedOption, setSelectedOption] = useState<SelectOption>();
   const [options, setOptions] = useState<SelectOption[]>(dummyUnrefinedData);
   const [isLoading, setIsLoading] = React.useState(false);
 
@@ -39,6 +40,8 @@ const SelectShowcase: React.FC<SelectShowcaseProps> = ({ minCharactersToSearch =
         isAsync
         label={'Flavour'}
         options={options}
+        selectedOption={selectedOption}
+        onChange={setSelectedOption}
         asyncSearch={mockedApiCall}
         isLoading={isLoading}
         onKeyPress={() => setIsLoading(true)}


### PR DESCRIPTION
## Description

[NDS-807](https://orfium.atlassian.net/browse/NDS-807)

In this PR: 
- the Backspace issue is resolved: when Backspace is clicked on SingleSelect while the input value equals the selected option's label, then the Select will be cleared (that also fixes the issue of non-searchable Select where you cannot clear the field)
- as implemented on v4, the empty state of Select from now on is `undefined` ; so when the field is cleared, the onChange is called with `undefined` as an argument.
- Typos are fixed.
- Async Select Showcase wasn't working properly; now it's fixed.

[NDS-807]: https://orfium.atlassian.net/browse/NDS-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ