### PR TITLE
fix: build storybook and prepublishonly script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install
+      - name: Prepare library
+        run: |
+          yarn install
+          yarn build:lib
 
       - name: Release 📌
         if: "github.event_name == 'push'"

--- a/environments/review.env
+++ b/environments/review.env
@@ -6,4 +6,3 @@ BASE_DOMAIN=orfium-dev.com
 
 CI=false
 REACT_APP_STAGE=staging
-NODE_ENV=staging

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
   },
   "scripts": {
     "postinstall": "patch-package",
-    "prepare": "yarn build:lib && husky install",
+    "prepublishOnly": "yarn build:lib",
+    "prepare": "husky install",
     "start": "storybook dev -p 6006",
     "prebuild": "rimraf dist",
     "build:rollOneBundleDTS": "rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->
This PR changes the way we build for Review Apps to not build twice by introducing `prepare` and `prepublishOnly`

Also it fixed an issue with `he.jsxDEV is not a function emotion` where we were building having `NODE_ENV=staging` for reviews 

## Screenshot

<!-- Provide a screenshot or gif of the change to demonstrate it -->

## Test Plan

<!-- Explain what you tested and why -->

<!--
  Have any questions? Check out the contributing doc for more
-->
