### PR TITLE
chore: add security settings to pnpm workspace configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - 'packages/*'
   - 'apps/*'
+# Security settings - this will limit the use of packages that have been published for at least 1440 minutes (24 hours)
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@orfium/*'


### PR DESCRIPTION
## Description

Lately there was a NPM compromise - https://www.ox.security/blog/npm-packages-compromised/ 

With pnpm strict release `minimum-release-age` we make sure we dont update anything less than a day that can push something malicious