### PR TITLE
feat: improve how table cell tooltipContent works

### DIFF
--- a/src/components/Table/TableRowContext.ts
+++ b/src/components/Table/TableRowContext.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Row, TableType } from './Table';
+import { ExtendedColumn } from 'components/Table/types';
 
 export type TableRowContextProps<T extends { [key: string]: unknown }> = {
   row: Row<T>;
@@ -9,7 +10,7 @@ export type TableRowContextProps<T extends { [key: string]: unknown }> = {
   onSelectionChangeExist: boolean;
   isRowSelected: boolean;
   columnCount: number;
-  columns: string[];
+  columns: (string | ExtendedColumn)[];
   fixedHeader: boolean;
   tChange: () => void;
   type: TableType;

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import ContentCell from './components/ContentCell';
+import ExpandedButtonCell from './components/ExpandedButtonCell';
+import { borderedRowStyle, expandableRowStyle } from './RenderRowOrNestedRow.style';
 import useToggle from '../../../../hooks/useToggle';
 import { isComponentFunctionType } from '../../../../utils/helpers';
 import CheckBox from '../../../CheckBox';
@@ -8,9 +11,6 @@ import { tableStyle } from '../../Table.style';
 import { TableRowContext } from '../../TableRowContext';
 import TableCell from '../TableCell';
 import TableRow from '../TableRow';
-import ContentCell from './components/ContentCell';
-import ExpandedButtonCell from './components/ExpandedButtonCell';
-import { borderedRowStyle, expandableRowStyle } from './RenderRowOrNestedRow.style';
 
 const RenderRowWithCells = React.memo(
   ({
@@ -59,7 +59,7 @@ const RenderRowWithCells = React.memo(
             rowIndex={rowIndex}
             index={0}
           >
-            <div onClick={e => e.stopPropagation()}>
+            <div onClick={(e) => e.stopPropagation()}>
               <CheckBox
                 dataTestIdSuffix={'row-check'}
                 checked={isRowSelected}

--- a/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/RenderRowOrNestedRow.tsx
@@ -79,13 +79,7 @@ const RenderRowWithCells = React.memo(
               cellCounter={index}
               columnWidth={columnsWithWidth[index]}
               columns={columns}
-              tooltipContent={
-                hasTruncatedTooltip
-                  ? isComponentFunctionType(content)
-                    ? tooltipContent
-                    : tooltipContent ?? content.toString()
-                  : undefined
-              }
+              tooltipContent={hasTruncatedTooltip ? tooltipContent : null}
               padded={padded}
               colSpan={colSpan}
               content={content}

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { isComponentFunctionType } from 'utils/helpers';
 
+import { nestedHeaderStyle } from './ContentCell.style';
 import TruncatedContent from '../../../../../TruncatedContent';
 import { ContentComponent, TableType } from '../../../../Table';
 import TableCell from '../../../TableCell';
-import { nestedHeaderStyle } from './ContentCell.style';
+import { ExtendedColumn } from 'components/Table/types';
 
 type Props = {
-  columns: string[];
+  columns: (string | ExtendedColumn)[];
   padded: boolean;
   tooltipContent?: string;
   columnWidth?: number;
@@ -38,6 +39,7 @@ const ContentCell: React.FC<Props> = ({
   index,
 }) => {
   const isNumeral = !Number.isNaN(Number(content));
+  const col = columns[cellCounter];
 
   return (
     <TableCell
@@ -53,7 +55,7 @@ const ContentCell: React.FC<Props> = ({
       {rowType === 'nested-header' && (
         <div css={nestedHeaderStyle()}>
           {/* nested header render */}
-          {columns[cellCounter]}
+          {typeof col === 'string' ? col : col.content.label}
         </div>
       )}
 
@@ -64,7 +66,7 @@ const ContentCell: React.FC<Props> = ({
         {isComponentFunctionType(content) ? (
           content({ content, colSpan })
         ) : (
-          <span data-column={columns[cellCounter]}>{content}</span>
+          <span data-column={col}>{content}</span>
         )}
       </TruncatedContent>
     </TableCell>

--- a/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
+++ b/src/components/Table/components/RenderRowOrNestedRow/components/ContentCell/ContentCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { isComponentFunctionType } from 'utils/helpers';
 
 import { nestedHeaderStyle } from './ContentCell.style';
@@ -10,7 +10,8 @@ import { ExtendedColumn } from 'components/Table/types';
 type Props = {
   columns: (string | ExtendedColumn)[];
   padded: boolean;
-  tooltipContent?: string;
+  // null value means we explicitly do not want any tooltips to be shown
+  tooltipContent: string | undefined | null;
   columnWidth?: number;
   content: number | string | ContentComponent<any>;
   colSpan?: number;
@@ -39,6 +40,7 @@ const ContentCell: React.FC<Props> = ({
   index,
 }) => {
   const isNumeral = !Number.isNaN(Number(content));
+  const [contentElementRef, setContentElementRef] = useState<HTMLSpanElement | null>(null);
   const col = columns[cellCounter];
 
   return (
@@ -61,13 +63,20 @@ const ContentCell: React.FC<Props> = ({
 
       <TruncatedContent
         placement={'bottom'}
-        tooltipContent={tooltipContent}
+        tooltipContent={
+          tooltipContent === null
+            ? undefined
+            : tooltipContent ?? contentElementRef?.textContent ?? ''
+        }
       >
-        {isComponentFunctionType(content) ? (
-          content({ content, colSpan })
-        ) : (
-          <span data-column={col}>{content}</span>
-        )}
+        <span
+          ref={(el) => {
+            setContentElementRef(el);
+          }}
+          data-column={col}
+        >
+          {isComponentFunctionType(content) ? content({ content, colSpan }) : content}
+        </span>
       </TruncatedContent>
     </TableCell>
   );

--- a/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
+++ b/src/components/Table/components/TableRowWrapper/TableRowWrapper.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Row, Selection, TableType } from '../../Table';
 import { TableRowContext } from '../../TableRowContext';
 import RenderRowOrNestedRow from '../RenderRowOrNestedRow/RenderRowOrNestedRow';
+import { ExtendedColumn } from 'components/Table/types';
 
 type TableRowWrapperProps<T> = {
   row: Row<T>;
@@ -12,7 +13,7 @@ type TableRowWrapperProps<T> = {
   padded: boolean;
   onSelectionChangeExist: boolean;
   columnCount: number;
-  columns: string[];
+  columns: (string | ExtendedColumn)[];
   fixedHeader: boolean;
   type: TableType;
   expanded: boolean;

--- a/src/components/TruncatedContent/__snapshots__/TruncatedContent.stories.storyshot
+++ b/src/components/TruncatedContent/__snapshots__/TruncatedContent.stories.storyshot
@@ -212,8 +212,12 @@ exports[`Storyshots System/Truncated Text with Tooltip Regular Table with cell t
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
-              <span>
-                JSX Content without tooltip
+              <span
+                data-column="Column 3"
+              >
+                <span>
+                  JSX Content without tooltip
+                </span>
               </span>
             </div>
           </td>
@@ -226,8 +230,12 @@ exports[`Storyshots System/Truncated Text with Tooltip Regular Table with cell t
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
-              <span>
-                JSX Content with forced tooltip
+              <span
+                data-column="Column 4"
+              >
+                <span>
+                  JSX Content with forced tooltip
+                </span>
               </span>
             </div>
           </td>


### PR DESCRIPTION
Tooltip content is now only necessary if you actually want to show
something completely different than the cell content.
It is no longer required for cases where your cell content is not a
string

commit-id:c0571df4

---

**Stack**:
- #804 ⬅
- #803


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*