### PR TITLE
[NDS-951] feat: storybook navigation links

### DIFF
--- a/docs/Foundations/COLORS_V4.mdx
+++ b/docs/Foundations/COLORS_V4.mdx
@@ -12,13 +12,22 @@ import ThemeWrapper from '../../src/components/storyUtils/ThemeWrapper';
   }}
 />
 
-<SectionHeader title={'Colors'} isPending />
+<SectionHeader
+  title={'Colors'}
+  isPending
+  sections={[
+    { title: 'Palette', href: '#palette' },
+    { title: 'Shades', href: '#shades' },
+    { title: 'Color Palette', href: '#color-palette' },
+    { title: 'Color States', href: '#color-states' },
+  ]}
+/>
 
-### PALETTE
+### Palette
 
 The palette is a collection of colors that has being designed with colors that work harmoniously with each other
 
-### SHADES
+### Shades
 
 All the colors in palette are created with the same principle.
 
@@ -55,7 +64,7 @@ This way we get the following colors for magenta
 }
 ```
 
-### COLOR PALETTE
+### Color Palette
 
 The color palette have some text color for each shade either black or white. This text color was picked based on the best accessibility for the end user.
 
@@ -63,7 +72,7 @@ The color palette have some text color for each shade either black or white. Thi
   <PaletteShowcase />
 </ThemeWrapper>
 
-### COLOR STATES
+### Color States
 
 Each color state must follow some rules for lighten or darken the basic color. Rules are as follows
 

--- a/docs/Foundations/DesignTokens/Global/BORDER_RADIUS.mdx
+++ b/docs/Foundations/DesignTokens/Global/BORDER_RADIUS.mdx
@@ -11,10 +11,13 @@ import RadiusShowcase from '../../../../src/storybook/Showcases/RadiusShowcase';
   }}
 />
 
-<SectionHeader title={'Border Radius'} />
-
-- [Overview](#overview)
-- [Tokens](#tokens)
+<SectionHeader
+  title={'Border Radius'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Tokens', href: '#tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Global/BOX_SHADOW.mdx
+++ b/docs/Foundations/DesignTokens/Global/BOX_SHADOW.mdx
@@ -11,10 +11,13 @@ import BoxShadowShowcase from '../../../../src/storybook/Showcases/BoxShadowShow
   }}
 />
 
-<SectionHeader title={'Box Shadow'} />
-
-- [Overview](#overview)
-- [Tokens](#tokens)
+<SectionHeader
+  title={'Box Shadow'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Tokens', href: '#tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Global/COLORS.mdx
+++ b/docs/Foundations/DesignTokens/Global/COLORS.mdx
@@ -11,10 +11,13 @@ import TokenColorsShowcase from '../../../../src/storybook/Showcases/TokenColors
   }}
 />
 
-<SectionHeader title={'Colors'} />
-
-- [Overview](#overview)
-- [Tokens](#tokens)
+<SectionHeader
+  title={'Colors'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Tokens', href: '#tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Global/SIZING.mdx
+++ b/docs/Foundations/DesignTokens/Global/SIZING.mdx
@@ -11,10 +11,13 @@ import SizingShowcase from '../../../../src/storybook/Showcases/SizingShowcase';
   }}
 />
 
-<SectionHeader title={'Sizing'} />
-
-- [Overview](#overview)
-- [Tokens](#tokens)
+<SectionHeader
+  title={'Sizing'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Tokens', href: '#tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Global/SPACING.mdx
+++ b/docs/Foundations/DesignTokens/Global/SPACING.mdx
@@ -11,10 +11,13 @@ import SpacingSizingShowcase from '../../../../src/storybook/Showcases/SpacingSi
   }}
 />
 
-<SectionHeader title={'Spacing'} />
-
-- [Overview](#overview)
-- [Tokens](#tokens)
+<SectionHeader
+  title={'Spacing'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Tokens', href: '#tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Semantic/COLORS.mdx
+++ b/docs/Foundations/DesignTokens/Semantic/COLORS.mdx
@@ -11,10 +11,13 @@ import TokenColorsShowcase from '../../../../src/storybook/Showcases/TokenColors
   }}
 />
 
-<SectionHeader title={'Colors'} />
-
-- [Overview](#overview)
-- [Tokens](#tokens)
+<SectionHeader
+  title={'Colors'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Tokens', href: '#tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Semantic/TEXT_COLOR.mdx
+++ b/docs/Foundations/DesignTokens/Semantic/TEXT_COLOR.mdx
@@ -11,10 +11,13 @@ import TextColorShowcase from '../../../../src/storybook/Showcases/TextColorShow
   }}
 />
 
-<SectionHeader title={'Text Color'} />
-
-- [Overview](#overview)
-- [Text Color](#text-color)
+<SectionHeader
+  title={'Text Color'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Text Color', href: '#text-color' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/Semantic/TYPOGRAPHY.mdx
+++ b/docs/Foundations/DesignTokens/Semantic/TYPOGRAPHY.mdx
@@ -13,10 +13,13 @@ import { overviewTableText } from '../../../../src/storybook/Typography/constant
   }}
 />
 
-<SectionHeader title={'Typography'} />
-
-- [Overview](#overview)
-- [Text Style tokens](#text-style-tokens)
+<SectionHeader
+  title={'Typography'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Text Style tokens', href: '#text-style-tokens' },
+  ]}
+/>
 
 ## Overview
 

--- a/docs/Foundations/DesignTokens/TOKENS_ABOUT.mdx
+++ b/docs/Foundations/DesignTokens/TOKENS_ABOUT.mdx
@@ -10,19 +10,20 @@ import { Meta } from '@storybook/addon-docs';
   }}
 />
 
-<SectionHeader title={'Design Tokens'} />
+<SectionHeader
+  title={'Design Tokens'}
+  sections={[
+    { title: 'Global Tier', href: '#global-tier' },
+    { title: 'Theme Tier', href: '#theme-tier-(you-can-see-it-as-semantic-for-now)' },
+    { title: 'Component Tier', href: '#component-tier' },
+  ]}
+/>
 
 Design tokens are a way of abstracting visual design attributes such as color, typography, spacing, and other aspects of design, into reusable, platform-independent variables. They are a central source of truth for the design system that defines the visual language of a product or brand.
-
-## Theming with design tokens
 
 We use design tokens to create consistency and coherence in Ictinus design system.
 
 We split our logic in 3 tiers where each of them are reference to each other.
-
-- [Global Tier](#global-tier)
-- [Theme Tier](<#theme-tier-(you-can-see-it-as-semantic-for-now)>)
-- [Component Tier](#components-tier)
 
 ### Global Tier
 

--- a/docs/Foundations/Layout/LAYOUT_ABOUT.mdx
+++ b/docs/Foundations/Layout/LAYOUT_ABOUT.mdx
@@ -11,7 +11,14 @@ import { Layout, Grid, ExamplesContainer } from '../../../src/storybook/Showcase
   }}
 />
 
-<SectionHeader title={'Layout'} />
+<SectionHeader
+  title={'Layout'}
+  sections={[
+    { title: 'Structure', href: '#structure' },
+    { title: 'Examples', href: '#examples' },
+    { title: 'Content grid examples', href: '#content-grid-examples' },
+  ]}
+/>
 
 ## Structure
 

--- a/docs/Foundations/THEME.mdx
+++ b/docs/Foundations/THEME.mdx
@@ -10,11 +10,14 @@ import { Meta } from '@storybook/addon-docs';
   }}
 />
 
-<SectionHeader title={'Theme'} />
-
-- [Introduction](#introduction)
-- [Theme Configuration](#theme-configuration)
-- [Development](#development)
+<SectionHeader
+  title={'Theme'}
+  sections={[
+    { title: 'Introduction', href: '#introduction' },
+    { title: 'Theme Configuration', href: '#theme-configuration' },
+    { title: 'Development', href: '#development' },
+  ]}
+/>
 
 ## Introduction
 

--- a/docs/GettingStarted/WELCOME.mdx
+++ b/docs/GettingStarted/WELCOME.mdx
@@ -19,12 +19,6 @@ import { Meta } from '@storybook/addon-docs';
   [atomic design](https://atomicdesign.bradfrost.com/chapter-2/).
 </p>
 
-## What's Inside
-
-- [Theme & Design Tokens](../?path=/docs/foundations-theme--overview)
-- [Utilities](../?path=/docs/utilities-theme-utilities--overview)
-- [Components](../?path=/docs/updated-components-avatar-avatar--overview)
-
 ## Our Mission
 
 <SubsectionHeader title="Documentation" variant={'headline04'} />

--- a/src/components/Avatar/Avatar.mdx
+++ b/src/components/Avatar/Avatar.mdx
@@ -5,12 +5,15 @@ import * as AvatarStories from './Avatar.stories';
 
 <Meta of={AvatarStories} />
 
-<SectionHeader title={'Avatar'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Avatar'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Avatar/AvatarStack.mdx
+++ b/src/components/Avatar/AvatarStack.mdx
@@ -6,12 +6,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={AvatarStackStories} />
 
-<SectionHeader title={'Avatar Stack'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Avatar Stack'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Box/Box.mdx
+++ b/src/components/Box/Box.mdx
@@ -7,12 +7,15 @@ import Typography from '../Typography/index';
 
 <Meta of={BoxStories} />
 
-<SectionHeader title={'Box'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Box'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Breadcrumb/Breadcrumb.mdx
+++ b/src/components/Breadcrumb/Breadcrumb.mdx
@@ -6,12 +6,15 @@ import { BreadcrumbItemDummyStory } from '../storyUtils/componentsForTypes';
 
 <Meta of={BreadcrumbStories} />
 
-<SectionHeader title={'Breadcrumb'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Breadcrumb'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Button/Button.mdx
+++ b/src/components/Button/Button.mdx
@@ -6,16 +6,25 @@ import Link from '../../storybook/Link';
 
 <Meta of={ButtonStories} />
 
-<SectionHeader title={'Button'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Button'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 
 A universal Button component that is a clickable element that can hold many forms.
+
+## Props
+
+<ArgTypes of={Button} />
+
+<SubsectionHeader title="Variants" />
 
 ## Usage
 
@@ -40,12 +49,6 @@ A universal Button component that is a clickable element that can hold many form
   <Link href="../?path=/docs/updated-components-buttons-iconbutton--overview">Icon button</Link>{' '}
   component
 </Tip>
-
-## Props
-
-<ArgTypes of={Button} />
-
-<SubsectionHeader title="Variants" />
 
 ### Button Types and Sizes
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -4,12 +4,16 @@ import * as CardStories from './Card.stories';
 
 <Meta of={CardStories} />
 
-<SectionHeader title={'Card'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Card'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Chart/Chart.mdx
+++ b/src/components/Chart/Chart.mdx
@@ -6,7 +6,15 @@ import * as ChartStories from './Chart.stories';
 
 <Meta of={ChartStories} />
 
-<SectionHeader title={'Charts'} isPending />
+<SectionHeader
+  title={'Charts'}
+  isPending
+  sections={[
+    { title: 'LineChart', href: '#linechart' },
+    { title: 'BarChart', href: '#barchart' },
+    { title: 'DonutChart', href: '#donutchart' },
+  ]}
+/>
 
 # LineChart
 

--- a/src/components/Controls/CheckBox/CheckBox.mdx
+++ b/src/components/Controls/CheckBox/CheckBox.mdx
@@ -5,12 +5,15 @@ import { LabelConfigStory } from '../../storyUtils/LabelConfigStoryComponents';
 
 <Meta of={CheckBoxStories} />
 
-<SectionHeader title={'CheckBox'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'CheckBox'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Controls/Radio/Radio.mdx
+++ b/src/components/Controls/Radio/Radio.mdx
@@ -6,13 +6,15 @@ import { LabelConfigStory } from '../../storyUtils/LabelConfigStoryComponents';
 
 <Meta of={RadioStories} />
 
-<SectionHeader title={'Radio'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
-
+<SectionHeader
+  title={'Radio'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 ## Overview
 
 A components that allows the user to select a single option from a group.

--- a/src/components/Controls/Switch/Switch.mdx
+++ b/src/components/Controls/Switch/Switch.mdx
@@ -5,12 +5,15 @@ import { LabelConfigStory } from '../../storyUtils/LabelConfigStoryComponents';
 
 <Meta of={SwitchStories} />
 
-<SectionHeader title={'Switch'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Switch'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -9,12 +9,15 @@ import {
 
 <Meta of={DatePickerStories} />
 
-<SectionHeader title={'DatePicker'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'DatePicker'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Drawer/Drawer.mdx
+++ b/src/components/Drawer/Drawer.mdx
@@ -5,12 +5,16 @@ import * as DrawerStories from './Drawer.stories';
 
 <Meta of={DrawerStories} />
 
-<SectionHeader title={'Drawer'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Drawer'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Drawer/components/DrawerContent/DrawerContent.mdx
+++ b/src/components/Drawer/components/DrawerContent/DrawerContent.mdx
@@ -4,12 +4,15 @@ import SectionHeader from '../../../../storybook/SectionHeader';
 
 <Meta title="Updated Components/Drawer/DrawerContent" />
 
-<SectionHeader title={'DrawerContent'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [References](#references)
+<SectionHeader
+  title={'DrawerContent'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Drawer/components/DrawerFooter/DrawerFooter.mdx
+++ b/src/components/Drawer/components/DrawerFooter/DrawerFooter.mdx
@@ -4,12 +4,15 @@ import SectionHeader from '../../../../storybook/SectionHeader';
 
 <Meta title="Updated Components/Drawer/DrawerFooter" />
 
-<SectionHeader title={'DrawerFooter'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [References](#references)
+<SectionHeader
+  title={'DrawerFooter'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Drawer/components/DrawerHeader/DrawerHeader.mdx
+++ b/src/components/Drawer/components/DrawerHeader/DrawerHeader.mdx
@@ -4,12 +4,15 @@ import SectionHeader from '../../../../storybook/SectionHeader';
 
 <Meta title="Updated Components/Drawer/DrawerHeader" />
 
-<SectionHeader title={'DrawerHeader'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [References](#references)
+<SectionHeader
+  title={'DrawerHeader'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/DropdownButton/DropdownButton.mdx
+++ b/src/components/DropdownButton/DropdownButton.mdx
@@ -5,12 +5,15 @@ import Link from '../../storybook/Link';
 
 <Meta of={DropdownButtonStories} />
 
-<SectionHeader title={'DropdownButton'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'DropdownButton'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/ExpandCollapse/ExpandCollapse.mdx
+++ b/src/components/ExpandCollapse/ExpandCollapse.mdx
@@ -4,12 +4,16 @@ import * as ExpandCollapseStories from './ExpandCollapse.stories';
 
 <Meta of={ExpandCollapseStories} />
 
-<SectionHeader title={'ExpandCollapse'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'ExpandeCollapse'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Filter/Filter.mdx
+++ b/src/components/Filter/Filter.mdx
@@ -6,12 +6,15 @@ import { SelectOptionDummyStory } from '../storyUtils/componentsForTypes';
 
 <Meta of={FilterStories} />
 
-<SectionHeader title={'Filter'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Filter'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Icon/Icon.mdx
+++ b/src/components/Icon/Icon.mdx
@@ -4,12 +4,15 @@ import * as IconStories from './Icon.stories';
 
 <Meta of={IconStories} />
 
-<SectionHeader title={'Icon'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Collection](#collection)
-- [Variants](#variants)
+<SectionHeader
+  title={'Icon'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Collection', href: '#collection' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/IconButton/IconButton.mdx
+++ b/src/components/IconButton/IconButton.mdx
@@ -5,13 +5,15 @@ import * as IconButtonStories from './IconButton.stories';
 
 <Meta of={IconButtonStories} />
 
-<SectionHeader title={'IconButton'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
-
+<SectionHeader
+  title={'IconButton'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 ## Overview
 
 A universal IconButton component that with the help of Button hold the icon inside it and makes

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -6,12 +6,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={LinkStories} />
 
-<SectionHeader title={'Link'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Link'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/List/stories/List.mdx
+++ b/src/components/List/stories/List.mdx
@@ -5,13 +5,16 @@ import * as ListStories from './List.stories';
 
 <Meta of={ListStories} />
 
-<SectionHeader title={'List'} />
-
-- [Overview](#overview)
-- [Usage](#usage)
-- [Props](#props)
-- [Variants](#variants)
-- [References](#references)
+<SectionHeader
+  title={'List'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Props', href: '#props' },
+    { title: 'Variants', href: '#variants' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/List/stories/ListItem.mdx
+++ b/src/components/List/stories/ListItem.mdx
@@ -5,13 +5,16 @@ import * as ListItemStories from './ListItem.stories';
 
 <Meta of={ListItemStories} />
 
-<SectionHeader title={'ListItem'} />
-
-- [Overview](#overview)
-- [Usage](#usage)
-- [Props](#props)
-- [Variants](#variants)
-- [References](#references)
+<SectionHeader
+  title={'ListItem'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Props', href: '#props' },
+    { title: 'Variants', href: '#variants' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/List/stories/ListItemAction.mdx
+++ b/src/components/List/stories/ListItemAction.mdx
@@ -3,12 +3,15 @@ import SectionHeader from '../../../storybook/SectionHeader';
 
 <Meta title="Updated Components/List/ListItemAction" />
 
-<SectionHeader title={'ListItemAction'} />
-
-- [Overview](#overview)
-- [Usage](#usage)
-- [Props](#props)
-- [References](#references)
+<SectionHeader
+  title={'ListItemAction'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Props', href: '#props' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/List/stories/ListItemText.mdx
+++ b/src/components/List/stories/ListItemText.mdx
@@ -5,13 +5,16 @@ import * as ListItemTextStories from './ListItemText.stories';
 
 <Meta of={ListItemTextStories} />
 
-<SectionHeader title={'ListItemText'} />
-
-- [Overview](#overview)
-- [Usage](#usage)
-- [Props](#props)
-- [Variants](#variants)
-- [References](#references)
+<SectionHeader
+  title={'ListItemText'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Props', href: '#props' },
+    { title: 'Variants', href: '#variants' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/List/stories/ListSection.mdx
+++ b/src/components/List/stories/ListSection.mdx
@@ -5,13 +5,16 @@ import * as ListSectionStories from './ListSection.stories';
 
 <Meta of={ListSectionStories} />
 
-<SectionHeader title={'ListSection'} />
-
-- [Overview](#overview)
-- [Usage](#usage)
-- [Props](#props)
-- [Variants](#variants)
-- [References](#references)
+<SectionHeader
+  title={'ListSection'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Props', href: '#props' },
+    { title: 'Variants', href: '#variants' },
+    { title: 'References', href: '#references' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Menu/Menu.mdx
+++ b/src/components/Menu/Menu.mdx
@@ -4,12 +4,15 @@ import * as MenuStories from './Menu.stories';
 
 <Meta of={MenuStories} />
 
-<SectionHeader title={'Menu'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Menu'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 
@@ -24,6 +27,8 @@ A menu displays a list of choices on a temporary surface when the user interacts
 <UsageGuidelines
   guidelines={['Use menu for list of selections that can be accessible via arrows']}
 />
+
+<SubsectionHeader title="Variants" />
 
 ### Menu different triggers
 

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -5,11 +5,14 @@ import * as ModalStories from './Modal.stories';
 
 <Meta of={ModalStories} />
 
-<SectionHeader title={'Modal'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-
+<SectionHeader
+  title={'Modal'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+  ]}
+/>
 ## Overview
 
 A modal is used to reveal critical information, show information without losing context, or when the system requires a user response.

--- a/src/components/Navigation/Navigation.mdx
+++ b/src/components/Navigation/Navigation.mdx
@@ -5,12 +5,16 @@ import * as NavigationStories from './Navigation.stories';
 
 <Meta of={NavigationStories} />
 
-<SectionHeader title={'Navigation'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Navigation'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Notification/Notification.mdx
+++ b/src/components/Notification/Notification.mdx
@@ -8,13 +8,16 @@ import * as NotificationStories from './Notification.stories';
 
 <Meta of={NotificationStories} />
 
-<SectionHeader title={'Notifications'} isPending />
-
-- [Overview](#overview)
-- [Inline Notification](#inline-notification)
-- [Banner Notification](#banner-notification)
-- [Toast Notification](#toast-notification)
-- [Snackbar Notification](#snackbar-notification)
+<SectionHeader
+  title={'Notifications'}
+  isPending
+  sections={[
+    { title: 'Inline Notification', href: '#inline-notification' },
+    { title: 'Banner Notification', href: '#banner-notification' },
+    { title: 'Toast Notification', href: '#toast-notification' },
+    { title: 'Snackbar Notification', href: '#snackbar-notification' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/NumberField/NumberField.mdx
+++ b/src/components/NumberField/NumberField.mdx
@@ -5,12 +5,15 @@ import * as NumberFieldStories from './NumberField.stories';
 
 <Meta of={NumberFieldStories} />
 
-<SectionHeader title={'NumberField'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'NumberField'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -4,12 +4,16 @@ import * as PaginationStories from './Pagination.stories';
 
 <Meta of={PaginationStories} />
 
-<SectionHeader title={'Pagination'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Pagination'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -7,12 +7,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={ProgressIndicatorStories} />
 
-<SectionHeader title={'Progress Indicator'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'ProgressIndicator'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Search/Search.mdx
+++ b/src/components/Search/Search.mdx
@@ -5,12 +5,15 @@ import { SearchFilterConfigDummyStory } from '../storyUtils/componentsForTypes';
 
 <Meta of={SearchStories} />
 
-<SectionHeader title={'Search'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Search'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 # Overview
 

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -6,12 +6,15 @@ import { SelectOptionDummyStory } from '../storyUtils/componentsForTypes';
 
 <Meta of={SelectStories} />
 
-<SectionHeader title={'Select'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Select'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Slider/Slider.mdx
+++ b/src/components/Slider/Slider.mdx
@@ -4,12 +4,16 @@ import * as SliderStories from './Slider.stories';
 
 <Meta of={SliderStories} />
 
-<SectionHeader title={'Slider'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Slider'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Table/Table.mdx
+++ b/src/components/Table/Table.mdx
@@ -5,12 +5,16 @@ import * as TableStories from './Table.stories';
 
 <Meta of={TableStories} />
 
-<SectionHeader title={'Table'} isPending />
-
-- [Overview](#overview)
-- [Props](#table-props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Table'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#table-props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Tag/Tag.mdx
+++ b/src/components/Tag/Tag.mdx
@@ -5,12 +5,15 @@ import * as TagStories from './Tag.stories';
 
 <Meta of={TagStories} />
 
-<SectionHeader title={'Tag'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Tag'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/TextArea/TextArea.mdx
+++ b/src/components/TextArea/TextArea.mdx
@@ -6,12 +6,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={TextAreaStories} />
 
-<SectionHeader title={'TextArea'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'TextArea'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 # Overview
 

--- a/src/components/TextField/TextField.mdx
+++ b/src/components/TextField/TextField.mdx
@@ -6,13 +6,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={TextFieldStories} />
 
-<SectionHeader title={'TextField'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
-
+<SectionHeader
+  title={'TextField'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 ## Overview
 
 A universal TextField component which provides a wide range of features such as statuses, inline

--- a/src/components/ThemeProvider/ThemeProvider.mdx
+++ b/src/components/ThemeProvider/ThemeProvider.mdx
@@ -5,12 +5,16 @@ import * as ThemeProviderStories from './ThemeProvider.stories';
 
 <Meta of={ThemeProviderStories} />
 
-<SectionHeader title={'ThemeProvider'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'ThemeProvider'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -5,12 +5,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={TooltipStories} />
 
-<SectionHeader title={'Tooltip'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Tooltip'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/components/TopAppBar/TopAppBar.mdx
+++ b/src/components/TopAppBar/TopAppBar.mdx
@@ -5,13 +5,16 @@ import * as TopAppBarStories from './TopAppBar.stories';
 
 <Meta of={TopAppBarStories} />
 
-<SectionHeader title={'TopAppBar'} isPending />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
-
+<SectionHeader
+  title={'TopAppBar'}
+  isPending
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 ## Overview
 
 A universal TopAppBar component.

--- a/src/components/TruncatedContent/TruncatedContent.mdx
+++ b/src/components/TruncatedContent/TruncatedContent.mdx
@@ -5,7 +5,13 @@ import * as TruncatedContentStories from './TruncatedContent.stories';
 
 <Meta of={TruncatedContentStories} />
 
-<SectionHeader title={'Truncated Text with Tooltip'} />
+<SectionHeader
+  title={'Truncated Text with Tooltip'}
+  sections={[
+    { title: 'Usage', href: '#usage' },
+    { title: 'Props', href: '#props' },
+  ]}
+/>
 
 A generic component that wraps around an element with a maximum width value and shows ellipsis if the text inside would
 overflow. In that case, a tooltip is shown as well.

--- a/src/components/Typography/Typography.mdx
+++ b/src/components/Typography/Typography.mdx
@@ -6,12 +6,15 @@ import Overview from '../../storybook/Overview';
 
 <Meta of={TypographyStories} />
 
-<SectionHeader title={'Typography'} />
-
-- [Overview](#overview)
-- [Props](#props)
-- [Usage](#usage)
-- [Variants](#variants)
+<SectionHeader
+  title={'Typography'}
+  sections={[
+    { title: 'Overview', href: '#overview' },
+    { title: 'Props', href: '#props' },
+    { title: 'Usage', href: '#usage' },
+    { title: 'Variants', href: '#variants' },
+  ]}
+/>
 
 ## Overview
 

--- a/src/hooks/useSearchQueryParams.mdx
+++ b/src/hooks/useSearchQueryParams.mdx
@@ -3,10 +3,13 @@ import * as UseSearchQueryParamsStories from './useSearchQueryParams.stories';
 
 <Meta of={UseSearchQueryParamsStories} />
 
-<SectionHeader title="useSearchQueryParams" />
-
-- [Usage](#usage)
-- [Demo](#Demo)
+<SectionHeader
+  title={'useSearchQueryParams'}
+  sections={[
+    { title: 'Usage', href: '#usage' },
+    { title: 'Demo', href: '#demo' },
+  ]}
+/>
 
 ## Usage
 

--- a/src/storybook/SectionHeader/SectionHeader.style.ts
+++ b/src/storybook/SectionHeader/SectionHeader.style.ts
@@ -1,5 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type { Theme } from 'theme';
 
 export const sectionHeaderWrapper = () => (): SerializedStyles =>
   css`
