### PR TITLE
feat: slot provider

### DIFF
--- a/src/__storyshots__/Updated Components/Breadcrumb-BasicBreadcrumbs.snap
+++ b/src/__storyshots__/Updated Components/Breadcrumb-BasicBreadcrumbs.snap
@@ -162,6 +162,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 1_link"
               href="/first-level"
             >
@@ -196,6 +197,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 2_link"
               href="/second-level"
             >
@@ -230,6 +232,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 3_link"
               href="/third-level"
             >
@@ -264,6 +267,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 4_link"
               href="/forth-level"
             >

--- a/src/__storyshots__/Updated Components/Breadcrumb-GoBackTo.snap
+++ b/src/__storyshots__/Updated Components/Breadcrumb-GoBackTo.snap
@@ -113,6 +113,7 @@
         >
           <a
             class="emotion-3"
+            data-slot="link"
             data-testid="_breadcrumb_go_back_to_Level 1_link"
             href="/first-level"
           >

--- a/src/__storyshots__/Updated Components/Breadcrumb-Playground.snap
+++ b/src/__storyshots__/Updated Components/Breadcrumb-Playground.snap
@@ -253,6 +253,7 @@
             >
               <a
                 class="emotion-7"
+                data-slot="link"
                 data-testid="_breadcrumb_link_Level 1_link"
                 href="/first-level"
               >

--- a/src/__storyshots__/Updated Components/Breadcrumb-ThirdPartyRoutingLibrary.snap
+++ b/src/__storyshots__/Updated Components/Breadcrumb-ThirdPartyRoutingLibrary.snap
@@ -162,6 +162,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 1_link"
               href="/first-level"
             >
@@ -196,6 +197,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 2_link"
               href="/second-level"
             >
@@ -230,6 +232,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 3_link"
               href="/third-level"
             >
@@ -264,6 +267,7 @@
           >
             <a
               class="emotion-4"
+              data-slot="link"
               data-testid="_breadcrumb_link_Level 4_link"
               href="/forth-level"
             >

--- a/src/__storyshots__/Updated Components/Link-LinkStyles.snap
+++ b/src/__storyshots__/Updated Components/Link-LinkStyles.snap
@@ -142,6 +142,7 @@
     >
       <a
         class="emotion-1"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >
@@ -159,6 +160,7 @@
     >
       <a
         class="emotion-3"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >

--- a/src/__storyshots__/Updated Components/Link-LinkWithIcon.snap
+++ b/src/__storyshots__/Updated Components/Link-LinkWithIcon.snap
@@ -234,6 +234,7 @@
     >
       <a
         class="emotion-1"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >
@@ -263,6 +264,7 @@
     >
       <a
         class="emotion-4"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >
@@ -292,6 +294,7 @@
     >
       <a
         class="emotion-7"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >

--- a/src/__storyshots__/Updated Components/Link-Placement.snap
+++ b/src/__storyshots__/Updated Components/Link-Placement.snap
@@ -132,6 +132,7 @@
          
         <a
           class="emotion-1"
+          data-slot="link"
           data-testid="_link"
           href="#"
         >
@@ -149,6 +150,7 @@
         This is a
         <a
           class="emotion-2"
+          data-slot="link"
           data-testid="_link"
           href="#"
         >

--- a/src/__storyshots__/Updated Components/Link-Playground.snap
+++ b/src/__storyshots__/Updated Components/Link-Playground.snap
@@ -74,6 +74,7 @@
     >
       <a
         class="emotion-1"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >

--- a/src/__storyshots__/Updated Components/Link-Sizes.snap
+++ b/src/__storyshots__/Updated Components/Link-Sizes.snap
@@ -180,6 +180,7 @@
     >
       <a
         class="emotion-1"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >
@@ -193,6 +194,7 @@
     >
       <a
         class="emotion-2"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >
@@ -206,6 +208,7 @@
     >
       <a
         class="emotion-3"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >

--- a/src/__storyshots__/Updated Components/Link-ThirdPartyRoutingLibrary.snap
+++ b/src/__storyshots__/Updated Components/Link-ThirdPartyRoutingLibrary.snap
@@ -54,6 +54,7 @@
 <div>
   <a
     class="emotion-0"
