### PR TITLE
fix(tooltip): set opacity to 1 for consistent visibility

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -34,6 +34,7 @@ const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
           clickable={isInteractive}
           className="tooltip"
           isOpen={isOpen}
+          opacity={1}
           role="tooltip"
         >
           {content}


### PR DESCRIPTION
## Description

this PR makes the opacity of tooltip 1 as the react-tooltip puts opacity by default
