### PR TITLE
fix: hasHover

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -33,17 +33,17 @@ const Icon = React.forwardRef<HTMLDivElement, IconProps>((props, ref) => {
     size = 20,
     onClick,
     dataTestId,
+    hasHover,
     ...rest
   } = props;
   const combinedRef = useCombinedRefs<HTMLDivElement>(ref, useRef(null));
   const isInteractive = Boolean(onClick);
-  const { hasHover = isInteractive } = props;
   const Icon = iconSelector[name];
 
   return (
     <div
       onClick={onClick}
-      css={iconContainerStyles({ size, hasHover, isInteractive })}
+      css={iconContainerStyles({ size, hasHover: hasHover ?? isInteractive, isInteractive })}
       data-testid={dataTestId}
       ref={combinedRef}
       tabIndex={isInteractive ? 0 : undefined}


### PR DESCRIPTION
## Description

Fixes the following React warning:
```
Warning: React does not recognize the `hasHover` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `hashover` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```
