### PR TITLE
fix: export breadcrumb types

### DIFF
--- a/src/components/Breadcrumb/index.ts
+++ b/src/components/Breadcrumb/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Breadcrumb';
 export * from './Breadcrumb';
+export * from './Breadcrumb.types';


### PR DESCRIPTION
## Description

Exporting types from breadcrumb