+    data-slot="link"
     data-testid="_link"
     href="/"
   >

--- a/src/__storyshots__/Updated Components/Menu-MenuTriggers.snap
+++ b/src/__storyshots__/Updated Components/Menu-MenuTriggers.snap
@@ -275,6 +275,7 @@
         aria-haspopup="true"
         aria-label="Menu"
         class="emotion-8"
+        data-slot="link"
         data-testid="_link"
         href="#"
       >

--- a/src/__storyshots__/Updated Components/Notifications/Inline Alert-Error.snap
+++ b/src/__storyshots__/Updated Components/Notifications/Inline Alert-Error.snap
@@ -252,6 +252,7 @@
       >
         <a
           class="emotion-7"
+          data-slot="link"
           data-testid="_link"
         >
           <span>

--- a/src/__storyshots__/Updated Components/Notifications/Inline Alert-Informational.snap
+++ b/src/__storyshots__/Updated Components/Notifications/Inline Alert-Informational.snap
@@ -254,6 +254,7 @@
       >
         <a
           class="emotion-7"
+          data-slot="link"
           data-testid="_link"
         >
           <span>

--- a/src/__storyshots__/Updated Components/Notifications/Inline Alert-Neutral.snap
+++ b/src/__storyshots__/Updated Components/Notifications/Inline Alert-Neutral.snap
@@ -214,6 +214,7 @@
       >
         <a
           class="emotion-5"
+          data-slot="link"
           data-testid="_link"
         >
           <span>

--- a/src/__storyshots__/Updated Components/Notifications/Inline Alert-Playground.snap
+++ b/src/__storyshots__/Updated Components/Notifications/Inline Alert-Playground.snap
@@ -214,6 +214,7 @@
       >
         <a
           class="emotion-5"
+          data-slot="link"
           data-testid="_link"
         >
           <span>

--- a/src/__storyshots__/Updated Components/Notifications/Inline Alert-Success.snap
+++ b/src/__storyshots__/Updated Components/Notifications/Inline Alert-Success.snap
@@ -252,6 +252,7 @@
       >
         <a
           class="emotion-7"
+          data-slot="link"
           data-testid="_link"
         >
           <span>

--- a/src/__storyshots__/Updated Components/Notifications/Inline Alert-Warning.snap
+++ b/src/__storyshots__/Updated Components/Notifications/Inline Alert-Warning.snap
@@ -254,6 +254,7 @@
       >
         <a
           class="emotion-7"
+          data-slot="link"
           data-testid="_link"
         >
           <span>

--- a/src/components/ButtonBase/ButtonBase.tsx
+++ b/src/components/ButtonBase/ButtonBase.tsx
@@ -7,6 +7,7 @@ import { generateTestDataId } from 'utils/helpers';
 import type { ComponentSizes, TestProps } from 'utils/types';
 
 import { buttonBaseStyle, buttonWrapperStyle } from './ButtonBase.style';
+import { useSlotProps } from '../utils/Slots';
 import type { ButtonTypes } from 'components/Button/Button.types';
 import ButtonLoader from 'components/Button/ButtonLoader';
 import type { IconButtonShape } from 'components/IconButton';