@@ -11,9 +12,25 @@ export const sectionHeaderWrapper = () => (): SerializedStyles =>
     background-position: right;
     border-radius: 4px;
     display: flex;
-    align-items: center;
-    padding: 0 32px;
+    flex-direction: column;
+    justify-content: center;
+    padding: 32px;
+    box-sizing: border-box;
     h1 {
       margin: 0;
     }
   `;
+
+export const sectionHeaderContainer = () => (): SerializedStyles =>
+  css`
+    display: flex;
+    align-items: center;
+  `;
+
+export const sectionHeaderLinksDivider =
+  () =>
+  (theme: Theme): SerializedStyles =>
+    css`
+      padding: 0 12px;
+      color: ${theme.tokens.colors.get('textColor.default.active')};
+    `;

--- a/src/storybook/SectionHeader/SectionHeader.tsx
+++ b/src/storybook/SectionHeader/SectionHeader.tsx
@@ -1,8 +1,13 @@
 import { Unstyled } from '@storybook/blocks';
+import { Link } from 'index';
 import type { FCC } from 'react';
 import React from 'react';
 
-import { sectionHeaderWrapper } from './SectionHeader.style';
+import {
+  sectionHeaderWrapper,
+  sectionHeaderContainer,
+  sectionHeaderLinksDivider,
+} from './SectionHeader.style';
 import Box from '../../components/Box';
 import Typography from '../Typography';
 import Tag from 'components/Tag';
@@ -10,17 +15,35 @@ import Tag from 'components/Tag';
 export type SectionHeaderProps = {
   title?: string;
   isPending?: boolean;
+  sections?: {
+    title: string;
+    href: string;
+  }[];
 };
 
-const SectionHeader: FCC<SectionHeaderProps> = ({ title = '', isPending = false }) => {
+const SectionHeader: FCC<SectionHeaderProps> = ({ title = '', isPending = false, sections }) => {
   return (
     <Unstyled>
       <div css={sectionHeaderWrapper()}>
-        <Typography variant="headline01">{title}</Typography>
-        {isPending && (
-          <Box ml="6">
-            <Tag>v4</Tag>
-          </Box>
+        <div css={sectionHeaderContainer()}>
+          <Typography variant="headline01">{title}</Typography>
+          {isPending && (
+            <Box ml="6">
+              <Tag>v4</Tag>
+            </Box>
+          )}
+        </div>
+        {sections && (
+          <div css={sectionHeaderContainer()}>
+            {sections.map((section, index) => (
+              <div key={`link_${section.href}_container`} css={sectionHeaderContainer()}>
+                <Link key={`link_${section.href}`} href={section.href} target="_self">
+                  {section.title}
+                </Link>
+                {index !== sections.length - 1 && <div css={sectionHeaderLinksDivider()}>|</div>}
+              </div>
+            ))}
+          </div>
         )}
       </div>
     </Unstyled>


### PR DESCRIPTION
## Description

[NDS-951](https://orfium.atlassian.net/browse/NDS-951)

In this PR we change the UI in terms of navigation anchor links.

- Update the `SectionHeader` component by adding the `Link` component inside.
- Update all mdx pages.

### Before

<img width="1028" alt="Screenshot 2024-02-06 at 17 09 55" src="https://github.com/Orfium/orfium-ictinus/assets/57801353/325be726-0125-47fe-8cbf-4f0e1a46132d">

### After

<img width="1025" alt="Screenshot 2024-02-06 at 17 10 22" src="https://github.com/Orfium/orfium-ictinus/assets/57801353/248370a5-0e4d-4532-b9e3-3f6480ce80a4">


[NDS-951]: https://orfium.atlassian.net/browse/NDS-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