@@ -43,6 +44,7 @@ export type ButtonBaseProps = {
 
 //@TODO fix props to not overwrite button props
 const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>((props, ref) => {
+  props = useSlotProps(props, 'button');
   const {
     type = 'primary',
     size = 'normal',
@@ -70,7 +72,6 @@ const ButtonBase = React.forwardRef<HTMLButtonElement, ButtonBaseProps>((props, 
         ref={ref}
         type={htmlType}
         data-testid={generateTestDataId(testIdName, dataTestId)}
-        data-slot="button"
         css={buttonBaseStyle({
           type,
           size,

--- a/src/components/InlineAlert/InlineAlert.stories.tsx
+++ b/src/components/InlineAlert/InlineAlert.stories.tsx
@@ -30,7 +30,7 @@ type Story = StoryObj<typeof InlineAlert>;
 
 export const Neutral: Story = {
   render: (args) => (
-    <InlineAlert actions={<Link size={2}>Single Action</Link>} onDismiss={() => {}} {...args}>
+    <InlineAlert actions={<Link>Single Action</Link>} onDismiss={() => {}} {...args}>
       Alert copy should be short, easy to understand and actionable.
     </InlineAlert>
   ),
@@ -40,7 +40,7 @@ export const Informational: Story = {
   render: (args) => (
     <InlineAlert
       status="informational"
-      actions={<Link size={2}>Single Action</Link>}
+      actions={<Link>Single Action</Link>}
       onDismiss={() => {}}
       {...args}
     >
@@ -51,12 +51,7 @@ export const Informational: Story = {
 
 export const Error: Story = {
   render: (args) => (
-    <InlineAlert
-      status="error"
-      actions={<Link size={2}>Single Action</Link>}
-      onDismiss={() => {}}
-      {...args}
-    >
+    <InlineAlert status="error" actions={<Link>Single Action</Link>} onDismiss={() => {}} {...args}>
       Alert copy should be short, easy to understand and actionable.
     </InlineAlert>
   ),
@@ -66,7 +61,7 @@ export const Warning: Story = {
   render: (args) => (
     <InlineAlert
       status="warning"
-      actions={<Link size={2}>Single Action</Link>}
+      actions={<Link>Single Action</Link>}
       onDismiss={() => {}}
       {...args}
     >
@@ -79,7 +74,7 @@ export const Success: Story = {
   render: (args) => (
     <InlineAlert
       status="success"
-      actions={<Link size={2}>Single Action</Link>}
+      actions={<Link>Single Action</Link>}
       onDismiss={() => {}}
       {...args}
     >
@@ -92,12 +87,7 @@ export const WithButtons: Story = {
   render: (args) => (
     <InlineAlert
       status="informational"
-      actions={[
-        <Button type="tertiary" size="compact">
-          Tertiary
-        </Button>,
-        <Button size="compact">Primary</Button>,
-      ]}
+      actions={[<Button type="tertiary">Tertiary</Button>, <Button>Primary</Button>]}
       onDismiss={() => {}}
       {...args}
     >
@@ -141,7 +131,7 @@ export const WithTrigger: Story = {
 
 export const Playground: Story = {
   render: (args) => (
-    <InlineAlert actions={<Link size={2}>Single Action</Link>} onDismiss={() => {}} {...args}>
+    <InlineAlert actions={<Link>Single Action</Link>} onDismiss={() => {}} {...args}>
       Alert copy should be short, easy to understand and actionable.
     </InlineAlert>
   ),

--- a/src/components/InlineAlert/InlineAlert.tsx
+++ b/src/components/InlineAlert/InlineAlert.tsx
@@ -5,12 +5,14 @@ import { useId } from 'react-aria';
 import { getIconColor, styles } from './InlineAlert.style';
 import type { InlineAlertProps } from './InlineAlert.types';
 import Icon from '../Icon';
+import { SlotProvider, useSlotProps } from '../utils/Slots';
 import { useDOMRef } from '../utils/useDOMRef';
 
 import useTheme from '~/hooks/useTheme';
 
 export const InlineAlert = forwardRef<HTMLDivElement, InlineAlertProps>(
   (props: InlineAlertProps, ref: RefObject<HTMLDivElement>) => {
+    props = useSlotProps(props, 'inline-alert');
     const {
       status = 'neutral',
       actions,
@@ -46,7 +48,6 @@ export const InlineAlert = forwardRef<HTMLDivElement, InlineAlertProps>(
         tabIndex={0}
         role={status === 'warning' || status === 'error' ? 'alert' : 'status'}
         aria-describedby={onDismiss ? dismissId : undefined}
-        data-slot="inline-alert"
         data-testid={`${dataTestPrefixId}_inline_alert`}
       >
         {status !== 'neutral' ? (
@@ -59,7 +60,18 @@ export const InlineAlert = forwardRef<HTMLDivElement, InlineAlertProps>(
           />
         ) : null}
         <div css={styles.content}>{children}</div>
-        {actionsArray.length > 0 ? <div css={styles.actions}>{actionsArray}</div> : null}
+        {actionsArray.length > 0 ? (
+          <div css={styles.actions}>
+            <SlotProvider
+              slots={{
+                button: { size: 'compact' },
+                link: { size: 2 },
+              }}
+            >
+              {actionsArray}
+            </SlotProvider>
+          </div>
+        ) : null}
         {onDismiss ? (
           <Icon
             role="button"

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -4,9 +4,11 @@ import React from 'react';
 import { iconSize } from './constants';
 import { linkContainer } from './Link.style';
 import type { LinkProps } from './Link.types';
+import { useSlotProps } from '../utils/Slots';
 import Icon from 'components/Icon';
 
 const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  props = useSlotProps(props, 'link');
   const {
     type = 'primary',
     placement = 'block',

--- a/src/components/utils/Slots.tsx
+++ b/src/components/utils/Slots.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from 'react';
+import { createContext, useContext, useMemo } from 'react';
+import { mergeProps } from 'react-aria';
+
+interface SlotProps {
+  'data-slot'?: string;
+}
+
+const SlotContext = createContext(null);
+
+export function useSlotProps<T>(props: T, defaultSlot?: string) {
+  const slot = (props as SlotProps)['data-slot'] || defaultSlot;
+  const { [slot]: slotProps = {} } = useContext(SlotContext) || {};
+
+  return mergeProps(props, mergeProps(slotProps, { 'data-slot': slot }));
+}
+
+/**
+ * SlotProvider manages and provides slot props to its descendants.
+ * It allows for the definition and inheritance of props for named slots in a component tree.
+ *
+ * @component
+ * @param {Object} [props.slots={}] - An object containing slot names as keys and their corresponding props as values.
+ * @param {ReactNode} props.children - The child components to be wrapped by the SlotProvider.
+ *
+ *  * @example
+ * // Register component with the useSlotProps() hook
+ * function Button(props) {
+ *   props = useSlotProps(props, 'button');
+ *
+ *   return (
+ *     <button {...props}>{props.children}</button>
+ *   );
+ * }
+ *
+ * function ButtonsWithPadding(props) {
+ *   return (
+ *     <SlotProvider slots={{ button: { style: { padding: '1rem' } } }}>
+ *       {props.children}
+ *     </SlotProvider>
+ *   )
+ * }
+ *
+ * <ButtonsWithPadding>
+ *   <Button>Button 1</Button> // Gets 1rem padding
+ *   <Button>Button 2</Button> // Gets 1rem padding
+ * </ButtonsWithPadding>
+ *
+ * @example
+ * // Nested usage
+ * <SlotProvider slots={{ outer: { className: 'outer-class' } }}>
+ *   <SlotProvider slots={{ inner: { className: 'inner-class' } }}>
+ *     <Component />
+ *   </SlotProvider>
+ * </SlotProvider>
+ *
+ */
+export function SlotProvider({ slots = {}, children }: { slots?: object; children: ReactNode }) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const parentSlots = useContext(SlotContext) || {};
+
+  const value = useMemo(() => {
+    return Object.keys(parentSlots)
+      .concat(Object.keys(slots))
+      .reduce(
+        (acc, slot) => ({
+          ...acc,
+          [slot]: mergeProps(parentSlots[slot] || {}, slots[slot] || {}),
+        }),
+        {}
+      );
+  }, [parentSlots, slots]);
+
+  return <SlotContext.Provider value={value}>{children}</SlotContext.Provider>;
+}
+
+/**
+ * ClearSlots resets the SlotContext to an empty object for its children.
+ * It's used to remove any inherited slot props from parent SlotProviders.
+ *
+ * @component
+ * @param {React.ReactNode} props.children - The child components to be wrapped by ClearSlots.
+ *
+ * @example
+ * // Basic usage
+ * <SlotProvider slots={{ text: { color: 'blue' } }}>
+ *   <div>
+ *     <p {...useSlotProps({}, 'text')}>This text is blue</p>
+ *     <ClearSlots>
+ *       <p {...useSlotProps({}, 'text')}>This text is black</p>
+ *     </ClearSlots>
+ *   </div>
+ * </SlotProvider>
+ *
+ * @example
+ * // Usage within nested SlotProviders
+ * <SlotProvider slots={{ text: { color: 'blue' } }}>
+ *   <p {...useSlotProps({}, 'text')}>This text is blue</p>
+ *   <ClearSlots>
+ *     <SlotProvider slots={{ text: { color: 'red' } }}>
+ *       <p {...useSlotProps({}, 'text')}>This text is red, not blue</p>
+ *     </SlotProvider>
+ *   </ClearSlots>
+ * </SlotProvider>
+ *
+ */
+export function ClearSlots({ children }: { children: ReactNode }) {
+  return <SlotContext.Provider value={{}}>{children}</SlotContext.Provider>;
+}

--- a/src/components/utils/tests/Slots.test.tsx
+++ b/src/components/utils/tests/Slots.test.tsx
@@ -1,0 +1,91 @@
+import { render, renderHook } from '~/test';
+import { ClearSlots, SlotProvider, useSlotProps } from '../Slots';
+
+describe('useSlotProps()', () => {
+  it('merges props with slot props', () => {
+    const wrapper = ({ children }) => (
+      <SlotProvider slots={{ test: { className: 'test-class' } }}>{children}</SlotProvider>
+    );
+
+    const { result } = renderHook(() => useSlotProps({ id: 'test-id' }, 'test'), { wrapper });
+
+    expect(result.current).toEqual({
+      id: 'test-id',
+      className: 'test-class',
+      'data-slot': 'test',
+    });
+  });
+
+  it('uses the data-slot attribute if provided', () => {
+    const wrapper = ({ children }) => (
+      <SlotProvider slots={{ custom: { className: 'test-class' } }}>{children}</SlotProvider>
+    );
+
+    const { result } = renderHook(() => useSlotProps({ id: 'test-id', 'data-slot': 'custom' }), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual({
+      id: 'test-id',
+      className: 'test-class',
+      'data-slot': 'custom',
+    });
+  });
+});
+
+describe('<SlotProvider />', () => {
+  it('provides slot props to children', () => {
+    const Component = () => {
+      const props = useSlotProps({}, 'test');
+      return <div {...props} />;
+    };
+
+    const { container } = render(
+      <SlotProvider slots={{ test: { className: 'test-class' } }}>
+        <Component />
+      </SlotProvider>
+    );
+
+    expect(container.firstChild).toHaveClass('test-class');
+    expect(container.firstChild).toHaveAttribute('data-slot', 'test');
+  });
+
+  it('merges parent and child slot props', () => {
+    const Component = () => {
+      const props = useSlotProps({}, 'test');
+      return <div {...props} />;
+    };
+
+    const { container } = render(
+      <SlotProvider slots={{ test: { className: 'test-class' } }}>
+        <SlotProvider slots={{ test: { id: 'test-id' } }}>
+          <Component />
+        </SlotProvider>
+      </SlotProvider>
+    );
+
+    expect(container.firstChild).toHaveClass('test-class');
+    expect(container.firstChild).toHaveAttribute('id', 'test-id');
+    expect(container.firstChild).toHaveAttribute('data-slot', 'test');
+  });
+});
+
+describe('<ClearSlots />', () => {
+  it('clears slot context for children', () => {
+    const Component = () => {
+      const props = useSlotProps({}, 'test');
+      return <div {...props} />;
+    };
+
+    const { container } = render(
+      <SlotProvider slots={{ test: { className: 'test-class' } }}>
+        <ClearSlots>
+          <Component />
+        </ClearSlots>
+      </SlotProvider>
+    );
+
+    expect(container.firstChild).not.toHaveClass('test-class');
+    expect(container.firstChild).toHaveAttribute('data-slot', 'test');
+  });
+});


### PR DESCRIPTION
## Description

`<SlotProvider />` manages and provides slot props to its descendants. It allows for the definition and inheritance of props for named slots in a component tree.

## Example
```jsx
// Register component with the useSlotProps() hook
function Button(props) {
  props = useSlotProps(props, 'button');

  return (
    <button {...props}>{props.children}</button>
  );
}

function ButtonsWithPadding(props) {
  return (
    <SlotProvider slots={{ button: { style: { padding: '1rem' } } }}>
      {props.children}
    </SlotProvider>
  )
}

// Somewhere in the app
<ButtonsWithPadding>
  <Button>Button 1</Button> // Gets 1rem padding
  <Button>Button 2</Button> // Gets 1rem padding
</ButtonsWithPadding>
```
